### PR TITLE
In-place edit  for node titles. [#93909154]

### DIFF
--- a/src/code/models/link-manager.coffee
+++ b/src/code/models/link-manager.coffee
@@ -186,13 +186,13 @@ module.exports = class LinkManager
     @selectedNode = @nodeKeys[nodeKey]
     if @selectedNode
       @selectedNode.selected = true
-      log.info "Selection happened for #{nodeKey} -- #{@selectedNode.title}"
     for listener in @selectionListeners
+      log.info "Selection happened for #{nodeKey} -- #{@selectedNode.title}"
       listener({node:@selectedNode, connection:null})
 
-  changeNode: (data) ->
-    if @selectedNode
-      node = @selectedNode
+  changeNode: (data, node) ->
+    node = node or @selectedNode
+    if node
       originalData =
         title: node.title
         image: node.image
@@ -208,8 +208,17 @@ module.exports = class LinkManager
       if data[key]
         log.info "Change #{key} for #{node.title}"
         node[key] = data[key]
-    for listener in @selectionListeners
-      listener({node:node, connection:null})
+    for listener in @nodeListeners
+      listener.handleNodeChange(node)
+    if node is @selectedNode
+      for listener in @selectionListeners
+        log.info "Selected node changed data: #{@selectedNode.title}"
+        listener({node:@selectedNode, connection:null})
+
+  changeNodeWithKey: (key, data) ->
+    node = @nodeKeys[ key ]
+    if node
+      @changeNode(data,node)
 
   selectLink: (link) ->
     if @selectedLink

--- a/src/code/models/link-manager.coffee
+++ b/src/code/models/link-manager.coffee
@@ -1,8 +1,8 @@
-Importer = require '../utils/importer'
-Link     = require './link'
+Importer    = require '../utils/importer'
+Link        = require './link'
 DiagramNode = require './node'
-UndoRedo = require '../utils/undo-redo'
-
+UndoRedo    = require '../utils/undo-redo'
+tr          = require "../utils/translate"
 # LinkManager is the logical manager of Nodes and Links.
 module.exports = class LinkManager
   @instances: {} # map of context -> instance
@@ -12,17 +12,17 @@ module.exports = class LinkManager
     LinkManager.instances[context]
 
   constructor: (context) ->
-    @linkKeys  = {}
-    @nodeKeys  = {}
-    @linkListeners = []
-    @nodeListeners = []
+    @linkKeys           = {}
+    @nodeKeys           = {}
+    @nodeViewStates     = {}
+    @linkListeners      = []
+    @nodeListeners      = []
     @selectionListeners = []
-    @loadListeners = []
-    @filename = null
-    @filenameListeners = []
-    @selectedNode = {}
+    @loadListeners      = []
+    @filename           = null
+    @filenameListeners  = []
     @imageMetadataCache = {}
-    @undoRedoManager = new UndoRedo.Manager debug: true
+    @undoRedoManager    = new UndoRedo.Manager debug: true
 
   undo: ->
     @undoRedoManager.undo()

--- a/src/code/utils/lang/us-en.coffee
+++ b/src/code/utils/lang/us-en.coffee
@@ -8,6 +8,7 @@ module.exports =
 
   "~MENU.SETTINGS": "Advanced Settings …"
 
+  "~NODE.UNTITLED": "Untitled"
   "~NODE-EDIT.TITLE": "Name"
   "~NODE-EDIT.COLOR": "Color"
   "~NODE-EDIT.IMAGE": "Image"

--- a/src/code/views/link-view.coffee
+++ b/src/code/views/link-view.coffee
@@ -97,6 +97,10 @@ module.exports = React.createClass
     @setState links: @props.linkManager.getLinks()
     false
 
+  handleNodeChange: (nodeData) ->
+    @setState nodes: @props.linkManager.getNodes()
+    true
+
   handleNodeAdd: (nodeData) ->
     @setState nodes: @props.linkManager.getNodes()
     true

--- a/src/code/views/link-view.coffee
+++ b/src/code/views/link-view.coffee
@@ -3,6 +3,7 @@ Importer         = require '../utils/importer'
 NodeList         = require '../models/link-manager'
 DiagramToolkit   = require '../utils/js-plumb-diagram-toolkit'
 dropImageHandler = require '../utils/drop-image-handler'
+tr               = require '../utils/translate'
 
 {div} = React.DOM
 
@@ -42,13 +43,17 @@ module.exports = React.createClass
 
   addNode: (e, ui) ->
     {title, image} = ui.draggable.data()
+    # requirement change: new nodes are untitled
+    title = tr "~NODE.UNTITLED"
     offset = $(@refs.linkView.getDOMNode()).offset()
-    @props.linkManager.importNode
+    node = @props.linkManager.importNode
       data:
         x: ui.offset.left - offset.left
         y: ui.offset.top - offset.top
         title: title
         image: image
+    @props.linkManager.setNodeViewState(node, 'is-editing')
+
 
   getInitialState: ->
     nodes: []
@@ -191,7 +196,8 @@ module.exports = React.createClass
           (Node {
             key: node.key
             data: node
-            selected: node.selected
+            selected: @props.linkManager.nodeViewState(node, "selected")
+            editTitle: @props.linkManager.nodeViewState(node, "title-editing")
             nodeKey: node.key
             ref: node.key
             onMove: @onNodeMoved

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -1,8 +1,71 @@
-{div, i, img} = React.DOM
+{input, div, i, img} = React.DOM
+tr = require "../utils/translate"
+
+NodeTitle = React.createFactory React.createClass
+  displayName: "NodeTitle"
+
+  getDefaultProps: ->
+    isEditing: false
+    defaultValue: tr "~NODE.UNTITLED"
+
+  getInitialState: ->
+    isEditing: @props.editing
+    title: @props.title
+
+  componentWillUnmount: ->
+    # remove jQuery listeners
+    $(@getDOMNode()).off()
+
+  componentDidUpdate: ->
+    $elem = $(@getDOMNode())
+    if @state.isEditing
+      $elem.focus()
+
+    # switching btween div and input dom elements
+    # componentDidMount wasn"t adequate for
+    # registering this listener
+    $elem.off()
+    if @state.isEditing
+      enterKey = 13
+      $elem.on "keyup", (e)=>
+        if e.which is enterKey
+          @finishEditing()
+
+  toggleEdit:(e) ->
+    @setState({isEditing: not @state.isEditing})
+
+  updateTitle: (e) ->
+    newTitle = $(@getDOMNode()).val()
+    newTitle = if newTitle.length > 0 then newTitle else @props.defaultValue
+    @props.onChange(newTitle)
+
+  finishEditing: ->
+    @updateTitle()
+    @setState({isEditing: false})
+
+  renderTitle: ->
+    (div {className: "node-title", onClick: @toggleEdit }, @props.title)
+
+  renderTitleInput: ->
+    (input {
+      type: "text"
+      className: "node-title"
+      onChange: @updateTitle
+      value: @props.title
+      placeholder: @props.defaultValue
+      onBlur: =>
+        @finishEditing()
+    }, @props.title)
+
+  render: ->
+    if @state.isEditing
+      @renderTitleInput()
+    else
+      @renderTitle()
 
 module.exports = React.createClass
 
-  displayName: 'NodeView'
+  displayName: "NodeView"
 
   componentDidMount: ->
     $elem = $(@refs.node.getDOMNode())
@@ -10,12 +73,14 @@ module.exports = React.createClass
       # grid: [ 10, 10 ]
       drag: @doMove
       stop: @doStop
-      containment: 'parent'
-    $elem.bind 'click touchend', (=> @handleSelected true)
+      containment: "parent"
+
+  getInitialState: ->
+    editingNodeTitle: false
 
   handleSelected: (actually_select) ->
     if @props.linkManager
-      selectionKey = if actually_select then @props.nodeKey else 'dont-select-anything'
+      selectionKey = if actually_select then @props.nodeKey else "dont-select-anything"
       @props.linkManager.selectNode selectionKey
 
   propTypes:
@@ -25,10 +90,10 @@ module.exports = React.createClass
     nodeKey: React.PropTypes.string
 
   getDefaultProps: ->
-    onMove:   -> log.info 'internal move handler'
-    onStop:   -> log.info 'internal move handler'
-    onDelete: -> log.info 'internal on-delete handler'
-    onSelect: -> log.info 'internal select handler'
+    onMove:   -> log.info "internal move handler"
+    onStop:   -> log.info "internal move handler"
+    onDelete: -> log.info "internal on-delete handler"
+    onSelect: -> log.info "internal select handler"
 
   doMove: (evt, extra) ->
     @props.onMove
@@ -53,20 +118,32 @@ module.exports = React.createClass
       domElement: @refs.node.getDOMNode()
       syntheticEvent: evt
 
+  changeTitle: (newTitle) ->
+    log.info "Title is changing to #{newTitle}"
+    @props.linkManager.changeNodeWithKey(@props.nodeKey, {title:newTitle})
+
   render: ->
     style =
       top: @props.data.y
       left: @props.data.x
-      'color': @props.data.color
+      "color": @props.data.color
     className = "elm"
     if @props.selected
       className = "#{className} selected"
-    (div { className: className, ref: 'node', style: style, 'data-node-key': @props.nodeKey},
-      (div {className: "img-background"},
-        (if @props.data.image?.length > 0 and @props.data.image isnt '#remote' then (img {src: @props.data.image}) else null)
+    (div { className: className, ref: "node", style: style, "data-node-key": @props.nodeKey},
+      (div {
+        className: "img-background"
+        onClick: (=> @handleSelected true)
+        onTouchend: (=> @handleSelected true)
+        },
+        (if @props.data.image?.length > 0 and @props.data.image isnt "#remote" then (img {src: @props.data.image}) else null)
         if @props.selected
-          (div {className: 'connection-source', 'data-node-key': @props.nodeKey})
+          (div {className: "connection-source", "data-node-key": @props.nodeKey})
       )
-      (div {className: 'node-title'}, @props.data.title)
+      (NodeTitle {
+        edit: @state.editingNodeTitle
+        title: @props.data.title
+        onChange: @changeTitle
+      })
     )
 

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -9,8 +9,8 @@ NodeTitle = React.createFactory React.createClass
 
 
   componentWillUnmount: ->
-    # remove jQuery listeners
-    @inputElm().off()
+    if @props.isEditing
+      @inputElm().off()
 
   componentDidUpdate: ->
     if @props.isEditing
@@ -144,7 +144,9 @@ module.exports = React.createClass
         onClick: (=> @handleSelected true)
         onTouchend: (=> @handleSelected true)
         },
-        (if @props.data.image?.length > 0 and @props.data.image isnt "#remote" then (img {src: @props.data.image}) else null)
+        (div {className: "image-wrapper"},
+          (if @props.data.image?.length > 0 and @props.data.image isnt "#remote" then (img {src: @props.data.image}) else null)
+        )
         if @props.selected
           (div {className: "connection-source", "data-node-key": @props.nodeKey})
       )

--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -78,7 +78,8 @@ $deleteColor = hsl(1,50%,50%)
     max-width 100px
     margin-left auto
     margin-right auto
-
+    cursor pointer
+    margin-bottom 1.2em
   .delete-box
     margin 2px
     padding 0px

--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -8,7 +8,6 @@ $deleteColor = hsl(1,50%,50%)
   border-radius 5px
   background-color none
   text-align center
-
   .img-background
     padding 2px
     border-radius 5px
@@ -38,7 +37,10 @@ $deleteColor = hsl(1,50%,50%)
       margin-right auto
       background-color none
       border-radius 5px
-      img
+      .image-wrapper
+        padding 2px
+        width 50px
+        height 50px
         border-radius 5px
         border 2px solid
 
@@ -48,7 +50,7 @@ $deleteColor = hsl(1,50%,50%)
       box-sizing padding-box
       top 25px
       background-color white
-      right 16px
+      right 10px
       border-radius 18px
       width 18px
       height 18px


### PR DESCRIPTION
One thing which will need to described and built up is the idea of nodeViewStates.

These will be transient states related to selection for the Nodes in the link-view.

Our current model of selection in link-view is week.  This PR includes some an initial (inadequate) attempt to address some of this.

This PR is for https://www.pivotaltracker.com/story/show/93909154: "When a component is dragged from the palette to the model, it should have a name of 'untitled' and the title should immediately be editable with the cursor focus in the title."