### PR TITLE
Use protocol-relative paths for CFM urls; avoid mixed-content errors.

### DIFF
--- a/src/assets/sage.html
+++ b/src/assets/sage.html
@@ -3,9 +3,9 @@
     <title>Sage</title>
 
     <!-- Cloud File Manager -->
-    <script type="text/javascript" src="http://concord-consortium.github.io/cloud-file-manager/js/globals.js"></script>
-    <script type="text/javascript" src="http://concord-consortium.github.io/cloud-file-manager/js/app.js"></script>
-    <link rel="stylesheet" href="http://concord-consortium.github.io/cloud-file-manager/css/app.css">
+    <script type="text/javascript" src="//concord-consortium.github.io/cloud-file-manager/js/globals.js"></script>
+    <script type="text/javascript" src="//concord-consortium.github.io/cloud-file-manager/js/app.js"></script>
+    <link rel="stylesheet" href="//concord-consortium.github.io/cloud-file-manager/css/app.css">
 
   </head>
   <body>


### PR DESCRIPTION

Frieda encountered this tonight while trying to use Sage from   Lara(https) → Codap(https) → Sage(https).