### PR TITLE
Updated build script to remove old files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,14 @@ SHA=`git rev-parse --short=8 HEAD`
 
 echo "Building gh-pages branch in $DISTDIR for SHA $SHA on $DATE"
 
-# 1) Checkout a new clone of our repo into the dist directory
+# 1) make sure dist folder variable is not empty and folder exists
+if [ -z "$DISTDIR" ]; then
+  echo "DISTDIR variable is empty, aborting!"
+  exit 1
+fi
+mkdir -p $DISTDIR
+
+# 2) Checkout a new clone of our repo into the dist directory
 # which will contain the gh-pages branch we will deploy
 if [ -e "$GITCONFIG" ]
 then
@@ -18,19 +25,26 @@ then
   git pull
 else
   echo "cloning building-models repo in $DISTDIR"
+  rm -rf "$DISTDIR/*" &&\
   git clone git@github.com:concord-consortium/building-models.git $DISTDIR &&\
   cd $DISTDIR &&\
   echo "checking out gh-pages branch" &&\
   git checkout gh-pages
 fi
 
+# 3) clear out the dist directory
+echo "Clearing out existing files"
+git rm -rf .
+git clean -fxd
+
 cd $HERE
 
-# 2) Build our project using gulp:
+# 4) Build our project using gulp into the dist folder
+echo "Rebuilding app"
 gulp build-all --production --buildInfo '$SHA built on $DATE' &&\
 
-# 3) Commit and push
-cd $DISTDIR
+# 5) Commit and push
+cd $DISTDIR 
 git add * &&\
 git commit -a -m "deployment for $SHA built on $DATE" &&\
 git push origin gh-pages


### PR DESCRIPTION
This updates the build script to:

1. Make sure the dist folder variable is not empty (for safety)
2. Fixes an error if the checkout is done on a non-empty dist folder
3. Uses git rm/clean to clear out existing files so that deleted files get removed from the github pages

I just used this to update the site.