### PR TITLE
Show Run button only in codap

### DIFF
--- a/src/code/mixins/app-view.coffee
+++ b/src/code/mixins/app-view.coffee
@@ -1,5 +1,6 @@
 Simulation   = require "../models/simulation"
 PaletteStore = require "../stores/palette-store"
+CodapStore   = require "../stores/codap-store"
 
 module.exports =
 
@@ -9,6 +10,7 @@ module.exports =
       selectedConnection: null
       palette: []
       filename: null
+      undoRedoShowing: true
     _.extend mixinState, subState
 
   componentDidUpdate: ->
@@ -34,6 +36,7 @@ module.exports =
     @_loadInitialData()
     @_registerUndoRedoKeys()
     PaletteStore.store.listen @onPaletteChange
+    CodapStore.store.listen @onCodapStateChange
 
   componentDidUnmount: ->
     @addDeleteKeyHandler false
@@ -42,6 +45,10 @@ module.exports =
     @setState
       palette: status.palette
       internalLibrary: status.internalLibrary
+
+  onCodapStateChange: (status) ->
+    @setState
+      undoRedoShowing: not status.hideUndoRedo
 
   getData: ->
     @props.linkManager.toJsonString @state.palette
@@ -101,7 +108,7 @@ module.exports =
       else
         undo = redo = false
       if undo or redo
-        if (@props.linkManager.undoRedoIsVisible)
+        if (@state.undoRedoShowing)
           e.preventDefault()
           @props.linkManager.redo() if redo
           @props.linkManager.undo() if undo

--- a/src/code/mixins/app-view.coffee
+++ b/src/code/mixins/app-view.coffee
@@ -63,7 +63,7 @@ module.exports =
           _.map report.endState, (n) ->
             "#{n.title} #{n.initialValue} → #{n.value}"
         ).join("\n")
-        alert "Run for #{report.steps} steps\n#{nodeInfo}:"
+        log.info "Run for #{report.steps} steps\n#{nodeInfo}:"
         @props.codapConnect.sendSimulationData(report)
 
     simulator.run()

--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -124,7 +124,7 @@ module.exports = class CodapConnect
 
       when 'externalUndoAvailable'
         log.info 'Received externalUndoAvailable request from CODAP.'
-        @linkManager.hideUndoRedo(true)
+        CodapStore.actions.hideUndoRedo()
 
       when 'undoAction'
         log.info 'Received undoAction request from CODAP.'

--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -1,4 +1,5 @@
 IframePhoneRpcEndpoint = (require 'iframe-phone').IframePhoneRpcEndpoint
+CodapStore = require "../stores/codap-store"
 tr = require '../utils/translate'
 module.exports = class CodapConnect
 
@@ -145,8 +146,10 @@ module.exports = class CodapConnect
     return false for s in successes when s is false
     return true
 
-  initGameHandler: =>
-    @initAccomplished = true
+  initGameHandler: (result) =>
+    if result and result.success
+      @initAccomplished = true
+      CodapStore.actions.codapLoaded()
 
   #
   # Requests a CODAP action, if the Building Models tool is configured to reside

--- a/src/code/models/link-manager.coffee
+++ b/src/code/models/link-manager.coffee
@@ -54,12 +54,6 @@ module.exports   = class LinkManager
   revertToLastSave: ->
     @undoRedoManager.revertToLastSave()
 
-  hideUndoRedo: (hide) ->
-    @undoRedoManager.hideUndoRedo(hide)
-
-  undoRedoIsVisible: ->
-    @undoRedoManager.showUndoRedo
-
   addChangeListener: (listener) ->
     log.info("adding change listener")
     @undoRedoManager.addChangeListener listener

--- a/src/code/stores/codap-store.coffee
+++ b/src/code/stores/codap-store.coffee
@@ -1,6 +1,7 @@
 codapActions = Reflux.createActions(
   [
     "codapLoaded"
+    "hideUndoRedo"
   ]
 )
 
@@ -9,19 +10,26 @@ codapStore   = Reflux.createStore
 
   init: ->
     @codapHasLoaded = false
+    @hideUndoRedo   = false
 
   onCodapLoaded: ->
     @codapHasLoaded = true
     @notifyChange()
 
+  onHideUndoRedo: ->
+    @hideUndoRedo = true
+    @notifyChange()
+
   notifyChange: ->
     data =
       codapHasLoaded: @codapHasLoaded
+      hideUndoRedo:   @hideUndoRedo
     @trigger(data)
 
 mixin =
   getInitialState: ->
     codapHasLoaded: codapStore.codapHasLoaded
