### PR TITLE
Adds a remote image option to the node edit view

### DIFF
--- a/src/code/views/node-edit-view.coffee
+++ b/src/code/views/node-edit-view.coffee
@@ -1,4 +1,4 @@
-{div, h2, label, input, select, option} = React.DOM
+{div, h2, label, input, select, option, optgroup, button} = React.DOM
 
 module.exports = React.createClass
 
@@ -10,21 +10,53 @@ module.exports = React.createClass
   changeImage: (e) ->
     @props.onNodeChanged? @props.node, @props.node.title, e.target.value
 
+  addRemote: (e) ->
+    src = $.trim(@refs.remoteUrl?.getDOMNode().value or '')
+    if src.length > 0
+      img = new Image
+      img.onload = =>
+        @props.onNodeChanged? @props.node, @props.node.title, src
+        @props.onAddRemoteImage? src
+      img.onerror = =>
+        alert "Sorry, could not load #{src}"
+        @refs.remoteUrl.getDOMNode().focus()
+      img.src = src
+
   render: ->
     if @props.node
       (div {className: 'node-edit-view'},
         (h2 {}, @props.node.title)
         (div {className: 'edit-row'},
-          (label {name: 'title'}, 'Title')
+          (label {htmlFor: 'title'}, 'Title')
           (input {type: 'text', name: 'title', value: @props.node.title, onChange: @changeTitle})
         )
         (div {className: 'edit-row'},
-          (label {name: 'image'}, 'Image')
+          (label {htmlFor: 'image'}, 'Image')
           (select {name: 'image', value: @props.node.image, onChange: @changeImage},
-            for node, i in @props.protoNodes
-              (option {key: i, value: node.image}, node.title)
+            (optgroup {label: 'Built-In'},
+              for node, i in @props.protoNodes
+                if node.type is 'builtin'
+                  (option {key: i, value: node.image}, if node.title.length > 0 then node.title else '(none)')
+            )
+            (optgroup {label: 'Remote'},
+              for node, i in @props.protoNodes
+                if node.type is 'remote'
+                  (option {key: i, value: node.image}, node.image)
+              (option {key: i, value: '#remote'}, 'Add Remote...')
+            )
           )
         )
+        if @props.node.image is '#remote'
+          (div {},
+            (div {className: 'edit-row'},
+              (label {htmlFor: 'remoteUrl'}, 'URL')
+              (input {type: 'text', ref: 'remoteUrl', name: 'remoteUrl', placeholder: 'Remote image url'})
+            )
+            (div {className: 'edit-row'},
+              (label {htmlFor: 'save'}, '')
+              (button {name: 'save', onClick: @addRemote}, 'Add Remote Image')
+            )
+          )
       )
     else
       (div {className: 'node-edit-view hidden'})

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -54,7 +54,7 @@ module.exports = React.createClass
         (div {className: 'delete-box', onClick: @doDelete},
           (i {className: 'fa fa-times-circle'})
         )
-        (if @props.data.image?.length > 0 then (img {src: @props.data.image}) else null)
+        (if @props.data.image?.length > 0 and @props.data.image isnt '#remote' then (img {src: @props.data.image}) else null)
         (div {className: 'node-title'}, @props.data.title)
       )
     )

--- a/src/code/views/node-well-view.coffee
+++ b/src/code/views/node-well-view.coffee
@@ -12,5 +12,5 @@ module.exports = React.createClass
   render: ->
     (div {className: 'node-well'},
       for node, i in @props.protoNodes
-        (ProtoNodeView {key: i, image: node.image, title: node.title})
+        (ProtoNodeView {key: i, image: node.image, title: node.title, onNodeClicked: @props.onNodeClicked})
     )

--- a/src/code/views/proto-node-view.coffee
+++ b/src/code/views/proto-node-view.coffee
@@ -3,7 +3,7 @@
 module.exports = React.createClass
 
   displayName: 'ProtoNode'
-  
+
   componentDidMount: ->
     $(@refs.node.getDOMNode()).draggable
       drag: @doMove
@@ -11,10 +11,13 @@ module.exports = React.createClass
       helper: 'clone'
       revertDuration: 0
       opacity: 0.35
-  
+
   doMove: -> undefined
-  
+
+  onClick: ->
+    @props.onNodeClicked? @props.image
+
   render: ->
-    (div {className: 'proto-node', ref: 'node', 'data-node-key': @props.key, 'data-image': @props.image, 'data-title': @props.title},
+    (div {className: 'proto-node', ref: 'node', onClick: @onClick, 'data-node-key': @props.key, 'data-image': @props.image, 'data-title': @props.title},
       (div {className: 'img-background'}, if @props.image?.length > 0 then (img {src: @props.image}) else null)
     )

--- a/src/code/views/proto-nodes.coffee
+++ b/src/code/views/proto-nodes.coffee
@@ -1,0 +1,26 @@
+module.exports = [
+  {
+    "id": "1",
+    "type": "builtin",
+    "title": "Egg",
+    "image": "img/nodes/egg.png"
+  },
+  {
+    "id": "2",
+    "type": "builtin",
+    "title": "Chick"
+    "image": "img/nodes/chick.jpg"
+  },
+  {
+    "id": "3",
+    "type": "builtin",
+    "title": "Chicken"
+    "image": "img/nodes/chicken.jpg"
+  },
+  {
+    "id": "4",
+    "type": "builtin",
+    "title": ""
+    "image": ""
+  }
+]

--- a/src/stylus/node-edit.styl
+++ b/src/stylus/node-edit.styl
@@ -1,15 +1,21 @@
 .node-edit-view
   min-width  100px
   text-align left
-  
+
   flex 1 0 0
-  -webkit-flex 1 0 0 
-  
+  -webkit-flex 1 0 0
+
+  h2
+    margin-bottom 5px
+
   &.hidden
     display none
   .edit-row
     padding 0.2em
     white-space nowrap
   label
+    display inline-block
+    width 45px
     font-weight bold
-    margin-right 1.5em
+  input, select
+    width 175px


### PR DESCRIPTION
The node edit image select now has two option groups - built-in images and remote images.  Under the remote images option group there is an 'Add Remote...' option that when selected shows a remote url input and a button to add the image.  When the add image button is clicked the img url is tested to see if it can be loaded and if it can the image is changed and is also added to the palette to the left of the blank option.

I also added the ability to click on an image in the palette and immediately update the selected node to that image.  This was not in the story but I thought it would be interesting to test.