### PR TITLE
Simulation editable steps

### DIFF
--- a/src/code/app.coffee
+++ b/src/code/app.coffee
@@ -23,7 +23,6 @@ window.initApp = (wireframes=false) ->
     data: HashParams.getParam 'data'
     googleDoc: HashParams.getParam 'googleDoc'
 
-  opts.codapConnect = CodapConnect.instance 'building-models'
   appView = AppView opts
   elem = '#app'
 

--- a/src/code/mixins/app-view.coffee
+++ b/src/code/mixins/app-view.coffee
@@ -1,4 +1,3 @@
-Simulation      = require "../models/simulation"
 PaletteStore    = require "../stores/palette-store"
 CodapStore      = require "../stores/codap-store"
 GoogleFileStore = require "../stores/google-file-store"
@@ -14,7 +13,6 @@ module.exports =
       palette: []
       filename: null
       undoRedoShowing: true
-      graphIsValid: true
     _.extend mixinState, subState
 
   componentDidUpdate: ->
@@ -33,7 +31,6 @@ module.exports =
   componentDidMount: ->
     @addDeleteKeyHandler true
     @props.graphStore.selectionManager.addSelectionListener @_updateSelection
-    @props.graphStore.addChangeListener @onModelChanged
 
     @props.graphStore.addFilenameListener (filename) =>
       @setState filename: filename
@@ -55,37 +52,11 @@ module.exports =
     @setState
       undoRedoShowing: not status.hideUndoRedo
 
-  onModelChanged: ->
-    simulator = new Simulation
-      nodes: @props.graphStore.getNodes()
-    @setState
-      graphIsValid: simulator.graphIsValid()
-
   onNodeChanged: (node, data) ->
     @props.graphStore.changeNode data
 
   onNodeDelete: ->
     @props.graphStore.deleteSelected()
-
-  runSimulation: ->
-    if @state.graphIsValid
-      simulator = new Simulation
-        nodes: @props.graphStore.getNodes()
-        duration: 10
-        timeStep: 1
-        reportFunc: (report) =>
-          log.info report
-          nodeInfo = (
-            _.map report.endState, (n) ->
-              "#{n.title} #{n.initialValue} → #{n.value}"
-          ).join("\n")
-          log.info "Run for #{report.steps} steps\n#{nodeInfo}:"
-          @props.codapConnect.sendSimulationData(report)
-
-      simulator.run()
-      simulator.report()
-    else
-      alert tr "~DOCUMENT.ACTIONS.GRAPH_INVALID"
 
   # Update Selections. #TODO Move elsewhere
   _updateSelection: (manager) ->

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -8,6 +8,7 @@ SimulationActions = Reflux.createActions(
     "expandSimulationPanel"
     "collapseSimulationPanel"
     "runSimulation"
+    "setRunSteps"
   ]
 )
 
@@ -18,6 +19,7 @@ SimulationStore   = Reflux.createStore
     @settings =
       expanded: false
       graphIsValid: true
+      runSteps: 10
     @codapConnect = CodapConnect.instance 'building-models'
 
 
@@ -35,11 +37,17 @@ SimulationStore   = Reflux.createStore
     @settings.graphIsValid = simulator.graphIsValid()
     @notifyChange()
 
+  onSetRunSteps: (n) ->
+    @settings.runSteps = n
+    @notifyChange()
+
   onRunSimulation: ->
     if @settings.graphIsValid
+      steps = @settings.runSteps
+      steps = Math.min steps, 5000
       simulator = new Simulation
         nodes: GraphStore.getNodes()
-        duration: 10
+        duration: steps
         timeStep: 1
         reportFunc: (report) =>
           log.info report

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -1,7 +1,13 @@
+GraphStore   = require('./graph-store').store
+Simulation   = require "../models/simulation"
+CodapConnect = require '../models/codap-connect'
+tr           = require '../utils/translate'
+
 SimulationActions = Reflux.createActions(
   [
     "expandSimulationPanel"
     "collapseSimulationPanel"
+    "runSimulation"
   ]
 )
 
@@ -11,6 +17,9 @@ SimulationStore   = Reflux.createStore
   init: ->
     @settings =
       expanded: false
+      graphIsValid: true
+    @codapConnect = CodapConnect.instance 'building-models'
+
 
   onExpandSimulationPanel: ->
     @settings.expanded = true
@@ -19,6 +28,32 @@ SimulationStore   = Reflux.createStore
   onCollapseSimulationPanel: ->
     @settings.expanded = false
     @notifyChange()
