### PR TITLE
Drag add image

### DIFF
--- a/src/code/app.coffee
+++ b/src/code/app.coffee
@@ -20,7 +20,7 @@ window.initApp = (wireframes=false) ->
     simplified: getParameterByName 'simplified'
 
   opts.codapConnect = CodapConnect.instance 'building-models'
-
+  opts.tree = (require './models/image-manager').tree
   appView = AppView opts
   elem = '#app'
 

--- a/src/code/mixins/draggable.coffee
+++ b/src/code/mixins/draggable.coffee
@@ -1,0 +1,29 @@
+module.exports =
+  componentDidMount: ->
+    # Things to override in our classes
+    doMove        = @doMove or -> undefined
+    removeClasses = @removeClasses or ['proto-node']
+    addClasses    = @addClasses or ['elm']
+    domRef        = @refs.draggable or @
+
+    # converts from a paletteItem to a element
+    # in the diagram. (adding and removing css classes as required)
+    reactSafeClone = (e) ->
+      clone = $(@).clone(false)
+      _.each removeClasses, (classToRemove) ->
+        clone.removeClass classToRemove
+      _.each addClasses, (classToAdd) ->
+        clone.addClass classToAdd
+      clone.attr('data-reactid', null)
+      clone.find("*").each (i,v) ->
+        $(v).attr('data-reactid', null)
+      clone
+
+    $(domRef.getDOMNode()).draggable
+      drag: @doMove
+      revert: true
+      helper: reactSafeClone
+      revertDuration: 0
+      opacity: 0.35
+      appendTo: 'body'
+      zIndex: 1000

--- a/src/code/models/image-manager.coffee
+++ b/src/code/models/image-manager.coffee
@@ -24,6 +24,7 @@ store = Reflux.createStore
   onOpen: (callback=false)->
     @keepShowing = true
     @lastImage = null
+    @callback = null
     if callback
       @callback = callback
       @keepShowing = false

--- a/src/code/models/image-manager.coffee
+++ b/src/code/models/image-manager.coffee
@@ -1,0 +1,71 @@
+actions = Reflux.createActions([
+    "open", "close", "addImage"
+  ])
+
+
+store = Reflux.createStore
+  init: ->
+    @enableListening()
+    @initValues()
+
+  initValues: ->
+    @showing        = true
+    @keepShowing    = false
+    @lastImage      = null
+    @callback       = -> undefined
+    @_updateChanges()
+
+  enableListening: ->
+    @listenTo actions.open, @onOpen
+    @listenTo actions.close, @onClose
+    @listenTo actions.addImage, @onAddImage
+
+  onOpen: (callback=false)->
+    @keepShowing = true
+    @callback = false
+    if callback
+      @callback = callback
+      @keepShowing = false
+    @showing = true
+    @_updateChanges()
+
+  onClose: ->
+    @callback?()
+    @showing = false
+    @_updateChanges()
+
+  onImageAdd: (img) ->
+    @lastImage = img
+    @_updateChanges()
+
+  _updateChanges: ->
+    data =
+      showing: @showing
+      keepShowing: @keepShowing
+      lastImage: @lastImage
+
+    log.info "Sending changes to listeners: #{JSON.stringify(data)}"
+    @trigger(data)
+
+
+mixin =
+  actions: actions
+
+  getInitialState: ->
+    showing: store.showing
+    keepShowing: store.keepShowing
+    lastImage: store.lastImage
+
+  componentDidMount: ->
+    store.listen @onChange
+
+  onChange: (status) ->
+    @setState
+      showing: status.showing
+      keepShowing: status.keepShowing
+      lastImage: status.lastImage
+
+module.exports =
+  store: store
+  actions: actions
+  mixin: mixin

--- a/src/code/utils/lang/us-en.coffee
+++ b/src/code/utils/lang/us-en.coffee
@@ -45,7 +45,7 @@ module.exports =
   "~ADD-NEW-IMAGE.LINK-TAB": "Link"
 
   # views/palette-inspector-view.coffee
-  "~PALETTE-INSPECTOR.ADD_IMAGE": "New"
+  "~PALETTE-INSPECTOR.ADD_IMAGE": "New Image"
   "~PALETTE-INSPECTOR.ABOUT_IMAGE": "About This Image"
 
   # views/image-metadata-view.coffee

--- a/src/code/views/app-view.coffee
+++ b/src/code/views/app-view.coffee
@@ -71,10 +71,8 @@ module.exports = React.createClass
           toggleImageBrowser: @toggleImageBrowser
           linkManager: @props.linkManager
         )
-        if @state.showImageBrowser
-          (ImageBrowser
-            linkManager: @props.linkManager
-            close: @toggleImageBrowser
-          )
+        (ImageBrowser
+          linkManager: @props.linkManager
+        )
       )
     )

--- a/src/code/views/image-browser-view.coffee
+++ b/src/code/views/image-browser-view.coffee
@@ -6,12 +6,22 @@ ImageSearchDialog = React.createFactory require './image-search-dialog-view'
 MyComputerDialog = React.createFactory require './image-my-computer-dialog-view'
 LinkDialog = React.createFactory require './image-link-dialog-view'
 PaletteManager = require "../models/palette-manager"
