### PR TITLE
[#93911110] unify direct & inspector editing for node title.

### DIFF
--- a/src/code/mixins/node-title.coffee
+++ b/src/code/mixins/node-title.coffee
@@ -1,0 +1,19 @@
+tr = require "../utils/translate"
+module.exports =
+  defaultTitle: ->
+    tr "~NODE.UNTITLED"
+
+  titlePlaceholder: ->
+    @defaultTitle()
+
+  displayTitleForInput: (proposedTitle) ->
+    # For input fields, use 'placeholder' value @defaultTitle
+    # to work, the 'value' attribute of the input should be blank
+    if proposedTitle is @defaultTitle() then "" else proposedTitle
+
+  maxTitleLength: ->
+    35
+
+  cleanupTitle: (newTitle) ->
+    newTitle = newTitle.substr(0, @maxTitleLength())
+    newTitle = if newTitle.length > 0 then newTitle else @defaultTitle()

--- a/src/code/views/node-inspector-view.coffee
+++ b/src/code/views/node-inspector-view.coffee
@@ -6,9 +6,10 @@ ImagePickerView = React.createFactory require './image-picker-view'
 module.exports = React.createClass
 
   displayName: 'NodeInspectorView'
-
+  mixins: [require "../mixins/node-title"]
   changeTitle: (e) ->
-    @props.onNodeChanged? @props.node, {title: e.target.value}
+    newTitle = @cleanupTitle(e.target.value)
+    @props.onNodeChanged? @props.node, {title: newTitle}
 
   changeImage: (node) ->
     @props.onNodeChanged? @props.node, {image: node.image}
@@ -25,13 +26,14 @@ module.exports = React.createClass
     remoteNodes = []
     tabs = [tr('design'), tr('define')]
     selected = tr('design')
+    displayTitle = @displayTitleForInput(@props.node.title)
 
     (div {className: 'node-inspector-view'},
       (InspectorTabs {tabs: tabs, selected: selected} )
       (div {className: 'node-inspector-content'},
         (div {className: 'edit-row'},
           (label {htmlFor: 'title'}, tr "~NODE-EDIT.TITLE")
-          (input {type: 'text', name: 'title', value: @props.node.title, onChange: @changeTitle})
+          (input {type: 'text', name: 'title', value: displayTitle, placeholder: @titlePlaceholder(),  onChange: @changeTitle})
         )
         (div {className: 'edit-row'},
           (label {htmlFor: 'color'}, tr "~NODE-EDIT.COLOR")

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -3,9 +3,8 @@ tr = require "../utils/translate"
 
 NodeTitle = React.createFactory React.createClass
   displayName: "NodeTitle"
-  maxTitleLength: 35
+  mixins: [require '../mixins/node-title']
   getDefaultProps: ->
-    defaultValue: tr "~NODE.UNTITLED"
 
 
   componentWillUnmount: ->
@@ -30,9 +29,7 @@ NodeTitle = React.createFactory React.createClass
     @inputElm().val()
 
   updateTitle: (e) ->
-    newTitle = @inputValue()
-    newTitle = newTitle.substr(0,@maxTitleLength)
-    newTitle = if newTitle.length > 0 then newTitle else @props.defaultValue
+    newTitle = @cleanupTitle(@inputValue())
     @props.onChange(newTitle)
 
   finishEditing: ->
@@ -43,15 +40,15 @@ NodeTitle = React.createFactory React.createClass
     (div {className: "node-title", onClick: @props.onStartEditing }, @props.title)
 
   renderTitleInput: ->
-    displayValue = if @props.title is @props.defaultValue then "" else @props.title
+    displayTitle = @displayTitleForInput(@props.title)
     (input {
       type: "text"
       ref: "input"
       className: "node-title"
       onChange: @updateTitle
-      value: displayValue
+      value: displayTitle
       maxlength: @maxTitleLength
-      placeholder: @props.defaultValue
+      placeholder: @titlePlaceholder()
       onBlur: =>
         @finishEditing()
     })


### PR DESCRIPTION
The inspector title behaved differently form the direct node title editing.
This unifies the string truncation and other behaviors in both contexts.

https://www.pivotaltracker.com/story/show/93911110