### PR TITLE
Make undo and redo into actions, fix several bugs

### DIFF
--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -177,9 +177,16 @@ GraphStore  = Reflux.createStore
         isAccumulator: node.isAccumulator
         valueDefinedSemiQuantitatively: node.valueDefinedSemiQuantitatively
 
-      @undoRedoManager.createAndExecuteCommand 'changeNode',
-        execute: => @_changeNode node, data
-        undo: => @_changeNode node, originalData
+
+      nodeChanged = false
+      for key of data
+        if data.hasOwnProperty key
+          if data[key] isnt originalData[key] then nodeChanged = true
+
+      if nodeChanged        # don't do anything unless we've actually changed the node
+        @undoRedoManager.createAndExecuteCommand 'changeNode',
+          execute: => @_changeNode node, data
+          undo: => @_changeNode node, originalData
 
   _changeNode: (node, data) ->
     log.info "Change for #{node.title}"

--- a/src/code/stores/palette-delete-dialog-store.coffee
+++ b/src/code/stores/palette-delete-dialog-store.coffee
@@ -60,7 +60,7 @@ store = Reflux.createStore
     if @replacement and @deleted
       PaletteStore.actions.selectPaletteItem @replacement
     else if not @deleted
-      @undoManger.undo()
+      @undoManger.undo(true)
       PaletteStore.actions.restoreSelection()
 
 

--- a/src/code/utils/undo-redo.coffee
+++ b/src/code/utils/undo-redo.coffee
@@ -56,10 +56,13 @@ class Manager
 
   undo: Reflux.createAction()
 
-  _undo: ->
+  # @param drop: calling undo(true) will clear the redo stack. When called on
+  # the last item, this is equivalent to throwing away the undone action.
+  _undo: (drop) ->
     if @canUndo()
       result = @commands[@stackPosition].undo @debug
       @stackPosition--
+      if drop then @_clearRedo()
       @_changed()
       @log() if @debug
       result

--- a/src/code/utils/undo-redo.coffee
+++ b/src/code/utils/undo-redo.coffee
@@ -28,8 +28,9 @@ class Manager
 
   _endComandBatch: ->
     if @currentBatch
-      @commands.push @currentBatch
-      @stackPosition++
+      if @currentBatch.commands.length > 0
+        @commands.push @currentBatch
+        @stackPosition++
       @currentBatch = null
 
   createAndExecuteCommand: (name, methods) ->

--- a/src/code/utils/undo-redo.coffee
+++ b/src/code/utils/undo-redo.coffee
@@ -18,6 +18,8 @@ class Manager
 
     # listen to all our actions
     @endCommandBatch.listen @_endComandBatch, @
+    @undo.listen @_undo, @
+    @redo.listen @_redo, @
 
   startCommandBatch: ->
     @currentBatch = new CommandBatch() unless @currentBatch
@@ -52,7 +54,9 @@ class Manager
     @log() if @debug
     result
 
-  undo: ->
+  undo: Reflux.createAction()
+
+  _undo: ->
     if @canUndo()
       result = @commands[@stackPosition].undo @debug
       @stackPosition--
@@ -65,7 +69,9 @@ class Manager
   canUndo: ->
     return @stackPosition >= 0
 
-  redo: ->
+  redo: Reflux.createAction()
+
+  _redo: ->
     if @canRedo()
       @stackPosition++
       result = @commands[@stackPosition].redo @debug


### PR DESCRIPTION
This PR turns undo and redo into Reflux actions, and along the way fixes several bugs:

1. Closing the delete dialog without deleting anything called undo() on the last action
2. Opening the delete dialog, adding a new image, then cancelling and closing the dialog wasn't correctly removing the newly-added image
3. Even when the newly-added image was correctly removed, the use could re-add the item via the "redo" button, which would be unexpected as the user never explicitly undid anything
4. Clicking away from a node without changing its title was adding an empty action to the undo stack. (This was unrelated to the above, but fixed anyway.)

@knowuh When you have a little time, could you hammer on this for a new minutes and see if you catch any edge-cases where I might have added a regression? I haven't noticed any issue caused by turning undo/redo into actions, but I may have missed something. I don't think this is urgent, though.