### PR TITLE
Simulation panel

### DIFF
--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -1,0 +1,39 @@
+SimulationActions = Reflux.createActions(
+  [
+    "expandSimulationPanel"
+    "collapseSimulationPanel"
+  ]
+)
+
+SimulationStore   = Reflux.createStore
+  listenables: [SimulationActions]
+
+  init: ->
+    @settings =
+      expanded: false
+
+  onExpandSimulationPanel: ->
+    @settings.expanded = true
+    @notifyChange()
+
+  onCollapseSimulationPanel: ->
+    @settings.expanded = false
+    @notifyChange()
+
+  notifyChange: ->
+    @trigger _.clone @settings
+
+mixin =
+  getInitialState: ->
+    _.clone SimulationStore.settings
+
+  componentDidMount: ->
+    SimulationStore.listen @onSimulationStoreChange
+
+  onSimulationStoreChange: (newData) ->
+    @setState _.clone newData
+
+module.exports =
+  actions: SimulationActions
+  store: SimulationStore
+  mixin: mixin

--- a/src/code/utils/lang/us-en.coffee
+++ b/src/code/utils/lang/us-en.coffee
@@ -118,7 +118,11 @@ module.exports =
   "~FILE.CONFIRM_LAST_SAVE_REVERT": "Are you sure you want to revert to the last save?"
 
 
-  "~DOCUMENT.ACTIONS.RUN_SIMULATION": "Run simulation"
+  "~DOCUMENT.ACTIONS.SIMULATE": "Simulate"
+  "~DOCUMENT.ACTIONS.RUN": "Run"
+  "~DOCUMENT.ACTIONS.SAVE_TO_GRAPHS": "Save to graphs"
+  "~DOCUMENT.ACTIONS.SHOW_MINI_GRAPHS": "Show mini-graphs"
+  "~DOCUMENT.ACTIONS.QUICK_TEST": "Quick-test mode"
   "~DOCUMENT.ACTIONS.UNDO": "Undo"
   "~DOCUMENT.ACTIONS.REDO": "Redo"
   "~DOCUMENT.ACTIONS.GRAPH_INVALID": "Your model contains a loop of dependent variables.\n\n

--- a/src/code/views/document-actions-view.coffee
+++ b/src/code/views/document-actions-view.coffee
@@ -1,6 +1,7 @@
 {div, span, i, br} = React.DOM
 
 ModalAppSettings = React.createFactory require './modal-app-settings-view'
+SimulationPanel  = React.createFactory require './simulation-panel-view'
 AppSettingsStore = require '../stores/app-settings-store'
 CodapStore       = require "../stores/codap-store"
 tr               = require '../utils/translate'
@@ -31,11 +32,8 @@ module.exports = React.createClass
 
   renderRunLink: ->
     if @state.codapHasLoaded and not @props.diagramOnly
