### PR TITLE
Fix missing metadata bug: [#100136692]

### DIFF
--- a/src/code/views/image-metadata-view.coffee
+++ b/src/code/views/image-metadata-view.coffee
@@ -26,7 +26,7 @@ module.exports = React.createClass
       license: @refs.license.getDOMNode().value
       source: 'external'
 
-    PaletteManager.actions.setImageMetadata @state.selectedPaletteImage, newMetaData
+    PaletteManager.actions.setImageMetadata @props.image, newMetaData
 
   render: ->
     license = licenses.getLicense (@state.imageMetadata.license or 'public domain')

--- a/src/code/views/palette-inspector-view.coffee
+++ b/src/code/views/palette-inspector-view.coffee
@@ -60,11 +60,11 @@ module.exports = React.createClass
         (div {className: 'palette-about-image-title'},
           (i {className: "fa fa-info-circle"})
           (span {}, tr '~PALETTE-INSPECTOR.ABOUT_IMAGE')
-          (img {src: @state.selectedPaletteItem?.image})
+          (img {src: @state.selectedPaletteImage})
         )
-        if @state.selectedPaletteItem?.image
+        if @state.selectedPaletteImage
           (div {className: 'palette-about-image-info'},
-            (ImageMetadata {})
+            (ImageMetadata {image: @state.selectedPaletteImage})
           )
       )
     )

--- a/src/code/views/preview-image-dialog-view.coffee
+++ b/src/code/views/preview-image-dialog-view.coffee
@@ -14,9 +14,6 @@ module.exports = React.createClass
   addImage: ->
     @props.addImage @props.imageInfo
 
-  setImageMetadata: (image, metadata) ->
-    @props.linkManager.setImageMetadata image, metadata
-
   render: ->
     (div {},
       (div {className: 'header'}, tr '~IMAGE-BROWSER.PREVIEW')
@@ -32,6 +29,6 @@ module.exports = React.createClass
       )
       if @props.imageInfo.metadata
         (div {className: 'preview-metadata'},
-          (ImageMetadata {className: 'image-browser-preview-metadata'})
+          (ImageMetadata {image: @props.imageInfo.image, className: 'image-browser-preview-metadata'})
         )
     )


### PR DESCRIPTION
The image metadata cache wasn't being saved & loaded correctly.

The main issue was that the onLoad handler wasn't handling it.

Additionally when images were loaded from the local machine, the metadata was being added to the wrong image.


https://www.pivotaltracker.com/story/show/100136692