### PR TITLE
Batch undo redo

### DIFF
--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -194,6 +194,12 @@ GraphStore  = Reflux.createStore
     if node
       @changeNode(data,node)
 
+  startNodeEdit: ->
+    @undoRedoManager.startCommandBatch()
+
+  endNodeEdit: ->
+    @undoRedoManager.endCommandBatch()
+
   selectLink: (link) ->
     @selectionManager.selectLink(link)
 

--- a/src/code/stores/palette-delete-dialog-store.coffee
+++ b/src/code/stores/palette-delete-dialog-store.coffee
@@ -1,4 +1,5 @@
 PaletteStore = require './palette-store'
+UndoRedo       = require '../utils/undo-redo'
 
 paletteDialogActions = Reflux.createActions([
     "open", "close", "delete", "cancel", "select"
@@ -11,6 +12,7 @@ store = Reflux.createStore
   init: ->
     @enableListening()
     @initValues()
+    @undoManger = UndoRedo.instance debug:true
 
   initValues: ->
     @showing      = false
@@ -40,8 +42,10 @@ store = Reflux.createStore
 
   onDelete: (item) ->
     @deleted = true
+    @undoManger.startCommandBatch()
     PaletteStore.actions.deleteSelected()
     @close()
+    @undoManger.endCommandBatch()
 
   onPaletteSelect: (status) ->
     @paletteItem = status.selectedPaletteItem

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -117,6 +117,7 @@ module.exports = React.createClass
       syntheticEvent: evt
 
   changeTitle: (newTitle) ->
+    @props.graphStore.startNodeEdit()
     log.info "Title is changing to #{newTitle}"
     @props.graphStore.changeNodeWithKey(@props.nodeKey, {title:newTitle})
 
@@ -124,6 +125,7 @@ module.exports = React.createClass
     @props.selectionManager.selectForTitleEditing(@props.data)
 
   stopEditing: ->
+    @props.graphStore.endNodeEdit()
     @props.selectionManager.clearTitleEditing()
 
   isEditing: ->


### PR DESCRIPTION
Allows us to batch multiple undoable commands into a single command that can be undone or redone in one click.

https://www.pivotaltracker.com/story/show/101973812

@knowuh Let me know if you have a better solution for the `setTimeout` that is called in `endCommandBatch`. Without it, if we call

    @undoManger.startCommandBatch()
    PaletteStore.actions.deleteSelected()
    ... anything else
    @undoManger.endCommandBatch()

then `deleteSelected` gets called after `endCommandBatch`, because it uses an async callback.