### PR TITLE
Codap undo redo

### DIFF
--- a/src/code/app.coffee
+++ b/src/code/app.coffee
@@ -14,7 +14,7 @@ window.initApp = (wireframes=false) ->
     linkManager: LinkManager.instance 'building-models'
     data: getParameterByName 'data'
 
-  opts.codapConnect = new CodapConnect opts.linkManager
+  opts.codapConnect = CodapConnect.instance 'building-models'
 
   appView = AppView opts
   elem = '#app'

--- a/src/code/mixins/app-view.coffee
+++ b/src/code/mixins/app-view.coffee
@@ -98,9 +98,10 @@ module.exports =
       else
         undo = redo = false
       if undo or redo
-        e.preventDefault()
-        @props.linkManager.redo() if redo
-        @props.linkManager.undo() if undo
+        if (@props.linkManager.undoRedoIsVisible)
+          e.preventDefault()
+          @props.linkManager.redo() if redo
+          @props.linkManager.undo() if undo
 
   componentDidUnmount: ->
     @addDeleteKeyHandler false

--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -121,6 +121,10 @@ module.exports = class CodapConnect
         callback
           success: true
 
+      when 'externalUndoAvailable'
+        log.info 'Received externalUndoAvailable request from CODAP.'
+        @linkManager.hideUndoRedo(true)
+
       when 'undoAction'
         log.info 'Received undoAction request from CODAP.'
         @linkManager.undo()

--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -120,6 +120,15 @@ module.exports = class CodapConnect
         @linkManager.loadData args.state
         callback
           success: true
+
+      when 'undoAction'
+        log.info 'Received undoAction request from CODAP.'
+        @linkManager.undo()
+
+      when 'redoAction'
+        log.info 'Received redoAction request from CODAP.'
+        @linkManager.redo()
+
       else
         log.info 'Unknown request received from CODAP: ' + operation
 

--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -99,7 +99,7 @@ module.exports = class CodapConnect
         }
     }, openCaseCallback)
 
-  sendUndoableActionPerformed: () ->
+  sendUndoableActionPerformed: ->
     @codapPhone.call
       action: 'undoableActionPerformed'
 
@@ -127,18 +127,27 @@ module.exports = class CodapConnect
 
       when 'undoAction'
         log.info 'Received undoAction request from CODAP.'
-        @linkManager.undo()
+        successes = @linkManager.undo()
+        callback {success: @reduceSuccesses successes}
 
       when 'redoAction'
         log.info 'Received redoAction request from CODAP.'
-        @linkManager.redo()
+        successes = @linkManager.redo()
+        callback {success: @reduceSuccesses successes}
 
       else
         log.info 'Unknown request received from CODAP: ' + operation
 
+  # undo/redo events can return an array of successes
+  # this reduces that array to true iff every element is true
+  reduceSuccesses: (successes) ->
+    return successes unless successes.length
+    return false for s in successes when s is false
+    return true
+
   initGameHandler: =>
     @initAccomplished = true
-  
+
   #
   # Requests a CODAP action, if the Building Models tool is configured to reside
   # in CODAP. For actions that may be requested, see

--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -8,10 +8,16 @@ module.exports = class CodapConnect
 
   initAccomplished: false
 
-  constructor: (linkManager, name) ->
+  @instances: {} # map of context -> instance
+
+  @instance: (context) ->
+    CodapConnect.instances[context] ?= new CodapConnect context
+    CodapConnect.instances[context]
+
+  constructor: (context) ->
     log.info 'CodapConnect: initializing'
-    @linkManager = linkManager
-    name and @name = name
+    LinkManager = require './link-manager'
+    @linkManager = LinkManager.instance context
 
     @codapPhone = new IframePhoneRpcEndpoint( @codapRequestHandler,
       'codap-game', window.parent )
@@ -92,6 +98,10 @@ module.exports = class CodapConnect
         values: [data.steps]
         }
     }, openCaseCallback)
+
+  sendUndoableActionPerformed: () ->
+    @codapPhone.call
+      action: 'undoableActionPerformed'
 
   codapRequestHandler: (cmd, callback) =>
     operation = cmd.operation

--- a/src/code/models/link-manager.coffee
+++ b/src/code/models/link-manager.coffee
@@ -41,6 +41,12 @@ module.exports   = class LinkManager
   revertToLastSave: ->
     @undoRedoManager.revertToLastSave()
 
+  hideUndoRedo: (hide) ->
+    @undoRedoManager.hideUndoRedo(hide)
+
+  undoRedoIsVisible: ->
+    @undoRedoManager.showUndoRedo
+
   addChangeListener: (listener) ->
     log.info("adding change listener")
     @undoRedoManager.addChangeListener listener

--- a/src/code/utils/undo-redo.coffee
+++ b/src/code/utils/undo-redo.coffee
@@ -8,6 +8,7 @@ class Manager
     @stackPosition = -1
     @savePosition = -1
     @changeListeners = []
+    @showUndoRedo = true
 
   createAndExecuteCommand: (name, methods) ->
     @execute (new Command name, methods)
@@ -50,6 +51,10 @@ class Manager
 
   canRedo: ->
     return @stackPosition < @commands.length - 1
+
+  hideUndoRedo: (hide) ->
+    @showUndoRedo = !hide
+    @_changed()
 
   save: ->
     @savePosition = @stackPosition
@@ -94,6 +99,7 @@ class Manager
         canUndo: @canUndo()
         canRedo: @canRedo()
         saved: @saved()
+        showUndoRedo: @showUndoRedo
       for listener in @changeListeners
         listener status
 