+ImageManager = require "../models/image-manager"
 
 tr = require '../utils/translate'
+{div, img, i, span} = React.DOM
 
 module.exports = React.createClass
   displayName: 'Image Browser'
+  mixins: [ImageManager.mixin]
+
   render: ->
+    if @state.showing
+      @renderDialog()
+    else
+      @renderNothing()
+
+  renderDialog: ->
     store   = PaletteManager.store
     addToPalette = (node) ->
       PaletteManager.actions.addToPalette.trigger(node)
@@ -21,10 +31,11 @@ module.exports = React.createClass
       addToPalette: addToPalette
       inPalette: store.inPalette
       inLibrary: store.inLibrary
-      linkManager: @props.linkManager
 
-    (ModalTabbedDialogFactory {title: (tr "~ADD-NEW-IMAGE.TITLE"), close: @props.close, tabs: [
+    (ModalTabbedDialogFactory {title: (tr "~ADD-NEW-IMAGE.TITLE"), close: @actions.close, tabs: [
       TabbedPanel.Tab {label: (tr "~ADD-NEW-IMAGE.IMAGE-SEARCH-TAB"), component: (ImageSearchDialog props)}
       TabbedPanel.Tab {label: (tr "~ADD-NEW-IMAGE.MY-COMPUTER-TAB"), component: (MyComputerDialog props)}
       TabbedPanel.Tab {label: (tr "~ADD-NEW-IMAGE.LINK-TAB"), component: (LinkDialog props)}
     ]})
+
+  renderNothing: -> (div {} )

--- a/src/code/views/link-view.coffee
+++ b/src/code/views/link-view.coffee
@@ -5,6 +5,7 @@ DiagramToolkit   = require '../utils/js-plumb-diagram-toolkit'
 dropImageHandler = require '../utils/drop-image-handler'
 tr               = require '../utils/translate'
 PaletteManager   = require '../models/palette-manager'
+ImageManager     = require '../models/image-manager'
 
 {div} = React.DOM
 
@@ -65,13 +66,15 @@ module.exports = React.createClass
     else if data.droptype is 'paletteItem'
       paletteItem = PaletteManager.store.palette[data.index]
       @addPaletteNode(ui,paletteItem)
-      
+
   addNewPaletteNode: (e,ui) ->
-    undefined
+    ImageManager.actions.open (savedPaletteItem) =>
+      if savedPaletteItem
+        @addPaletteNode(ui, savedPaletteItem)
 
 
   addPaletteNode: (ui, paletteItem) ->
-    # requirement change: new nodes are untitled
+    # Default new nodes are untitled
     title = tr "~NODE.UNTITLED"
     offset = $(@refs.linkView.getDOMNode()).offset()
     node = @props.linkManager.importNode

--- a/src/code/views/link-view.coffee
+++ b/src/code/views/link-view.coffee
@@ -58,8 +58,19 @@ module.exports = React.createClass
           @addNode e, ui
 
   addNode: (e, ui) ->
-    {title, index} = ui.draggable.data()
-    paletteItem = PaletteManager.store.palette[index]
+    data = ui.draggable.data()
+    if data.droptype is 'new'
+      paletteItem = @addNewPaletteNode(e,ui)
+
+    else if data.droptype is 'paletteItem'
+      paletteItem = PaletteManager.store.palette[data.index]
+      @addPaletteNode(ui,paletteItem)
+      
+  addNewPaletteNode: (e,ui) ->
+    undefined
+
+
+  addPaletteNode: (ui, paletteItem) ->
     # requirement change: new nodes are untitled
     title = tr "~NODE.UNTITLED"
     offset = $(@refs.linkView.getDOMNode()).offset()

--- a/src/code/views/palette-inspector-view.coffee
+++ b/src/code/views/palette-inspector-view.coffee
@@ -13,7 +13,7 @@ PaletteAddImage = React.createFactory React.createClass
   mixins: [Draggable]
   render: ->
     (div {className: 'palette-image', 'data-droptype': 'new'},
-      (div {className: 'palette-add-image', onClick: ImageManager.actions.open },
+      (div {className: 'palette-add-image', onClick: -> ImageManager.actions.open(false) },
         (div { className: 'proto-node'},
           (div {className: 'img-background'},
             tr '~PALETTE-INSPECTOR.ADD_IMAGE'

--- a/src/code/views/palette-inspector-view.coffee
+++ b/src/code/views/palette-inspector-view.coffee
@@ -3,6 +3,7 @@ ImageMetadata  = React.createFactory require './image-metadata-view'
 
 Draggable      = require '../mixins/draggable'
 PaletteManager = require "../models/palette-manager"
+ImageManager   = require "../models/image-manager"
 tr             = require "../utils/translate"
 
 
@@ -12,7 +13,7 @@ PaletteAddImage = React.createFactory React.createClass
   mixins: [Draggable]
   render: ->
     (div {className: 'palette-image', 'data-droptype': 'new'},
-      (div {className: 'palette-add-image', onClick: @props.onClick},
+      (div {className: 'palette-add-image', onClick: ImageManager.actions.open },
         (div { className: 'proto-node'},
           (div {className: 'img-background'},
             tr '~PALETTE-INSPECTOR.ADD_IMAGE'
@@ -34,7 +35,7 @@ module.exports = React.createClass
     (div {className: 'palette-inspector'},
       (div {className: 'palette', ref: 'palette'},
         (div {},
-          (PaletteAddImage {onClick: @props.toggleImageBrowser})
+          (PaletteAddImage {})
           # _.forEach @state.palette, (node,index) =>
           _.map @state.palette, (node, index) =>
             (PaletteItemView {

--- a/src/code/views/palette-inspector-view.coffee
+++ b/src/code/views/palette-inspector-view.coffee
@@ -1,6 +1,7 @@
 PaletteItemView  = React.createFactory require './palette-item-view'
 ImageMetadata  = React.createFactory require './image-metadata-view'
 
+Draggable      = require '../mixins/draggable'
 PaletteManager = require "../models/palette-manager"
 tr             = require "../utils/translate"
 
@@ -8,10 +9,15 @@ tr             = require "../utils/translate"
 {div, img, i, span} = React.DOM
 
 PaletteAddImage = React.createFactory React.createClass
+  mixins: [Draggable]
   render: ->
-    (div {className: 'palette-image'},
+    (div {className: 'palette-image', 'data-droptype': 'new'},
       (div {className: 'palette-add-image', onClick: @props.onClick},
-        tr '~PALETTE-INSPECTOR.ADD_IMAGE'
+        (div { className: 'proto-node'},
+          (div {className: 'img-background'},
+            tr '~PALETTE-INSPECTOR.ADD_IMAGE'
+          )
+        )
       )
     )
 

--- a/src/code/views/palette-item-view.coffee
+++ b/src/code/views/palette-item-view.coffee
@@ -21,6 +21,7 @@ module.exports = React.createClass
     (div {
       'data-index': @props.index
       'data-title': @props.node.title
+      'data-droptype': 'paletteItem'
       className: className
       ref: 'node'
       onClick: @onClick

--- a/src/code/views/palette-item-view.coffee
+++ b/src/code/views/palette-item-view.coffee
@@ -1,33 +1,16 @@
 {div, img} = React.DOM
+Draggable = require '../mixins/draggable'
 
 module.exports = React.createClass
 
   displayName: 'ProtoNode'
 
-  componentDidMount: ->
-    # converts from a paletteItem to a element
-    # in the diagram. (adding and removing css classes as required)
-    reactSafeClone = (e) ->
-      clone = $(@).clone(false)
-      clone.removeClass "proto-node"
-      clone.addClass "elm"
-      clone.attr('data-reactid', null)
-      clone.find("*").each (i,v) ->
-        $(v).attr('data-reactid', null)
-      clone
-    $(@refs.node.getDOMNode()).draggable
-      drag: @doMove
-      revert: true
-      helper: reactSafeClone
-      revertDuration: 0
-      opacity: 0.35
-      appendTo: 'body'
-      zIndex: 1000
-
-  doMove: -> undefined
+  mixins: [Draggable]
 
   onClick: ->
     @props.onSelect @props.index
+
+  removeClasses: ["palette-image"]
 
   render: ->
     className = "palette-image"

--- a/src/code/views/preview-image-dialog-view.coffee
+++ b/src/code/views/preview-image-dialog-view.coffee
@@ -1,4 +1,5 @@
 ImageMetadata = React.createFactory require './image-metadata-view'
+ImageManger   = require "../models/image-manager"
 
 tr = require '../utils/translate'
 
@@ -9,9 +10,11 @@ module.exports = React.createClass
 
   cancel: (e) ->
     e.preventDefault()
+    ImageManger.actions.cancel()
     @props.addImage null
 
   addImage: ->
+    ImageManger.actions.addImage @props.imageInfo
     @props.addImage @props.imageInfo
 
   render: ->

--- a/src/stylus/components/palette-inspector.styl
+++ b/src/stylus/components/palette-inspector.styl
@@ -47,7 +47,8 @@ pal-image-size()
       width $paletteItemDimension
       height $paletteItemDimension
       box-sizing border-box
-      line-height $paletteItemDimension
+      line-height 1.25em
+      padding-top 1em
       vertical-align middle
       font-size 10px
       text-align center


### PR DESCRIPTION
The image browsing dialog now has to support two modes.

In the first mode we are just adding images to the Palette. Nothing is being dragged on the canvas. Its current functionality is great -- we just keep the dialog open so that the user can add more and more images.

The second case is more modal. According to this story: https://www.pivotaltracker.com/story/show/95933006  we need to use the dialog to pick one single image to be dropped onto the canvas (and also added to palette).  

The ImageManager is an attempt to centralize the logic for configuring / showing / hiding the dialog box.  Its also possible to supply a call-back hook now so that the interrupted operation (dragging) can continue after the image is selected.

