### PR TITLE
Add editing panel for defining node values with words

### DIFF
--- a/src/code/data/migrations/03_add_semi_quant_editing.coffee
+++ b/src/code/data/migrations/03_add_semi_quant_editing.coffee
@@ -1,0 +1,18 @@
+Relationship = require '../../models/relationship'
+
+migration =
+  version: 1.2
+  description: "Adds initial value for defining node semiquantitatively."
+  date: "2015-09-02"
+
+  doUpdate: (data) ->
+    @updateNodes(data)
+    data
+
+  # Add initialValue if it doesn't exist
+  updateNodes: (data) ->
+    for node in data.nodes
+      node.data ||= {} # should never happen
+      node.data.valueDefinedSemiQuantitatively = false
+
+module.exports = _.mixin migration, require './migration-mixin'

--- a/src/code/data/migrations/migrations.coffee
+++ b/src/code/data/migrations/migrations.coffee
@@ -3,6 +3,7 @@
 migrations = [
   require "./01_base"
   require "./02_add_relations"
+  require "./03_add_semi_quant_editing"
 ]
 
 module.exports =

--- a/src/code/models/node.coffee
+++ b/src/code/models/node.coffee
@@ -14,6 +14,7 @@ module.exports = class Node extends GraphPrimitive
     @initialValue  ?= 50
     @isAccumulator ?= false
     @color ?= Colors[0].value
+    @valueDefinedSemiQuantitatively = false
 
   type: 'Node'
   addLink: (link) ->

--- a/src/code/models/node.coffee
+++ b/src/code/models/node.coffee
@@ -5,16 +5,16 @@ tr = require '../utils/translate'
 
 module.exports = class Node extends GraphPrimitive
 
-  constructor: (nodeSpec={x:0,y:0,title:"untitled",image:null,initialValue:50, isAccumulator:false}, key) ->
+  constructor: (nodeSpec={x:0,y:0,title:"untitled",image:null,initialValue:50, isAccumulator:false, valueDefinedSemiQuantitatively:false}, key) ->
     super()
     if key
       @key = key
     @links = []
-    {@x, @y, @title, @image, @initialValue, @isAccumulator} = nodeSpec
+    {@x, @y, @title, @image, @initialValue, @isAccumulator, @valueDefinedSemiQuantitatively} = nodeSpec
     @initialValue  ?= 50
     @isAccumulator ?= false
     @color ?= Colors[0].value
-    @valueDefinedSemiQuantitatively = false
+    @valueDefinedSemiQuantitatively ?= false
 
   type: 'Node'
   addLink: (link) ->
@@ -69,6 +69,7 @@ module.exports = class Node extends GraphPrimitive
       image: @image
       initialValue: @initialValue
       isAccumulator: @isAccumulator
+      valueDefinedSemiQuantitatively: @valueDefinedSemiQuantitatively
     key: @key
 
   paletteItemIs: (paletteItem) ->

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -175,6 +175,7 @@ GraphStore  = Reflux.createStore
         color: node.color
         initialValue: node.initialValue
         isAccumulator: node.isAccumulator
+        valueDefinedSemiQuantitatively: node.valueDefinedSemiQuantitatively
 
       @undoRedoManager.createAndExecuteCommand 'changeNode',
         execute: => @_changeNode node, data
@@ -182,7 +183,7 @@ GraphStore  = Reflux.createStore
 
   _changeNode: (node, data) ->
     log.info "Change for #{node.title}"
-    for key in ['title','image','color', 'initialValue', 'isAccumulator']
+    for key in ['title','image','color', 'initialValue', 'isAccumulator', 'valueDefinedSemiQuantitatively']
       if data.hasOwnProperty key
         log.info "Change #{key} for #{node.title}"
         node[key] = data[key]

--- a/src/code/utils/lang/us-en.coffee
+++ b/src/code/utils/lang/us-en.coffee
@@ -20,8 +20,13 @@ module.exports =
 
   # views/node-value-inspector-view.coffee
   "~NODE-VALUE-EDIT.INITIAL-VALUE": "Initial Value"
-  "~NODE-VALUE-EDIT.DEFINING_WITH_WORDS": "You are defining values with numbers. Switch to define with words."
+  "~NODE-VALUE-EDIT.DEFINING_WITH_NUMBERS": "You are defining values with numbers."
+  "~NODE-VALUE-EDIT.DEFINING_WITH_WORDS": "You are defining values with words."
+  "~NODE-VALUE-EDIT.SWITCH_TO_DEFINING_WITH_WORDS": "Switch to define with words."
+  "~NODE-VALUE-EDIT.SWITCH_TO_DEFINING_WITH_NUMBERS": "Switch to define with numbers."
   "~NODE-VALUE-EDIT.IS_ACCUMULATOR": "Accumulator"
+  "~NODE-VALUE-EDIT.LOW": "Low"
+  "~NODE-VALUE-EDIT.HIGH": "High"
 
   # views/relation-inspector-view.coffee
   "~NODE-RELATION-EDIT.DEFINING_WITH_WORDS": "You are defining relationships with graphs. Switch to define with equations."

--- a/src/code/views/node-value-inspector-view.coffee
+++ b/src/code/views/node-value-inspector-view.coffee
@@ -27,6 +27,9 @@ module.exports = React.createClass
     value = evt.target.checked
     @props.graphStore.changeNode(isAccumulator:value)
 
