### PR TITLE
Sliders are connected to node initial-values.  [#102293636]

### DIFF
--- a/src/code/models/node.coffee
+++ b/src/code/models/node.coffee
@@ -7,9 +7,9 @@ module.exports = class Node extends GraphPrimitive
   # Properties that can be changed.
   @fields: [
     'title', 'image', 'color', 'paletteItem',
-    'initialValue', 'min', 'max', 'isAccumulator',
-    'valueDefinedSemiQuantitatively']
-    
+    'initialValue', 'min', 'max', 'value',
+    'isAccumulator', 'valueDefinedSemiQuantitatively']
+
   constructor: (nodeSpec={x:0,y:0,title:"untitled",image:null,initialValue:50,min:0,max:100,isAccumulator:false, valueDefinedSemiQuantitatively:false}, key) ->
     super()
     if key
@@ -91,6 +91,9 @@ module.exports = class Node extends GraphPrimitive
       isAccumulator: @isAccumulator
       valueDefinedSemiQuantitatively: @valueDefinedSemiQuantitatively
     key: @key
+
+  canEditValue: ->
+    @inLinks().length is 0 or @isAccumulator
 
   paletteItemIs: (paletteItem) ->
     paletteItem.uuid is @paletteItem

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -172,6 +172,7 @@ GraphStore  = Reflux.createStore
         paletteItem: node.paletteItem
         color: node.color
         initialValue: node.initialValue
+        value: node.value or node.initialValue
         min: node.min
         max: node.max
         isAccumulator: node.isAccumulator

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -18,7 +18,7 @@ module.exports = React.createClass
   mixins: [ LinkStore.mixin, SimulationStore.mixin ]
 
   getDefaultProps: ->
-    linkTarget: '.img-background'
+    linkTarget: '.link-target'
 
   componentDidMount: ->
     $container = $(@refs.container.getDOMNode())

--- a/src/code/views/node-value-inspector-view.coffee
+++ b/src/code/views/node-value-inspector-view.coffee
@@ -87,7 +87,7 @@ module.exports = React.createClass
 
   render: ->
     node = @props.node
-    canEditValue = node.inLinks().length is 0 or node.isAccumulator
+    canEditValue = node.canEditValue()
     (div {className: 'value-inspector'},
       (div {className: 'inspector-content group'},
         if canEditValue

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -104,6 +104,7 @@ module.exports = NodeView = React.createClass
     onSelect: -> log.info "internal select handler"
     selected: falsepreviewImageClassName = "img-background link-target"
     simulating: false
+    value: null
     data:
       title: "foo"
       x: 10
@@ -133,6 +134,9 @@ module.exports = NodeView = React.createClass
       domElement: @refs.node.getDOMNode()
       syntheticEvent: evt
 
+  changeValue: (newValue) ->
+    @props.graphStore.changeNodeWithKey(@props.nodeKey, {initialValue:newValue})
+
   changeTitle: (newTitle) ->
     @props.graphStore.startNodeEdit()
     log.info "Title is changing to #{newTitle}"
@@ -149,10 +153,25 @@ module.exports = NodeView = React.createClass
     @props.selectionManager.isSelectedForTitleEditing(@props.data)
 
   renderValue: ->
+    value = @props.data.value or @props.data.initialValue
+    value = Math.round(value)
     (div {className: "value"},
       (label {}, tr "~NODE.SIMULATION.VALUE")
-      (input  {type: "text", className: "value", value: @props.value})
+      (input  {type: "text", className: "value", value: value})
     )
+
+  renderSliderView: ->
+    if @props.data.canEditValue()
+      (SliderView
+        width: 70
+        onValueChange: @changeValue
+        value: @props.data.initialValue
+        displaySemiQuant: @props.data.valueDefinedSemiQuantitatively
+        max: @props.data.max
+        min: @props.data.min
+      )
+    else
+      null
 
   render: ->
     style =
@@ -192,10 +211,10 @@ module.exports = NodeView = React.createClass
           if @props.selected
             (div {className: 'centered-block'},
               @renderValue()
-              (SliderView {width: 70} )
+              @renderSliderView()
             )
           else
-            (SliderView {width: 70} )
+            @renderSliderView()
       )
     )
 

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -102,7 +102,7 @@ module.exports = NodeView = React.createClass
     onStop:   -> log.info "internal move handler"
     onDelete: -> log.info "internal on-delete handler"
     onSelect: -> log.info "internal select handler"
-    selected: falsepreviewImageClassName = "img-background link-target"
+    selected: false
     simulating: false
     value: null
     data:
@@ -173,48 +173,59 @@ module.exports = NodeView = React.createClass
     else
       null
 
+  nodeClasses: ->
+    classes = ['elm']
+    if @props.selected
+      classes.push "selected"
+    classes.join " "
+
+  topClasses: ->
+    classes = ['top']
+    unless @props.selected
+      classes.push "link-target"
+    classes.join " "
+
+
   render: ->
     style =
       top: @props.data.y
       left: @props.data.x
       "color": @props.data.color
-    className = "elm"
-    if @props.selected
-      className = "#{className} selected"
 
