### PR TITLE
Added new button and google drive open and save buttons

### DIFF
--- a/src/assets/json/serialized.json
+++ b/src/assets/json/serialized.json
@@ -1,4 +1,6 @@
 {
+    "version": 0.1,
+    "filename": "Sample Model",
     "nodes": [
         {
             "title": "Chicken",

--- a/src/code/utils/google-drive-io.coffee
+++ b/src/code/utils/google-drive-io.coffee
@@ -1,55 +1,104 @@
 module.exports = class GoogleDriveIO
 
+  APP_ID : '1095918012594'
+  DEVELOPER_KEY: 'AIzaSyAUobrEXqtbZHBvr24tamdE6JxmPYTRPEA'
   CLIENT_ID: '1095918012594-svs72eqfalasuc4t1p1ps1m8r9b8psso.apps.googleusercontent.com'
   SCOPES: 'https://www.googleapis.com/auth/drive'
+  
+  authorized: false
 
   authorize: (immediate, callback) ->
     args =
       'client_id': @CLIENT_ID
       'scope': @SCOPES
       'immediate': immediate or false
-    gapi.auth.authorize args, callback
+    gapi.auth.authorize args, (token) =>
+      if callback
+        err = (if not token
+          'Unable to authorize'
+        else if token.error
+          token.error
+        else
+          null
+        )
+        @authorized = err is null
+        callback err, token
 
   makeMultipartBody: (parts, boundary) ->
     ((for part in parts
-      type = "\r\n--#{boundary}\r\nContent-Type: #{part.fileType}"
-      encoding = if part.encoding then "\r\nContent-Transfer-Encoding: #{part.encoding}" else ''
-      "#{type}#{encoding}\r\n\r\n#{part.message}"
+      "\r\n--#{boundary}\r\nContent-Type: application/json\r\n\r\n#{part}"
     ).join '') + "\r\n--#{boundary}--"
 
   sendFile: (fileSpec, contents, callback) ->
     boundary = '-------314159265358979323846'
-    contentType = fileSpec.mimeType or 'application/octet-stream'
-    metadata =
-      'title': fileSpec.fileName
-      'mimeType': contentType
-    parts = [
-      {
-        fileType: contentType
-        message: JSON.stringify metadata
-      },
-      {
-        fileType: 'application/json'
-        message: contents
-      }
-    ]
-    multipartRequestBody = @makeMultipartBody parts, boundary
-
+    metadata = JSON.stringify
+      title: fileSpec.fileName
+      mimeType: 'application/json'
+    
+    [method, path] = if fileSpec.fileId
+      ['PUT', "/upload/drive/v2/files/#{fileSpec.fileId}"]
+    else
+      ['POST', '/upload/drive/v2/files']
+      
     request = gapi.client.request
-      path: '/upload/drive/v2/files'
-      method: 'POST'
-      params:
-        uploadType: 'multipart'
-      headers:
-        'Content-Type': 'multipart/mixed; boundary="' + boundary + '"'
-      body: multipartRequestBody
+      path: path
+      method: method
+      params: {uploadType: 'multipart', alt: 'json'}
+      headers: {'Content-Type': 'multipart/mixed; boundary="' + boundary + '"'}
+      body: @makeMultipartBody [metadata, contents], boundary
+      
+    request.execute (file) ->
+      if callback
+        if file
+          callback null, file
+        else
+          callback 'Unabled to upload file'
 
-    request.execute callback or ((file) -> console.log file)
-
-  upload: (fileSpec, contents) ->
-    @authorize true, (token) =>
-      if token and not token.error
-        gapi.client.load 'drive', 'v2', => @sendFile fileSpec, contents
+  upload: (fileSpec, contents, callback) ->
+    @authorize @authorized, (err) =>
+      if not err
+        gapi.client.load 'drive', 'v2', => @sendFile fileSpec, contents, callback
       else
-        console.log "No authorization. Upload failed for file: #{fileSpec.fileName}"
+        callback "No authorization. Upload failed for file: #{fileSpec.fileName}"
+
+  download: (fileSpec, callback) ->
+    @authorize @authorized, (err, token) ->
+      if err
+        callback err
+      else
+        gapi.client.load 'drive', 'v2', ->
+          request = gapi.client.drive.files.get
+            fileId: fileSpec.id
+          request.execute (file) ->
+            if file?.downloadUrl
+              xhr = new XMLHttpRequest()
+              xhr.open 'GET', file.downloadUrl
+              xhr.setRequestHeader 'Authorization', "Bearer #{token.access_token}"
+              xhr.onload = ->
+                try
+                  json = JSON.parse xhr.responseText
+                catch e
+                  callback e
+                  return
+                callback null, json
+              xhr.onerror = ->
+                callback "Unable to download #{file.downloadUrl}"
+              xhr.send()
+            else
+              callback "Unable to get download url"
+
+  filePicker: (callback) ->
+    @authorize @authorized, (err, token) ->
+      if err
+        callback err
+      else
+        gapi.load 'picker', callback: ->
+          pickerCallback = (data, etc) ->
+            callback null, if data.action is 'picked' then data.docs[0] else null
+          picker = new google.picker.PickerBuilder()
+            .addView google.picker.ViewId.DOCS
+            .setOAuthToken token.access_token
+            .setCallback pickerCallback
+            .build()
+          picker.setVisible true
 

--- a/src/code/views/google-file-view.coffee
+++ b/src/code/views/google-file-view.coffee
@@ -5,62 +5,76 @@ GoogleDriveIO = require '../utils/google-drive-io'
 module.exports = React.createClass
 
   displayName: 'GoogleFileView'
-  
+
   getInitialState: ->
-    filename: 'model'
-    authStatus: 'unknown'
-    
+    gapiLoaded: false
+    fileId: null
+    action: 'Checking authorization...'
+
   componentDidMount: ->
-    googleDrive = new GoogleDriveIO()
-    
+    @googleDrive = new GoogleDriveIO()
+
     # wait for gapi to finish initing
-    waitForGAPI = =>
+    waitForAuthCheck = =>
       if gapi?.auth?.authorize
-        @authorize true
+        @googleDrive.authorize true, =>
+          @setState
+            gapiLoaded: true
+            action: null
       else
-        setTimeout waitForGAPI, 10
-    waitForGAPI()
-    
-  saveToGDrive: ->
-    googleDrive = new GoogleDriveIO()
-    filename = @state.filename
+        setTimeout waitForAuthCheck, 10
+    waitForAuthCheck()
 
-    log.info "Proposing to save to '#{filename}'"
-    if not filename or filename.length is 0
-      filename = 'model'
-    if not /\.json$/.test filename
-      filename += '.json'
+  newFile: ->
+    if confirm 'Are you sure?'
+      @props.linkManager.deleteAll()
+      @setState
+        fileId: null
+
+  openFile: ->
+    @googleDrive.filePicker (err, fileSpec) =>
+      if err
+        alert err
+      else if fileSpec
+        @setState action: 'Downloading...'
+        @googleDrive.download fileSpec, (err, data) =>
+          if err
+            alert err
+            @setState action: null
+          else
+            @setState
+              fileId: fileSpec.id
+              action: null
+            @props.linkManager.deleteAll()
+            @props.linkManager.loadData data
+
+  saveFile: ->
+    filename = $.trim ((prompt 'Filename', @props.filename) or '')
+    if filename.length > 0
+      @setState action: 'Uploading...'
       
-    log.info "Saving to '#{filename}'"
-    googleDrive.upload {fileName: filename, mimeType: 'application/json'}, @props.linkManager.toJsonString()
-
-  authorize: (immediate) ->
-    googleDrive = new GoogleDriveIO()
-    googleDrive.authorize immediate, (token) =>
-      if token and not token.error
-        @setState authStatus: 'authorized'
-      else
-        @setState authStatus: 'unauthorized'
-        console.error "Google Drive Authorization failed: #{token?.error or 'Unknown error'}"
-        
-  changeFilename: (e) ->
-    log.info "Changing filename: #{e.target.value}"
-    # TODO: Maybe move the filename property up to be state in App.
-    @setState filename: e.target.value
+      # set the filename before serializing so it is saved in the data
+      @props.linkManager.setFilename filename
+      
+      # if this is a save of an existing file with the same name use the fileid
+      fileId = if filename is @props.filename then @state.fileId else null
+      @googleDrive.upload {fileName: filename, fileId: fileId}, @props.getData(), (err, fileSpec) =>
+        if err
+          alert err
+          @setState action: null
+        else
+          @setState
+            fileId: fileSpec.id
+            action: null
 
   render: ->
-    switch @state.authStatus
-      when 'authorized'
-        (div {className: 'file-dialog-view'},
-          (label {}, 'Filename:')
-          (input {type: 'text', onChange: @changeFilename, value: @state.fileName, id: 'filename'})
-          (button {id: 'send', onClick: @saveToGDrive}, 'Save to Google Drive')
-        )
-      when 'unauthorized'
-        (div {className: 'file-dialog-view'},
-          (button {id: 'authorize', onClick: (=> @authorize false)}, 'Authorize for Google Drive')
-        )
-      else
-        null
-      
+    (div {className: 'file-dialog-view'},
+      (div {className: 'filename'}, if @state.action then @state.action else @props.filename),
+      (div {className: 'buttons'},
+        (button {onClick: @newFile}, 'New'),
+        (button {onClick: @openFile, disabled: not @state.gapiLoaded}, 'Open'),
+        (button {onClick: @saveFile, disabled: not @state.gapiLoaded}, 'Save')
+      )
+    )
+
 

--- a/src/code/views/node-edit-view.coffee
+++ b/src/code/views/node-edit-view.coffee
@@ -16,7 +16,6 @@ module.exports = React.createClass
       img = new Image
       img.onload = =>
         @props.onNodeChanged? @props.node, @props.node.title, src
-        @props.onAddRemoteImage? src
       img.onerror = =>
         alert "Sorry, could not load #{src}"
         @refs.remoteUrl.getDOMNode().focus()
@@ -35,12 +34,12 @@ module.exports = React.createClass
           (select {name: 'image', value: @props.node.image, onChange: @changeImage},
             (optgroup {label: 'Built-In'},
               for node, i in @props.protoNodes
-                if node.type is 'builtin'
+                if not node.image.match /^https?/
                   (option {key: i, value: node.image}, if node.title.length > 0 then node.title else '(none)')
             )
             (optgroup {label: 'Remote'},
               for node, i in @props.protoNodes
-                if node.type is 'remote'
+                if node.image.match /^https?/
                   (option {key: i, value: node.image}, node.image)
               (option {key: i, value: '#remote'}, 'Add Remote...')
             )

--- a/src/code/views/node-well-view.coffee
+++ b/src/code/views/node-well-view.coffee
@@ -12,5 +12,5 @@ module.exports = React.createClass
   render: ->
     (div {className: 'node-well'},
       for node, i in @props.protoNodes
-        (ProtoNodeView {key: i, image: node.image, title: node.title, onNodeClicked: @props.onNodeClicked})
+        (ProtoNodeView {key: i, image: node.image, title: node.title})
     )

--- a/src/code/views/proto-nodes.coffee
+++ b/src/code/views/proto-nodes.coffee
@@ -1,25 +1,21 @@
 module.exports = [
   {
     "id": "1",
-    "type": "builtin",
     "title": "Egg",
     "image": "img/nodes/egg.png"
   },
   {
     "id": "2",
-    "type": "builtin",
     "title": "Chick"
     "image": "img/nodes/chick.jpg"
   },
   {
     "id": "3",
-    "type": "builtin",
     "title": "Chicken"
     "image": "img/nodes/chicken.jpg"
   },
   {
     "id": "4",
-    "type": "builtin",
     "title": ""
     "image": ""
   }

--- a/src/code/views/status-menu-view.coffee
+++ b/src/code/views/status-menu-view.coffee
@@ -6,7 +6,7 @@ log.setLevel log.levels.TRACE
 
 module.exports = React.createClass
   displayName: 'StatusMenu',
-  
+
   openLink: ->
     if @props.getData
       window.open "#{window.location.protocol}//#{window.location.host}#{window.location.pathname}?data=#{encodeURIComponent @props.getData()}"
@@ -14,6 +14,6 @@ module.exports = React.createClass
   render: ->
     (div {className: 'status-menu'},
       (div {className: 'title'}, @props.title or 'Building Models')
-      (GoogleFileView {linkManager: @props.linkManager})
+      (GoogleFileView {linkManager: @props.linkManager, getData: @props.getData, filename: @props.filename})
       (div {className: 'open-data-url', onClick: @openLink}, @props.linkText or 'Link to my model')
     )

--- a/src/stylus/status-menu-view.styl
+++ b/src/stylus/status-menu-view.styl
@@ -4,7 +4,7 @@
   font-size 14px
   color white
   background-color #444
-  
+
   .title
     font-size 18px
     color hsla(0,0,100,1)
@@ -13,7 +13,7 @@
   .open-data-url
     text-decoration underline
     cursor pointer
-    
+
 
   flex 1 0 18px
   display flex
@@ -30,3 +30,11 @@
   -webkit-flex-wrap wrap
   -webkit-justify-content space-between
   -webkit-align-content baseline
+
+  .file-dialog-view
+    .filename
+      font-weight bold
+    .buttons
+      margin-top 5px
+      button
+        margin 0 5px

--- a/test/node-list-test.coffee
+++ b/test/node-list-test.coffee
@@ -181,7 +181,7 @@ describe 'Node', () ->
     
     describe "Serialization", () ->
       beforeEach () ->
-        @serializedForm = """{"nodes":[{"title":"a","x":10,"y":10,"key":"a"},{"title":"b","x":20,"y":20,"key":"b"}],"links":[{"title":"","color":"#777","sourceNodeKey":"a","sourceTerminal":"b","targetNodeKey":"b","targetTerminal":"a"}]}"""
+        @serializedForm = """{"version":0.1,"filename":null,"nodes":[{"title":"a","x":10,"y":10,"key":"a"},{"title":"b","x":20,"y":20,"key":"b"}],"links":[{"title":"","color":"#777","sourceNodeKey":"a","sourceTerminal":"b","targetNodeKey":"b","targetTerminal":"a"}]}"""
       
       describe "toJsonString", () ->
         it "should include nodes and links", () ->


### PR DESCRIPTION
Along with a new button and google drive open and save buttons this also:

1. Adds a version number, the filename and the state of the node well to the serialized data.  The version number can be used in the future and the filename is used when serializing to the url.  
2. Adds a load listener to the link manager that is used in the app view to both load the saved palette and replace the onAddRemoteImage() functionality 
3. Moves the filename into the link manager and adds a listener that the app view subscribes to so that it can update its filename state which is passed down to the google file view
4. Removes the node well click handler that updates the selected node image