+    hideUndoRedo:   codapStore.hideUndoRedo
 
   componentDidMount: ->
     codapStore.listen @onCodapStateChange
@@ -29,6 +37,7 @@ mixin =
   onCodapStateChange: (status) ->
     @setState
       codapHasLoaded: status.codapHasLoaded
+      hideUndoRedo:   status.hideUndoRedo
 
 module.exports =
   actions: codapActions

--- a/src/code/stores/codap-store.coffee
+++ b/src/code/stores/codap-store.coffee
@@ -1,0 +1,36 @@
+codapActions = Reflux.createActions(
+  [
+    "codapLoaded"
+  ]
+)
+
+codapStore   = Reflux.createStore
+  listenables: [codapActions]
+
+  init: ->
+    @codapHasLoaded = false
+
+  onCodapLoaded: ->
+    @codapHasLoaded = true
+    @notifyChange()
+
+  notifyChange: ->
+    data =
+      codapHasLoaded: @codapHasLoaded
+    @trigger(data)
+
+mixin =
+  getInitialState: ->
+    codapHasLoaded: codapStore.codapHasLoaded
+
+  componentDidMount: ->
+    codapStore.listen @onCodapStateChange
+
+  onCodapStateChange: (status) ->
+    @setState
+      codapHasLoaded: status.codapHasLoaded
+
+module.exports =
+  actions: codapActions
+  store: codapStore
+  mixin: mixin

--- a/src/code/utils/undo-redo.coffee
+++ b/src/code/utils/undo-redo.coffee
@@ -10,7 +10,6 @@ class Manager
     @stackPosition = -1
     @savePosition = -1
     @changeListeners = []
-    @showUndoRedo = true
 
   createAndExecuteCommand: (name, methods) ->
     result = @execute (new Command name, methods)
@@ -56,10 +55,6 @@ class Manager
   canRedo: ->
     return @stackPosition < @commands.length - 1
 
-  hideUndoRedo: (hide) ->
-    @showUndoRedo = not hide
-    @_changed()
-
   save: ->
     @savePosition = @stackPosition
     @_changed()
@@ -103,7 +98,6 @@ class Manager
         canUndo: @canUndo()
         canRedo: @canRedo()
         saved: @saved()
-        showUndoRedo: @showUndoRedo
       for listener in @changeListeners
         listener status
 

--- a/src/code/views/document-actions-view.coffee
+++ b/src/code/views/document-actions-view.coffee
@@ -1,7 +1,11 @@
 {div, span, i, br} = React.DOM
 
-tr = require '../utils/translate'
+CodapStore = require "../stores/codap-store"
+tr         = require '../utils/translate'
+
 module.exports = React.createClass
+
+  mixins: [ CodapStore.mixin ]
 
   displayName: 'DocumentActions'
 
@@ -25,7 +29,7 @@ module.exports = React.createClass
     @props.linkManager.redo()
 
   renderRunLink: ->
-    unless @props.simplified
+    if @state.codapHasLoaded and not @props.simplified
       (span {},
         (i {className: "fa fa-play-circle", onClick: @props.runSimulation})
         tr "~DOCUMENT.ACTIONS.RUN_SIMULATION"

--- a/src/code/views/document-actions-view.coffee
+++ b/src/code/views/document-actions-view.coffee
@@ -18,7 +18,6 @@ module.exports = React.createClass
 
   modelChanged: (status) ->
     @setState
-      undoRedoVisible: status.showUndoRedo
       canRedo: status.canRedo
       canUndo: status.canUndo
 
@@ -41,7 +40,7 @@ module.exports = React.createClass
       (div {className: "misc-actions"},
         @renderRunLink()
       )
-      if @state.undoRedoVisible
+      unless @state.hideUndoRedo
         (div {className: 'undo-redo'},
           (span {className: (buttonClass @state.canUndo), onClick: @undoClicked, disabled: not @state.canUndo}, tr "~DOCUMENT.ACTIONS.UNDO")
           (span {className: (buttonClass @state.canRedo), onClick: @redoClicked, disabled: not @state.canRedo}, tr "~DOCUMENT.ACTIONS.REDO")


### PR DESCRIPTION
We now only show the Run button if we are embedded in CODAP. We do this by listening to a successful phone call to CODAP, and setting state via a new codap-store.

Also refactored how we respond to CODAP asking us to hide the undo/redo buttons into the codap-store.

https://www.pivotaltracker.com/story/show/101447232