### PR TITLE
Fixed distorted rectangular images [#94094714]

### DIFF
--- a/src/stylus/components/image-picker.styl
+++ b/src/stylus/components/image-picker.styl
@@ -2,7 +2,6 @@
   display inline-block
   box-sizing border-box
   vertical-align top
-  width 75px
   margin-top 12px
   background-color white
   padding-right 10px
@@ -18,8 +17,8 @@
     background-size 10px 10px
     img
       padding 4px
-      width 42px
-      height 42px
+      max-width 42px
+      max-height 42px
   .image-choices
     box-sizing border-box
     margin 0px
@@ -42,13 +41,13 @@
       padding 0px
    img.image-choice
      padding 0px
-     width 24px
-     height 24px
+     max-width 24px
+     max-height 24px
    .image-choice
       padding 4px
       padding-bottom 12px
-      width 24px
-      height 24x
+      max-width 24px
+      max-height 24x
       &.selected
         background-color inherit
         box-shadow none

--- a/src/stylus/components/inspector-panel.styl
+++ b/src/stylus/components/inspector-panel.styl
@@ -40,8 +40,8 @@
       overflow visible
       .palette-inspector
         pallete-size()
-          height 50px
-          width 50px
+          max-height 50px
+          max-width 50px
         .palette
           margin 10px
           max-height 165px

--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -38,8 +38,8 @@ $deleteColor = hsl(1,50%,50%)
     box-shadow 2px 2px 2px hsla(0,0,0,0.2)
 
   img
-    width 50px
-    height 50px
+    max-width 50px
+    max-height 50px
 
   .node-title
     font-family sans-serif

--- a/src/stylus/components/proto-node.styl
+++ b/src/stylus/components/proto-node.styl
@@ -20,8 +20,8 @@
     width 108px
     height 108px
   img
-    width 100px
-    height 100px
+    max-width 100px
+    max-height 100px
   .node-title
     font-face sans-serif
     padding 5px

--- a/src/stylus/components/top-node-palette.styl
+++ b/src/stylus/components/top-node-palette.styl
@@ -34,8 +34,8 @@ node-well-tab-height = 30px
         height 30px
         border none
       img
-        width 25px
-        height 25px
+        max-width 25px
+        max-height 25px
   &.collapsed
     height node-well-collapsed-height
 


### PR DESCRIPTION
Any non-square images were being "squished" to squares in the css.

Test by dragging in the following image:

http://upload.wikimedia.org/wikipedia/commons/5/58/Sunset_2007-1.jpg