+
+  onModelChanged: ->
+    simulator = new Simulation
+      nodes: GraphStore.getNodes()
+    @settings.graphIsValid = simulator.graphIsValid()
+    @notifyChange()
+
+  onRunSimulation: ->
+    if @settings.graphIsValid
+      simulator = new Simulation
+        nodes: GraphStore.getNodes()
+        duration: 10
+        timeStep: 1
+        reportFunc: (report) =>
+          log.info report
+          nodeInfo = (
+            _.map report.endState, (n) ->
+              "#{n.title} #{n.initialValue} → #{n.value}"
+          ).join("\n")
+          log.info "Run for #{report.steps} steps\n#{nodeInfo}:"
+          @codapConnect.sendSimulationData(report)
+
+      simulator.run()
+      simulator.report()
+    else
+      alert tr "~DOCUMENT.ACTIONS.GRAPH_INVALID"
 
   notifyChange: ->
     @trigger _.clone @settings
@@ -29,6 +64,7 @@ mixin =
 
   componentDidMount: ->
     SimulationStore.listen @onSimulationStoreChange
+    GraphStore.addChangeListener SimulationStore.onModelChanged
 
   onSimulationStoreChange: (newData) ->
     @setState _.clone newData

--- a/src/code/views/app-view.coffee
+++ b/src/code/views/app-view.coffee
@@ -58,8 +58,6 @@ module.exports = React.createClass
           })
           (DocumentActions
             graphStore: @props.graphStore
-            graphIsValid: @state.graphIsValid
-            runSimulation: @runSimulation
             diagramOnly: @state.diagramOnly
             iframed: @state.iframed
           )

--- a/src/code/views/document-actions-view.coffee
+++ b/src/code/views/document-actions-view.coffee
@@ -32,9 +32,7 @@ module.exports = React.createClass
 
   renderRunLink: ->
     if @state.codapHasLoaded and not @props.diagramOnly
-      (SimulationPanel
-        runSimulation: @props.runSimulation
-      )
+      (SimulationPanel {})
 
   renderSettingsLink: ->
     (span {},

--- a/src/code/views/simulation-panel-view.coffee
+++ b/src/code/views/simulation-panel-view.coffee
@@ -16,6 +16,9 @@ module.exports = React.createClass
     else
       SimulationStore.actions.expandSimulationPanel()
 
+  stepsRangeChanged: (r) ->
+    SimulationStore.actions.setRunSteps r.max
+
   render: ->
     expanded = if @state.expanded then "expanded" else "collapsed"
     runButtonClasses = "button"
@@ -34,10 +37,12 @@ module.exports = React.createClass
           )
           (div {className: "row tall"},
             (ValueSlider {
-              min: "0"
-              max: "10"
-              value: "0"
-              width: "180"}
+              min: 0
+              max: @state.runSteps
+              value: 0
+              width: 180
+              maxEditable: true
+              onRangeChange: @stepsRangeChanged}
             )
           )
           (div {className: "row"},
@@ -75,10 +80,10 @@ module.exports = React.createClass
             "Speed"
             (div {style: {margin: "-3px 0 3px 7px"}},
               (ValueSlider {
-                min: "0"
-                max: "10"
-                value: "10"
-                width: "140"}
+                min: 0
+                max: 10
+                value: 10
+                width: 140}
               )
             )
           )

--- a/src/code/views/simulation-panel-view.coffee
+++ b/src/code/views/simulation-panel-view.coffee
@@ -18,6 +18,8 @@ module.exports = React.createClass
 
   render: ->
     expanded = if @state.expanded then "expanded" else "collapsed"