-      classNames = "fa fa-play-circle"
-      classNames += " error" unless @props.graphIsValid
-      (span {},
-        (i {className: classNames, onClick: @props.runSimulation})
-        tr "~DOCUMENT.ACTIONS.RUN_SIMULATION"
+      (SimulationPanel
+        runSimulation: @props.runSimulation
       )
 
   renderSettingsLink: ->
@@ -46,14 +44,15 @@ module.exports = React.createClass
   render: ->
     buttonClass = (enabled) -> "button-link #{if not enabled then 'disabled' else ''}"
     (div {className: 'document-actions'},
-      (div {className: "misc-actions"},
-        @renderRunLink()
-      )
       unless @state.hideUndoRedo
         (div {className: 'undo-redo'},
           (span {className: (buttonClass @state.canUndo), onClick: @undoClicked, disabled: not @state.canUndo}, tr "~DOCUMENT.ACTIONS.UNDO")
           (span {className: (buttonClass @state.canRedo), onClick: @redoClicked, disabled: not @state.canRedo}, tr "~DOCUMENT.ACTIONS.REDO")
         )
+
+      (div {className: "misc-actions"},
+        @renderRunLink()
+      )
 
       if @props.iframed
         (div {className: "misc-actions"},

--- a/src/code/views/document-actions-view.coffee
+++ b/src/code/views/document-actions-view.coffee
@@ -38,16 +38,16 @@ module.exports = React.createClass
 
   renderSettingsLink: ->
     (span {},
-      (i {className: "fa fa-cog", onClick: AppSettingsStore.actions.showSettingsDialog})
+      (i {className: "ivy-icon-options", onClick: AppSettingsStore.actions.showSettingsDialog})
     )
 
   render: ->
-    buttonClass = (enabled) -> "button-link #{if not enabled then 'disabled' else ''}"
+    buttonClass = (enabled) -> if not enabled then 'disabled' else ''
     (div {className: 'document-actions'},
       unless @state.hideUndoRedo
-        (div {className: 'undo-redo'},
-          (span {className: (buttonClass @state.canUndo), onClick: @undoClicked, disabled: not @state.canUndo}, tr "~DOCUMENT.ACTIONS.UNDO")
-          (span {className: (buttonClass @state.canRedo), onClick: @redoClicked, disabled: not @state.canRedo}, tr "~DOCUMENT.ACTIONS.REDO")
+        (div {className: 'misc-actions'},
+          (i {className: "ivy-icon-arrow-undo #{buttonClass @state.canUndo}", onClick: @undoClicked, disabled: not @state.canUndo})
+          (i {className: "ivy-icon-arrow-redo #{buttonClass @state.canRedo}", onClick: @redoClicked, disabled: not @state.canRedo})
         )
 
       (div {className: "misc-actions"},

--- a/src/code/views/dropdown-view.coffee
+++ b/src/code/views/dropdown-view.coffee
@@ -42,7 +42,7 @@ module.exports = React.createClass
     (div {className: 'menu'},
       (span {className: 'menu-anchor', onClick: => @select(null)},
         @props.anchor
-        (i {className: 'fa fa-caret-down'})
+        (i {className: 'ivy-icon-arrow-expand'})
       )
       (div {className: menuClass, onMouseLeave: @blur, onMouseEnter: @unblur},
         (ul {},

--- a/src/code/views/simulation-panel-view.coffee
+++ b/src/code/views/simulation-panel-view.coffee
@@ -1,4 +1,5 @@
 Dropdown        = React.createFactory require './dropdown-view'
+ValueSlider     = React.createFactory require './value-slider-view'
 SimulationStore = require '../stores/simulation-store'
 tr              = require '../utils/translate'
 {div, span, i, input, label}  = React.DOM
@@ -29,20 +30,13 @@ module.exports = React.createClass
           (div {className: "row"},
             (Dropdown {anchor: "Years", items: []})
           )
-          (div {className: "row"},
-            (div {className: "full"},
-              (input {
-                className: "full"
-                type: "range"
-                min: "0"
-                max: "10"
-                value: "0"}
-              )
+          (div {className: "row tall"},
+            (ValueSlider {
+              min: "0"
+              max: "10"
+              value: "0"
+              width: "180"}
             )
-          )
-          (div {className: "row short split"},
-            (span {}, "0")
-            (span {}, "10")
           )
           (div {className: "row"},
             (div {className: "button", onClick: @props.runSimulation},
@@ -77,12 +71,13 @@ module.exports = React.createClass
           )
           (div {className: "row left"},
             "Speed"
-            (input {
-              className: "wide"
-              type: "range"
-              min: "0"
-              max: "10"
-              value: "0"}
+            (div {style: {margin: "-3px 0 3px 7px"}},
+              (ValueSlider {
+                min: "0"
+                max: "10"
+                value: "10"
+                width: "140"}
+              )
             )
           )
           (div {className: "row left"},

--- a/src/code/views/simulation-panel-view.coffee
+++ b/src/code/views/simulation-panel-view.coffee
@@ -1,0 +1,101 @@
+Dropdown        = React.createFactory require './dropdown-view'
+SimulationStore = require '../stores/simulation-store'
+tr              = require '../utils/translate'
+{div, span, i, input, label}  = React.DOM
+
+module.exports = React.createClass
+
+  displayName: 'SimulationPanel'
+
+  mixins: [ SimulationStore.mixin ]
+
+  toggle: ->
+    if @state.expanded
+      SimulationStore.actions.collapseSimulationPanel()
+    else
+      SimulationStore.actions.expandSimulationPanel()
+
+  render: ->
+    expanded = if @state.expanded then "expanded" else "collapsed"
+    (div {className: 'simulation-panel-wrapper'},
+      (div {className: "top-button #{expanded}", onClick: @toggle},
+        (div {},
+          (i {className: "ivy-icon-simulateTool"})
+        )
+        (div {}, tr "~DOCUMENT.ACTIONS.SIMULATE")
+      )
+      (div {className: "simulation-panel #{expanded}"},
+        (div {className: "run-panel"},
+          (div {className: "row"},
+            (Dropdown {anchor: "Years", items: []})
+          )
+          (div {className: "row"},
+            (div {className: "full"},
+              (input {
+                className: "full"
+                type: "range"
+                min: "0"
+                max: "10"
+                value: "0"}
+              )
+            )
+          )
+          (div {className: "row short split"},
+            (span {}, "0")
+            (span {}, "10")
+          )
+          (div {className: "row"},
+            (div {className: "button", onClick: @props.runSimulation},
+              tr "~DOCUMENT.ACTIONS.RUN"
+              (i {className: "ivy-icon-play"})
+            )
+            (div {className: "button disabled"},
+              (i {className: "ivy-icon-controlsReset"})
+            )
+            (div {className: "button disabled"},
+              (i {className: "ivy-icon-controlsBackward"})
+            )
+            (div {className: "button disabled"},
+              (i {className: "ivy-icon-controlsForward"})
+            )
+          )
+          (div {className: "row left"},
+            (div {className: "button small disabled"},
+              (i {className: "ivy-icon-saveGraph"})
+              tr "~DOCUMENT.ACTIONS.SAVE_TO_GRAPHS"
+            )
+          )
+        )
+        (div {className: "options-panel"},
+          (div {className: "row left short"},
+            (input {type: 'checkbox', value: 'show-mini', checked: @props.showMiniGraphs})
+            (label {}, tr '~DOCUMENT.ACTIONS.SHOW_MINI_GRAPHS')
+          )
+          (div {className: "row left short"},
+            (input {type: 'checkbox', value: 'quick-test', checked: @props.quickTest})
+            (label {}, tr '~DOCUMENT.ACTIONS.QUICK_TEST')
+          )
+          (div {className: "row left"},
+            "Speed"
+            (input {
+              className: "wide"
+              type: "range"
+              min: "0"
+              max: "10"
+              value: "0"}
+            )
+          )
+          (div {className: "row left"},
+            "Step"
+            (input {
+              className: 'left'
+              type: "number"
+              size: "3"
+              value: 1
+              min: "0"}
+            )
+            (Dropdown {anchor: "Year", items: []})
+          )
+        )
+      )
+    )

--- a/src/stylus/components/document-actions-view.styl
+++ b/src/stylus/components/document-actions-view.styl
@@ -1,35 +1,20 @@
 .document-actions
   enable-flex(justify:flex-end)
   width 100%
-  .undo-redo
-    width 150px
-    text-align right
-    .button-link
-      no-select()
-      label-font()
-      margin 5px
-      cursor pointer
-      color #fff
-      background-color #00f
-      padding 2px 7px
-      -webkit-border-radius: 5px;
-      -moz-border-radius: 5px;
-      border-radius: 5px;
-
-      &.disabled
-        cursor not-allowed
-        background-color #777
   .misc-actions
     padding-left 22px
-    color #777
+    color #666
     font-size 12px
-    text-align center
     i
       padding-right 0.5em
-      font-size 24px
+      font-size 30px
       cursor pointer
-      &:hover
-        text-shadow 1px 1px 3px hsl(0,0.5, 0.5)
+      no-select()
+      &.disabled
+        color #BBB
+        cursor not-allowed
+      &:hover:not(.disabled)
+        color #444
     i.error
       color #AF0000
       &:hover

--- a/src/stylus/components/menu.styl
+++ b/src/stylus/components/menu.styl
@@ -6,6 +6,8 @@
     cursor pointer
     label-font(size: 13px)
     font-size 13px
+    i
+      font-size 7px
 
 .menu-hidden
   display none

--- a/src/stylus/components/simulation-panel.styl
+++ b/src/stylus/components/simulation-panel.styl
@@ -1,0 +1,102 @@
+@require 'mixins/metrics'
+@require 'mixins/fonts'
+@require 'mixins/blender-box-colors'
+panelWidth = 225px
+
+.simulation-panel-wrapper
+  width 70px
+  height 25px
+  .top-button
+    position absolute
+    top 9px
+    height palette-and-actions-height - 1
+    padding 3px 7px 0 7px
+    cursor pointer
+    label-font()
+    line-height 1.8em
+    &:hover
+      background-color #F3F3F3
+    &.expanded
+      background-color white
+    i
+      font-size 29px
+      width 100%
+      padding 0
+      &:hover
+        text-shadow none
+  .simulation-panel
+    position relative
+    right panelWidth - 66
+    top 36px
+    width panelWidth
+    padding 5px
+    z-index: 2
+    &.collapsed
+      display none
+    &>div
+      .row
+        padding 8px
+        display flex
+        justify-content center
+        &.left
+          justify-content flex-start
+        &.split
+          justify-content space-between
+        &.short
+          padding-bottom 0
+          span
+            margin-top -0.5em
+        .button
+          cursor pointer
+          display inline-block
+          label-font()
+          color white
+          background-color med-blue
+          border-radius(2px)
+          padding 3px 6px 3px 6px
+          margin 3px
+          display flex
+          align-items center
+          justify-content center
+          i
+            padding 5px
+            font-size 17px
+            &:hover
+              color white
+          &.small
+            font-size 9px
+            i
+              font-size 11px
+          &.disabled
+            background-color light-blue
+            cursor default
+            i
+              cursor default
+          &:hover:not(.disabled)
+            background-color dark-gray
+        .menu
+          .menu-anchor
+            default-font()
+          i
+            font-size 6px
+            padding-left 0.6em
+            vertical-align 25%
+        input[type="checkbox"]
+          margin 0.5em
+        input[type="number"]
+          width 3em
+          margin -0.2em 0.5em 0 1.2em
+        label
+          margin 0.5em 0 0 0.2em
+    .run-panel
+      background-color white
+      border-radius(10px, 10px, 0, 0)
+      border-bottom 1px solid #80c0ab
+    .options-panel
+      background-color #ebebeb
+      border-radius(0,0, 10px, 10px)
+  .full
+    width 100%
+  .wide
+    width 100%
+    margin 0 7px 0 8px

--- a/src/stylus/components/simulation-panel.styl
+++ b/src/stylus/components/simulation-panel.styl
@@ -13,6 +13,7 @@ panelWidth = 225px
     padding 3px 7px 0 7px
     cursor pointer
     label-font()
+    text-align center
     line-height 1.8em
     &:hover
       background-color #F3F3F3
@@ -46,6 +47,8 @@ panelWidth = 225px
           padding-bottom 0
           span
             margin-top -0.5em
+        &.tall
+          padding-bottom 14px
         .button
           cursor pointer
           display inline-block

--- a/src/stylus/components/value-slider.styl
+++ b/src/stylus/components/value-slider.styl
@@ -27,6 +27,7 @@
     i.ivy-icon-smallSliderLines
       color:white
       font-size 1em
+      padding 0
   .number
     display none
     position absolute

--- a/src/stylus/mixins/blender-box-colors.styl
+++ b/src/stylus/mixins/blender-box-colors.styl
@@ -6,3 +6,4 @@ blue-gray  = #a4b1b7
 gold       = #f7be33
 bbgray     = #ececec
 green-blue = #72bca6
+dark-gray  = #192f3c

--- a/src/stylus/mixins/fonts.styl
+++ b/src/stylus/mixins/fonts.styl
@@ -6,6 +6,7 @@ default-font(style=normal, variant=normal, weight=normal, size=12px)
   font-weight weight
   font-size size
   font-family 'Montserrat', sans-serif
+  text-transform none
 
 label-font(style=normal, variant=normal, weight=normal, size=12px)
   default-font(style:style, variant:variant, weight:weight, size:size)


### PR DESCRIPTION
This adds the Simulation Panel UI, as requested by https://www.pivotaltracker.com/story/show/103626652

No new functionality exists in this panel, only the run button works. The other buttons show disabled states, but the sliders don't show a disabled state, even though they are non-functional. If we think this will be confusing, I can add a disabled state to the sliders for the window of time where we have non-useful sliders.

I would normally want to keep working on this branch to add more functionality to the panel, but since it contains features useful to @knowuh, and since @ddamelin has indicated that the panel alone is a useful feature (to allow users to imagine future development) I think this could be ready as is?