--- a/src/code/utils/undo-redo.coffee
+++ b/src/code/utils/undo-redo.coffee
@@ -1,4 +1,5 @@
 # based on https://github.com/jzaefferer/undo/blob/master/undo.js
+CodapConnect = require '../models/codap-connect'
 
 class Manager
   constructor: (options = {}) ->
@@ -10,6 +11,10 @@ class Manager
 
   createAndExecuteCommand: (name, methods) ->
     @execute (new Command name, methods)
+
+    codapConnect = CodapConnect.instance 'building-models'
+    codapConnect.sendUndoableActionPerformed()
+
 
   execute: (command) ->
     @_clearRedo()

--- a/src/code/utils/undo-redo.coffee
+++ b/src/code/utils/undo-redo.coffee
@@ -11,10 +11,12 @@ class Manager
     @showUndoRedo = true
 
   createAndExecuteCommand: (name, methods) ->
-    @execute (new Command name, methods)
+    result = @execute (new Command name, methods)
 
     codapConnect = CodapConnect.instance 'building-models'
     codapConnect.sendUndoableActionPerformed()
+
+    result
 
 
   execute: (command) ->

--- a/src/code/utils/undo-redo.coffee
+++ b/src/code/utils/undo-redo.coffee
@@ -53,7 +53,7 @@ class Manager
     return @stackPosition < @commands.length - 1
 
   hideUndoRedo: (hide) ->
-    @showUndoRedo = !hide
+    @showUndoRedo = not hide
     @_changed()
 
   save: ->

--- a/src/code/views/document-actions-view.coffee
+++ b/src/code/views/document-actions-view.coffee
@@ -14,6 +14,7 @@ module.exports = React.createClass
 
   modelChanged: (status) ->
     @setState
+      undoRedoVisible: status.showUndoRedo
       canRedo: status.canRedo
       canUndo: status.canUndo
 
@@ -30,8 +31,9 @@ module.exports = React.createClass
         (i {className: "fa fa-play-circle", onClick: @props.runSimulation})
         tr "~DOCUMENT.ACTIONS.RUN_SIMULATION"
       )
-      (div {className: 'undo-redo'},
-        (span {className: (buttonClass @state.canUndo), onClick: @undoClicked, disabled: not @state.canUndo}, tr "~DOCUMENT.ACTIONS.UNDO")
-        (span {className: (buttonClass @state.canRedo), onClick: @redoClicked, disabled: not @state.canRedo}, tr "~DOCUMENT.ACTIONS.REDO")
-      )
+      if @state.undoRedoVisible
+        (div {className: 'undo-redo'},
+          (span {className: (buttonClass @state.canUndo), onClick: @undoClicked, disabled: not @state.canUndo}, tr "~DOCUMENT.ACTIONS.UNDO")
+          (span {className: (buttonClass @state.canRedo), onClick: @redoClicked, disabled: not @state.canRedo}, tr "~DOCUMENT.ACTIONS.REDO")
+        )
     )

--- a/test/node-list-test.coffee
+++ b/test/node-list-test.coffee
@@ -1,5 +1,6 @@
 global._ = require 'lodash'
 global.log = require 'loglevel'
+global.window = { location: '' }
 
 chai = require('chai')
 chai.config.includeStack = true
@@ -14,6 +15,7 @@ GraphPrimitive = requireModel 'graph-primitive'
 Link           = requireModel 'link'
 Node           = requireModel 'node'
 LinkManager    = requireModel 'link-manager'
+CodapConnect   = requireModel 'codap-connect'
 
 describe 'GraphPrimitive', ->
   it 'GraphPrimitive should exists', ->
@@ -148,6 +150,13 @@ describe 'Node', ->
 
   describe "LinkManager", ->
     beforeEach ->
+      sandbox = Sinon.sandbox.create()
+      sandbox.stub(CodapConnect, "instance", ->
+        return {
+          sendUndoableActionPerformed: -> return ''
+        }
+      )
+
       @nodeA = new Node({title: "a", x:10, y:10}, 'a')
       @nodeB = new Node({title: "b", x:20, y:20}, 'b')
       @linkManager = new LinkManager()
@@ -169,6 +178,9 @@ describe 'Node', ->
       })
       @otherNewLink.terminalKey = ->
         "otherNewLink"
+
+    afterEach ->
+      CodapConnect.instance.restore()
 
     describe "addLink", ->
       describe "When the link doesn't already exist", ->


### PR DESCRIPTION
This PR uses a new CODAP API to allow CODAP to control the app's undo/redo history.

Each time we perform an undoable event, we notify CODAP of this. CODAP can then send us
undo and redo commands, which we perform using our own undo-redo manager.

Our undoable events are stored in CODAP's undo stack, which closely mimics this undo stack, so when CODAP calls 'undo', it pops off the action from CODAP's stack, and causes BuildingModels to pop off the action from its stack. The two will track identically.

We also add the ability for CODAP to inform BuildingModels that it is using its own undo system (which it doesn't always), so that BuildingModels can hide its undo UI. (Note that this doesn't affect whether we send the undoableActionPerformed messages, since these are side-effect free if CODAP isn't using undo.)

We could optionally add to this system a way of passing IDs of events between BuildingModels and CODAP. This would be useful if BuildingModels failed to undo an action, and needed to be aware of that when CODAP tried to undo a second time. 

However, currently BuildingModels does not have any way or expectation that it will "fail" to undo or redo an action. It assumes that an undo or redo will always work perfectly. Therefore, there doesn't seem to be any way that the two systems could get out of sync -- or, at least, that BuildingModels would be aware that it had gotten out of sync. At the moment, therefore, an ID system seems to me to be unnecessary.