### PR TITLE
Saving references to a graph nodes PaletteItem (& tests)   [#100138582]

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "loglevel": "^1.2.0",
     "mathjs": "^1.7.0",
     "react": "^0.13.3",
-    "reflux": "^0.2.7"
+    "reflux": "^0.2.7",
+    "uuid": "^2.0.1"
   },
   "devDependencies": {
     "browserify": "^9.0.3",

--- a/src/code/data/migrations/06_add_palette_references.coffee
+++ b/src/code/data/migrations/06_add_palette_references.coffee
@@ -1,0 +1,26 @@
+uuid = require 'uuid'
+
+imageToUUIDMap= {}
+
+migration =
+  version: 1.5
+  description: "Nodes reference PaletteItems"
+  date: "2015-09-16"
+
+  doUpdate: (data) ->
+    @updatePalette(data)
+    @updateNodes(data)
+    data
+
+  updatePalette: (data) ->
+    _.each data.palette, (paletteItem) ->
+      paletteItem.uuid ||= uuid.v4()
+      imageToUUIDMap[paletteItem.image] = paletteItem.uuid
+
+  # Add initialValue if it doesn't exist
+  updateNodes: (data) ->
+    for node in data.nodes
+      if node.data.image
+        node.data.paletteItem = imageToUUIDMap[node.data.image]
+
+module.exports = _.mixin migration, require './migration-mixin'

--- a/src/code/data/migrations/migrations.coffee
+++ b/src/code/data/migrations/migrations.coffee
@@ -6,6 +6,7 @@ migrations = [
   require "./03_add_semi_quant_editing"
   require "./04_add_min_max"
   require "./05_add_settings_and_cap"
+  require "./06_add_palette_references"
 ]
 
 module.exports =

--- a/src/code/models/node.coffee
+++ b/src/code/models/node.coffee
@@ -10,7 +10,7 @@ module.exports = class Node extends GraphPrimitive
     if key
       @key = key
     @links = []
-    {@x, @y, @title, @image, @initialValue, @isAccumulator, @valueDefinedSemiQuantitatively} = nodeSpec
+    {@x, @y, @title, @image, @initialValue, @isAccumulator, @valueDefinedSemiQuantitatively, @paletteItem} = nodeSpec
     @initialValue  ?= 50
     @min ?= 0
     @max ?= 100
@@ -79,7 +79,7 @@ module.exports = class Node extends GraphPrimitive
       title: @title
       x: @x
       y: @y
-      image: @image
+      paletteItem: @paletteItem
       initialValue: @initialValue
       min: @min
       max: @max
@@ -88,4 +88,4 @@ module.exports = class Node extends GraphPrimitive
     key: @key
 
   paletteItemIs: (paletteItem) ->
-    paletteItem.image is @image
+    paletteItem.uuid is @paletteItem

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -1,6 +1,6 @@
 Importer            = require '../utils/importer'
 Link                = require '../models/link'
-DiagramNode         = require '../models/node'
+
 UndoRedo            = require '../utils/undo-redo'
 SelectionManager    = require '../models/selection-manager'
 PaletteStore        = require "../stores/palette-store"
@@ -103,10 +103,6 @@ GraphStore  = Reflux.createStore
     @nodeKeys[link.targetNode.key]?.removeLink(link)
     @updateListeners()
 
-  importNode: (nodeSpec) ->
-    node = new DiagramNode(nodeSpec.data, nodeSpec.key)
-    @addNode(node)
-    node
 
   addNode: (node) ->
     @undoRedoManager.createAndExecuteCommand 'addNode',
@@ -173,6 +169,7 @@ GraphStore  = Reflux.createStore
       originalData =
         title: node.title
         image: node.image
+        paletteItem: node.paletteItem
         color: node.color
         initialValue: node.initialValue
         min: node.min
@@ -284,10 +281,8 @@ GraphStore  = Reflux.createStore
 
   loadData: (data) ->
     log.info "json success"
-    importer = new Importer(@, AppSettingsStore.store)
+    importer = new Importer(@, AppSettingsStore.store, PaletteStore)
     importer.importData(data)
-    @setFilename data.filename or 'New Model'
-    PaletteStore.actions.loadData(data)
     @undoRedoManager.clearHistory()
 
   loadDataFromUrl: (url) =>

--- a/src/code/stores/palette-store.coffee
+++ b/src/code/stores/palette-store.coffee
@@ -2,7 +2,7 @@ resizeImage    = require '../utils/resize-image'
 initialPalette = require '../data/initial-palette'
 initialLibrary = require '../data/internal-library'
 UndoRedo       = require '../utils/undo-redo'
-
+uuid           = require 'uuid'
 
 # TODO: Maybe loadData goes into some other action-set
 paletteActions = Reflux.createActions(
@@ -40,9 +40,16 @@ paletteStore   = Reflux.createStore
     @selectPaletteIndex(0)
     @updateChanges()
 
+  makeNodeSignature: (node) ->
+    # 400 chars of a URL *might* be adequately unique,
+    # but data urls are going to be more trouble.
+    node.image.substr(0,400)
+
+
   standardizeNode: (node) ->
     node.image    ||= ""
-    node.key      ||= node.image.substr(0,400)
+    node.key      ||= @makeNodeSignature(node)
+    node.uuid     ||= uuid.v4()
     node.metadata ||= _.clone @blankMetadata, true
 
   addToLibrary: (node) ->
@@ -141,6 +148,9 @@ paletteStore   = Reflux.createStore
 
   inPalette: (node) ->
     _.find @palette, {key: node.key}
+
+  findByUUID: (uuid) ->
+    _.find @palette, {uuid: uuid}
 
   inLibrary: (node) ->
     @library[node.key]

--- a/src/code/utils/importer.coffee
+++ b/src/code/utils/importer.coffee
@@ -1,20 +1,33 @@
-Migrations = require '../data/migrations/migrations'
+Migrations          = require '../data/migrations/migrations'
+DiagramNode         = require '../models/node'
 
 module.exports = class MySystemImporter
 
-  constructor: (@system, @settings) ->
+  constructor: (@graphStore, @settings, @paletteStore) ->
     undefined
 
   importData: (data) ->
     Migrations.update(data)
+    # Synchronous invocation of actions / w trigger
+    @paletteStore.actions.loadData.trigger(data)
     @importNodes data.nodes
     @importLinks data.links
     @settings.importSettings data.settings
+    @graphStore.setFilename data.filename or 'New Model'
+
+  importNode: (nodeSpec) ->
+    data = nodeSpec.data
+    key = nodeSpec.key
+    if data.paletteItem
+      data.image = @paletteStore.store.findByUUID(data.paletteItem)?.image
+    node = new DiagramNode(data, key)
+    node
 
   importNodes: (importNodes) ->
-    for node in importNodes
-      @system.importNode node
+    for nodespec in importNodes
+      node = @importNode(nodespec)
+      @graphStore.addNode node
 
   importLinks: (links) ->
     for link in links
-      @system.importLink link
+      @graphStore.importLink link

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -1,4 +1,5 @@
 Node             = React.createFactory require './node-view'
+NodeModel        = require '../models/node'
 Importer         = require '../utils/importer'
 DiagramToolkit   = require '../utils/js-plumb-diagram-toolkit'
 dropImageHandler = require '../utils/drop-image-handler'
@@ -74,13 +75,15 @@ module.exports = React.createClass
     # Default new nodes are untitled
     title = tr "~NODE.UNTITLED"
     offset = $(@refs.linkView.getDOMNode()).offset()
-    node = @props.graphStore.importNode
-      data:
-        x: ui.offset.left - offset.left
-        y: ui.offset.top - offset.top
-        title: title
-        image: paletteItem.image
-    @props.graphStore.editNode(node.key)
+    newNode = new NodeModel
+      x: ui.offset.left - offset.left
+      y: ui.offset.top - offset.top
+      title: title
+      paletteItem: paletteItem.uuid
+      image: paletteItem.image
+
+    @props.graphStore.addNode newNode
+    @props.graphStore.editNode newNode.key
 
   getInitialState: ->
     nodes: []

--- a/test/migrations-test.coffee
+++ b/test/migrations-test.coffee
@@ -7,8 +7,8 @@ describe "Migrations",  ->
       @result = Migrations.update(originalData)
 
     describe "the final version number", ->
-      it "should be 1.4", ->
-        @result.version.should.equal 1.4
+      it "should be 1.5", ->
+        @result.version.should.equal 1.5
 
     describe "the nodes", ->
       it "should have two nodes", ->
@@ -43,6 +43,12 @@ describe "Migrations",  ->
           it "should have settings and cap value", ->
             @result.settings.capNodeValues.should.equal false
 
+        describe "v-1.5 changes", ->
+          it "should have settings and cap value", ->
+            for node in @result.nodes
+              node.data.image.should.not.be.null
+              node.data.paletteItem.should.not.be.null
+
     describe "the palette", ->
       it "should exist", ->
         @result.palette.should.exist
@@ -50,6 +56,11 @@ describe "Migrations",  ->
         blank = _.find @result.palette, (pitem) ->
           pitem.key is "img/nodes/blank.png"
         blank.should.exist
+
+      describe "v-1.5 changes", ->
+        it "paletteItems should have a uuid", ->
+          for paletteItem in @result.palette
+            paletteItem.uuid.should.not.be.null
 
     describe "the links", ->
       it "should have one link", ->


### PR DESCRIPTION
To save space in our serialized `.json` files, GraphNodes now reference PaletteItems by their UUID.   

When reconstituted via load the GraphNodes load images via the referenced PaletteItem.

This is mostly a migration and a few serialization tests.


@sfentress could you please review when you get a chance?

https://www.pivotaltracker.com/story/show/100138582