+  updateDefiningType: ->
+    @props.graphStore.changeNode(valueDefinedSemiQuantitatively:!@props.node.valueDefinedSemiQuantitatively)
+
   selectText: (evt) ->
     evt.target.select()
 
@@ -34,18 +37,19 @@ module.exports = React.createClass
     node = @props.node
     (div {className: 'value-inspector'},
       (div {className: 'inspector-content group'},
-        (span {className: 'full'},
-          (label {className: 'right'}, tr "~NODE-VALUE-EDIT.INITIAL-VALUE")
-          (input {
-            className: 'left'
-            type: "number",
-            min: "#{@props.min}",
-            max: "#{@props.max}",
-            value: "#{node.initialValue}",
-            onClick: @selectText,
-            onChange: @updateValue}
+        unless node.valueDefinedSemiQuantitatively
+          (span {className: 'full'},
+            (label {className: 'right'}, tr "~NODE-VALUE-EDIT.INITIAL-VALUE")
+            (input {
+              className: 'left'
+              type: "number",
+              min: "#{@props.min}",
+              max: "#{@props.max}",
+              value: "#{node.initialValue}",
+              onClick: @selectText,
+              onChange: @updateValue}
+            )
           )
-        )
         (div {className: "slider group full"},
           (input {
             className: "full"
@@ -55,8 +59,8 @@ module.exports = React.createClass
             value: "#{node.initialValue}",
             onChange: @updateValue}
           )
-          (label {className: "left half small"}, @props.min)
-          (label {className: "right half small"}, @props.max)
+          (label {className: "left half small"}, if node.valueDefinedSemiQuantitatively then tr "~NODE-VALUE-EDIT.LOW" else @props.min)
+          (label {className: "right half small"}, if node.valueDefinedSemiQuantitatively then tr "~NODE-VALUE-EDIT.HIGH" else @props.max)
         )
         (span {className: "checkbox group full"},
           (span {},
@@ -66,7 +70,16 @@ module.exports = React.createClass
           (i {className: "fa fa-question-circle"})
         )
       )
+
       (div {className: "bottom-pane"},
-        (p {}, tr "~NODE-VALUE-EDIT.DEFINING_WITH_WORDS")
+        (p {},
+          if node.valueDefinedSemiQuantitatively then tr "~NODE-VALUE-EDIT.DEFINING_WITH_WORDS"
+          else  tr "~NODE-VALUE-EDIT.DEFINING_WITH_NUMBERS")
+        (p {},
+          (label {className: 'node-switch-edit-mode', onClick: @updateDefiningType},
+            if node.valueDefinedSemiQuantitatively then tr "~NODE-VALUE-EDIT.SWITCH_TO_DEFINING_WITH_NUMBERS"
+            else tr "~NODE-VALUE-EDIT.SWITCH_TO_DEFINING_WITH_WORDS"
+          )
+        )
       )
     )

--- a/src/stylus/components/inspector-panel.styl
+++ b/src/stylus/components/inspector-panel.styl
@@ -58,7 +58,7 @@ inspector-panel-inner-height = 500px
       padding-right 50px
       // overflow hidden
 
-      .inspector-content
+      .inspector-content, .bottom-pane
         padding 1em
         text-align left
         background-color bbgray
@@ -76,10 +76,8 @@ inspector-panel-inner-height = 500px
           white-space nowrap
         label
           display inline-block
-          width 45px
           label-font()
-          margin 1em
-          &.node-delete, &.link-delete
+          &.node-delete, &.link-delete, &.node-switch-edit-mode
             color light-blue
             cursor pointer
             &:hover
@@ -92,6 +90,14 @@ inspector-panel-inner-height = 500px
           border-radius 3px
         i
           margin-right: 1em
+
+      .inspector-content
+        label
+          width 45px
+          margin 1em
+      .bottom-pane
+        label
+          margin-top: -0.8em
 
 
   &.collapsed

--- a/test/migrations-test.coffee
+++ b/test/migrations-test.coffee
@@ -6,9 +6,9 @@ describe "Migrations",  ->
     beforeEach ->
       @result = Migrations.update(originalData)
 
-    describe "the final version number as of 2015-08-13", ->
-      it "should be 1.1", ->
-        @result.version.should.equal 1.1
+    describe "the final version number", ->
+      it "should be 1.2", ->
+        @result.version.should.equal 1.2
 
     describe "the nodes", ->
       it "should have two nodes", ->
@@ -26,6 +26,12 @@ describe "Migrations",  ->
               node.data.initialValue.should.exist
               node.data.isAccumulator.should.exist
               node.data.isAccumulator.should.equal false
+
+        describe "v-1.2 node changes", ->
+          it "should have initial node values", ->
+            for node in @result.nodes
+              node.data.valueDefinedSemiQuantitatively.should.exist
+              node.data.valueDefinedSemiQuantitatively.should.equal false
 
     describe "the palette", ->
       it "should exist", ->


### PR DESCRIPTION
This adds a toggleable panel that allows a user to switch between defining
a node's value semi-quantitatively (low-high) or with numbers.

This adds a new property to a node, because any node that has been defined
in one way should keep being defined that way when the user re-opens the
editing panel.

The property `valueDefinedSemiQuantitatively` is a bit of a mouthful,
but it describes the intent. Note that this only describes how it's being
defined, nothing about the actual value changes.

[#97759284]