-    (div { className: className, ref: "node", style: style, "data-node-key": @props.nodeKey},
-      if @props.selected
-        (div {className: "actions"},
-          (div {className: "connection-source action-circle ivy-icon-link", "data-node-key": @props.nodeKey})
-          (div {className: "graph-source action-circle ivy-icon-graph", "data-node-key": @props.nodeKey})
-        )
+    (div { className: @nodeClasses(), ref: "node", style: style},
+      (div {className: 'link-target'},
+        if @props.selected
+          (div {className: "actions"},
+            (div {className: "connection-source action-circle ivy-icon-link", "data-node-key": @props.nodeKey})
+            (div {className: "graph-source action-circle ivy-icon-graph", "data-node-key": @props.nodeKey})
+          )
 
-      (div {className: 'top'},
-        (div {
-          className: "img-background"
-          "data-node-key": @props.nodeKey
-          onClick: (=> @handleSelected true)
-          onTouchend: (=> @handleSelected true)
-          },
-          (SquareImage {image: @props.data.image, ref: "thumbnail"})
+        (div {className: @topClasses(), "data-node-key": @props.nodeKey},
+          (div {
+            className: "img-background"
+            onClick: (=> @handleSelected true)
+            onTouchend: (=> @handleSelected true)
+            },
+            (SquareImage {image: @props.data.image, ref: "thumbnail"})
+          )
+          (NodeTitle {
+            isEditing: @props.editTitle
+            title: @props.data.title
+            onChange: @changeTitle
+            onStopEditing: @stopEditing
+            onStartEditing: @startEditing
+          })
         )
-        (NodeTitle {
-          isEditing: @props.editTitle
-          title: @props.data.title
-          onChange: @changeTitle
-          onStopEditing: @stopEditing
-          onStartEditing: @startEditing
-        })
-      )
-      (div {className: 'bottom centered-block'},
-        if @props.simulating
-          if @props.selected
-            (div {className: 'centered-block'},
-              @renderValue()
+        (div {className: 'bottom centered-block' ,"data-node-key": @props.nodeKey},
+          if @props.simulating
+            if @props.selected
+              (div {className: 'centered-block'},
+                @renderValue()
+                @renderSliderView()
+              )
+            else
               @renderSliderView()
-            )
-          else
-            @renderSliderView()
+        )
       )
     )
 

--- a/src/code/views/value-slider-view.coffee
+++ b/src/code/views/value-slider-view.coffee
@@ -144,7 +144,7 @@ ValueSlider = React.createClass
       padding: "0px"
       border: "0px"
       width: "#{@props.width}px"
-      minHeight:"#{@props.height}px"
+      minHeight:"#{@props.height + lengendHeight}px"
     circleRadius = 2
     (div {className: "value-slider", style: style},
       (svg {className: "svg-background", width: "#{@props.width}px", height:"#{@props.height}px", viewBox: "0 0 #{@props.width} #{@props.height}"},

--- a/src/code/views/value-slider-view.coffee
+++ b/src/code/views/value-slider-view.coffee
@@ -12,6 +12,8 @@ ValueSlider = React.createClass
     handleSize: 16
     minEditable: false
     maxEditable: false
+    stepSize: 1
+    displayPrecision: 0
     onValueChange: (v) ->
       log.info "new value #{v}"
     onRangeChange: (r) ->
@@ -62,7 +64,7 @@ ValueSlider = React.createClass
     newV = (displayX / @props.width * (@props.max - @props.min)) + @props.min
     newV = if newV > @props.max then @props.max else newV
     newV = if newV < @props.min then @props.min else newV
-    return newV
+    return Math.round(newV / @props.stepSize) * @props.stepSize
 
   sliderLocation: ->
     (@props.value - @props.min) / (@props.max - @props.min)
@@ -76,7 +78,7 @@ ValueSlider = React.createClass
 
     if @state.dragging
       style.display = "block"
-    (div {className: "number", style: style}, Math.round(@props.value))
+    (div {className: "number", style: style}, @props.value.toFixed(@props.displayPrecision))
 
   renderHandle: ->
     width = height = "#{@props.handleSize}px"

--- a/src/stylus/components/value-slider.styl
+++ b/src/stylus/components/value-slider.styl
@@ -47,7 +47,6 @@
     font-size 9px
     font-weight bold
     enable-flex(alignItems:center, alignContent:center, justify:space-between)
-    top 2.5em
     width 100%
     .min
       float left


### PR DESCRIPTION
Also part of https://www.pivotaltracker.com/story/show/102293636.  This time we have connected the sliders in the graph window to the nodes initial-values.  

There is more work to be done, but I thought I would put this up to talk about.  At the time of this PR, I also deployed to http://concord-consortium.github.io/building-models/

![initial-value-sliders](https://cloud.githubusercontent.com/assets/22908/10178345/2a066e78-66cd-11e5-8002-9721924fcc5b.png)

Changes:  

* Sliders only show up for independent variables, or accumulators.
* Sliders adjust the 'initial value' of nodes.
* The Value text-edit field is the 'current-value' -- which is usually just the initial value.