+    runButtonClasses = "button"
+    if not @state.graphIsValid then runButtonClasses += " disabled error"
     (div {className: 'simulation-panel-wrapper'},
       (div {className: "top-button #{expanded}", onClick: @toggle},
         (div {},
@@ -39,7 +41,7 @@ module.exports = React.createClass
             )
           )
           (div {className: "row"},
-            (div {className: "button", onClick: SimulationStore.actions.runSimulation},
+            (div {className: runButtonClasses, onClick: SimulationStore.actions.runSimulation},
               tr "~DOCUMENT.ACTIONS.RUN"
               (i {className: "ivy-icon-play"})
             )

--- a/src/code/views/simulation-panel-view.coffee
+++ b/src/code/views/simulation-panel-view.coffee
@@ -39,7 +39,7 @@ module.exports = React.createClass
             )
           )
           (div {className: "row"},
-            (div {className: "button", onClick: @props.runSimulation},
+            (div {className: "button", onClick: SimulationStore.actions.runSimulation},
               tr "~DOCUMENT.ACTIONS.RUN"
               (i {className: "ivy-icon-play"})
             )

--- a/src/code/views/value-slider-view.coffee
+++ b/src/code/views/value-slider-view.coffee
@@ -14,17 +14,10 @@ ValueSlider = React.createClass
       log.info "new value #{v}"
 
   getInitialState: ->
-    value = _.clone @props.value
-    value = if value > @props.max then @props.max else value
-    value = if value < @props.min then @props.min else value
-    value: value
     dragging: false
 
   updateValue: (xValue,dragging) ->
     value = @valueFromSliderUI(xValue)
-    @setState
-      'value': value
-      'dragging': dragging
     @props.onValueChange value
 
   componentDidMount: ->
@@ -33,12 +26,14 @@ ValueSlider = React.createClass
       axis: "x"
       containment: "parent"
       start: (event, ui) =>
+        @setState 'dragging': true
         @updateValue ui.position.left, true
 
       drag: (event, ui) =>
         @updateValue ui.position.left, true
 
       stop: (event, ui) =>
+        @setState 'dragging': false
         @updateValue ui.position.left, false
 
   valueFromSliderUI: (displayX) ->
@@ -48,7 +43,7 @@ ValueSlider = React.createClass
     return newV
 
   sliderLocation: ->
-    (@state.value - @props.min) / (@props.max - @props.min)
+    (@props.value - @props.min) / (@props.max - @props.min)
 
   sliderPercent: ->
     (@sliderLocation() * 100)
@@ -59,7 +54,7 @@ ValueSlider = React.createClass
 
     if @state.dragging
       style.display = "block"
-    (div {className: "number", style: style}, Math.round(@state.value))
+    (div {className: "number", style: style}, Math.round(@props.value))
 
   renderHandle: ->
     width = height = "#{@props.handleSize}px"
@@ -92,7 +87,7 @@ ValueSlider = React.createClass
       padding: "0px"
       border: "0px"
       width: "#{@props.width}px"
-      "min-height":"#{@props.height}px"
+      minHeight:"#{@props.height}px"
     circleRadius = 2
     (div {className: "value-slider", style: style},
       (svg {className: "svg-background", width: "#{@props.width}px", height:"#{@props.height}px", viewBox: "0 0 #{@props.width} #{@props.height}"},
@@ -106,5 +101,15 @@ ValueSlider = React.createClass
 
 
 module.exports = ValueSlider
-myView = React.createFactory ValueSlider
-window.testComponent = (domID) -> React.render myView({}), domID
+Slider = React.createFactory ValueSlider
+Demo = React.createClass
+  getInitialState: ->
+    value: 50
+  onValueChange: (v) ->
+    @setState({value: v})
+  render: ->
+    (div {},
+      Slider {value: @state.value, onValueChange: @onValueChange}
+    )
+
+window.testComponent = (domID) -> React.render React.createElement(Demo,{}), domID

--- a/src/stylus/components/simulation-panel.styl
+++ b/src/stylus/components/simulation-panel.styl
@@ -75,6 +75,8 @@ panelWidth = 225px
             cursor default
             i
               cursor default
+          &.error
+            background-color light-red
           &:hover:not(.disabled)
             background-color dark-gray
         .menu

--- a/src/stylus/components/simulation-panel.styl
+++ b/src/stylus/components/simulation-panel.styl
@@ -89,6 +89,8 @@ panelWidth = 225px
         input[type="checkbox"]
           margin 0.5em
         input[type="number"]
+          width 5em
+        input[type="number"]:not(.max)
           width 3em
           margin -0.2em 0.5em 0 1.2em
         label

--- a/src/stylus/components/value-slider.styl
+++ b/src/stylus/components/value-slider.styl
@@ -54,3 +54,11 @@
     .max
       float right
       text-align right
+    .editable
+      border: 1px solid #DDD
+      border-radius 3px
+      padding: 2px
+      margin: -4px;
+      box-shadow 1px 1px 3px -2px rgba(0,0,0,0.75)
+    input
+      width 100px

--- a/src/stylus/mixins/blender-box-colors.styl
+++ b/src/stylus/mixins/blender-box-colors.styl
@@ -7,3 +7,4 @@ gold       = #f7be33
 bbgray     = #ececec
 green-blue = #72bca6
 dark-gray  = #192f3c
+light-red  = #e08d8d


### PR DESCRIPTION
This adds an editable range to the slider, which is then used to set the number of steps the model will run for.

The editable range slider is modeled after the existing one in the node properties panel.

This also includes a slight refactoring of the slider. This isn't a necessary refactoring, but after a fair bit of time delving into best practices for React components, I think it makes sense.

This doesn't quite complete https://www.pivotaltracker.com/story/show/102293096, but it adds the most valuable feature (settable number of steps), and I think it makes sense as its own PR to encapsulate the slider changes.

https://www.pivotaltracker.com/story/show/102293096
https://www.pivotaltracker.com/story/show/102606120

@knowuh When you have a chance, can you take a look?