### PR TITLE
Reflux actions for loading. Serialize simulation [#104657406]

### DIFF
--- a/src/code/actions/graph-actions.coffee
+++ b/src/code/actions/graph-actions.coffee
@@ -1,0 +1,1 @@
+module.exports = Reflux.createActions [ "graphChanged" ]

--- a/src/code/actions/import-actions.coffee
+++ b/src/code/actions/import-actions.coffee
@@ -1,0 +1,1 @@
+module.exports = Reflux.createActions [ "import" ]

--- a/src/code/data/migrations/08_add_simulation_settings.coffee
+++ b/src/code/data/migrations/08_add_simulation_settings.coffee
@@ -1,0 +1,17 @@
+Relationship = require '../../models/relationship'
+TimeUnits = require '../../utils/time-units'
+
+migration =
+  version: 1.7
+  description: "Adds Simulation settings"
+  date: "2015-10-02"
+
+  doUpdate: (data) ->
+    data.settings ?= {}
+    data.settings.simulation ?= {}
+    data.settings.simulation.period ?= 10
+    data.settings.simulation.stepSize ?= 1
+    data.settings.simulation.periodUnits = TimeUnits.defaultUnit
+    data.settings.simulation.stepUnits = TimeUnits.defaultUnit
+
+module.exports = _.mixin migration, require './migration-mixin'

--- a/src/code/data/migrations/migrations.coffee
+++ b/src/code/data/migrations/migrations.coffee
@@ -8,6 +8,7 @@ migrations = [
   require "./05_add_settings_and_cap"
   require "./06_add_palette_references"
   require "./07_add_diagram_only_setting"
+  require "./08_add_simulation_settings"
 ]
 
 module.exports =

--- a/src/code/stores/app-settings-store.coffee
+++ b/src/code/stores/app-settings-store.coffee
@@ -1,4 +1,5 @@
-HashParams = require '../utils/hash-parameters'
+HashParams      = require '../utils/hash-parameters'
+ImportActions   = require '../actions/import-actions'
 
 AppSettingsActions = Reflux.createActions(
   [
@@ -10,7 +11,7 @@ AppSettingsActions = Reflux.createActions(
 )
 
 AppSettingsStore   = Reflux.createStore
-  listenables: [AppSettingsActions]
+  listenables: [AppSettingsActions, ImportActions]
 
   init: ->
     @settings =
@@ -41,8 +42,8 @@ AppSettingsStore   = Reflux.createStore
     else
       HashParams.clearParam('simplified')
 
-  importSettings: (data) ->
-    _.merge @settings, data
+  onImport: (data) ->
+    _.merge @settings, data.settings
     @notifyChange()
 
   serialize: ->

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -8,6 +8,8 @@ tr                  = require "../utils/translate"
 Migrations          = require "../data/migrations/migrations"
 PaletteDeleteStore  = require "../stores/palette-delete-dialog-store"
 AppSettingsStore    = require "../stores/app-settings-store"
+SimulationStore     = require "../stores/simulation-store"
+GraphActions        = require "../actions/graph-actions"
 
 GraphStore  = Reflux.createStore
   init: (context) ->
@@ -310,6 +312,7 @@ GraphStore  = Reflux.createStore
     linkExports = for key,link of @linkKeys
       link.toExport()
     settings = AppSettingsStore.store.serialize()
+    settings.simulation = SimulationStore.store.serialize()
 
     data =
       version: Migrations.latestVersion()
@@ -327,7 +330,7 @@ GraphStore  = Reflux.createStore
     data =
       nodes: @getNodes()
       links: @getLinks()
-    @trigger(data)
+    GraphActions.graphChanged.trigger(data)
 
 
 mixin =
@@ -336,9 +339,9 @@ mixin =
     links: GraphStore.links
 
   componentDidMount: ->
-    GraphStore.listen @onLinksChange
+    GraphActions.graphChanged.listen @onGraphChanged
 
-  onLinksChange: (status) ->
+  onGraphChanged: (status) ->
     @setState
       nodes: status.nodes
       links: status.links

--- a/src/code/stores/palette-store.coffee
+++ b/src/code/stores/palette-store.coffee
@@ -2,19 +2,20 @@ resizeImage    = require '../utils/resize-image'
 initialPalette = require '../data/initial-palette'
 initialLibrary = require '../data/internal-library'
 UndoRedo       = require '../utils/undo-redo'
+ImportActions  = require '../actions/import-actions'
 uuid           = require 'uuid'
+
 
 # TODO: Maybe loadData goes into some other action-set
 paletteActions = Reflux.createActions(
   [
-    "addToPalette", "loadData",
-    "selectPaletteIndex", "selectPaletteItem", "restoreSelection",
-    "itemDropped","update", "delete"
+    "addToPalette", "selectPaletteIndex", "selectPaletteItem",
+    "restoreSelection", "itemDropped","update", "delete"
   ]
 )
 
 paletteStore   = Reflux.createStore
-  listenables: [paletteActions]
+  listenables: [paletteActions, ImportActions]
 
   init: ->
     @initializeLibrary()
@@ -60,7 +61,7 @@ paletteStore   = Reflux.createStore
         node.image = dataUrl
       log.info "library: #{@library}"
 
-  onLoadData: (data) ->
+  onImport: (data) ->
     # reload the palette
     @palette = []
     if data.palette

--- a/src/code/utils/importer.coffee
+++ b/src/code/utils/importer.coffee
@@ -1,5 +1,6 @@
 Migrations          = require '../data/migrations/migrations'
 DiagramNode         = require '../models/node'
+ImportActions       = require '../actions/import-actions'
 
 module.exports = class MySystemImporter
 
@@ -9,10 +10,9 @@ module.exports = class MySystemImporter
   importData: (data) ->
     Migrations.update(data)
     # Synchronous invocation of actions / w trigger
-    @paletteStore.actions.loadData.trigger(data)
+    ImportActions.import.trigger(data)
     @importNodes data.nodes
     @importLinks data.links
-    @settings.importSettings data.settings
     @graphStore.setFilename data.filename or 'New Model'
 
   importNode: (nodeSpec) ->

--- a/test/loading-serialization-test.coffee
+++ b/test/loading-serialization-test.coffee
@@ -16,18 +16,16 @@ Link             = requireModel 'link'
 Node             = requireModel 'node'
 GraphStore       = require "#{__dirname}/../src/code/stores/graph-store"
 AppSettingsStore = require "#{__dirname}/../src/code/stores/app-settings-store"
+SimulationStore  = require "#{__dirname}/../src/code/stores/simulation-store"
 CodapConnect     = requireModel 'codap-connect'
 
 SerializedTestData = require "./serialized-test-data/v-0.1"
 
 describe "Serialization and Loading", ->
   beforeEach ->
-    sandbox = Sinon.sandbox.create()
-    sandbox.stub(CodapConnect, "instance", ->
-      return {
-        sendUndoableActionPerformed: -> return ''
-      }
-    )
+    @sandbox = Sinon.sandbox.create()
+    @sandbox.stub CodapConnect, "instance", ->
+      sendUndoableActionPerformed: -> return ''
 
     @serializedForm = JSON.stringify SerializedTestData
     @fakePalette = [
@@ -85,7 +83,7 @@ describe "Serialization and Loading", ->
         model.nodes.should.exist
         model.links.should.exist
 
-        model.version.should.equal 1.6
+        model.version.should.equal 1.7
         model.nodes.length.should.equal 2
         model.links.length.should.equal 1
 
@@ -137,6 +135,17 @@ describe "Serialization and Loading", ->
         model.settings.capNodeValues.should.equal true
         model.settings.diagramOnly.should.equal true
 
+      it "should be able to serialize the simulation settings", ->
+        SimulationStore.store.settings.period = 10
+        SimulationStore.store.settings.periodUnits = "YEAR"
+        SimulationStore.store.settings.stepSize = 1
+        SimulationStore.store.settings.stepUnits = "SECOND"
+        jsonString = @graphStore.toJsonString(@fakePalette)
+        model = JSON.parse jsonString
+        model.settings.simulation.period.should.equal 10
+        model.settings.simulation.periodUnits.should.equal "YEAR"
+        model.settings.simulation.stepSize.should.equal 1
+        model.settings.simulation.stepUnits.should.equal "SECOND"
 
   describe "loadData", ->
     beforeEach ->

--- a/test/migrations-test.coffee
+++ b/test/migrations-test.coffee
@@ -7,8 +7,8 @@ describe "Migrations",  ->
       @result = Migrations.update(originalData)
 
     describe "the final version number", ->
-      it "should be 1.6", ->
-        @result.version.should.equal 1.6
+      it "should be 1.7", ->
+        @result.version.should.equal 1.7
 
     describe "the nodes", ->
       it "should have two nodes", ->
@@ -52,6 +52,14 @@ describe "Migrations",  ->
         describe "v-1.6 changes", ->
           it "should have diagramOnly setting", ->
             @result.settings.diagramOnly.should.equal false
+
+        describe "v-1.7 changes", ->
+          it "should have settings for the simulation", ->
+            @result.settings.simulation.should.exist
+            @result.settings.simulation.period.should.equal 10
+            @result.settings.simulation.stepSize.should.equal 1
+            @result.settings.simulation.periodUnits.should.equal "YEAR"
+            @result.settings.simulation.stepUnits.should.equal "YEAR"
 
     describe "the palette", ->
       it "should exist", ->

--- a/test/stores/simulation-store-test.coffee
+++ b/test/stores/simulation-store-test.coffee
@@ -1,0 +1,40 @@
+chai = require('chai')
+chai.config.includeStack = true
+
+expect         = chai.expect
+should         = chai.should()
+
+SimulationStore = require "#{__dirname}/../../src/code/stores/simulation-store"
+TimeUnits = require "#{__dirname}/../../src/code/utils/time-units"
+SimStore = SimulationStore.store
+
+namedUnit = (name) ->
+  _.find TimeUnits.units, (n) -> n is name
+
+describe "SimulationStore", ->
+  describe "_setUnitsNames", ->
+    describe "With plural units", ->
+      beforeEach ->
+        SimStore.settings =
+          period: 10
+          periodUnits: namedUnit "YEAR"
+          stepSize: 2
+          stepUnits: namedUnit "SECOND"
+        SimStore._setUnitsNames()
+
+      it "should pluralize unit names", ->
+        SimStore.settings.periodUnitsName.should.equal "Years"
+        SimStore.settings.stepUnitsName.should.equal "Seconds"
+
+    describe "With singular units", ->
+      beforeEach ->
+        SimStore.settings =
+          period: 1
+          periodUnits: namedUnit "YEAR"
+          stepSize: 1
+          stepUnits: namedUnit "SECOND"
+        SimStore._setUnitsNames()
+
+      it "should pluralize unit names", ->
+        SimStore.settings.periodUnitsName.should.equal "Year"
+        SimStore.settings.stepUnitsName.should.equal "Second"


### PR DESCRIPTION
###  Action / Listener changes:

* Import is now an action.
* Broke out  graph-actions to resolve circular dependencies.
* Instead of listening for onLinksChange or onModelChange, just listen for onGraphChanged.

###  Changes to SimulationStore:

* Moved CODAP initialization into _sendSimulationData, to isolate that dependency.

* Broke out _setUnitsNames method, initially so names could be calculated after loading from serialized form.  Even though its overlaps functionally with `time-units-test.coffee`, I made a separate test for it.


There were also new migrations and serializations added.


See: https://www.pivotaltracker.com/story/show/104657406 for PT story.