### PR TITLE
If CODAP is standalone, send undo requests to CODAP

### DIFF
--- a/src/code/actions/codap-actions.coffee
+++ b/src/code/actions/codap-actions.coffee
@@ -2,5 +2,7 @@ module.exports = Reflux.createActions(
   [
     "codapLoaded"
     "hideUndoRedo"
+    "sendUndoToCODAP"
+    "sendRedoToCODAP"
   ]
 )


### PR DESCRIPTION
If we receive the new event `standaloneUndoModeAvailable`, we show
our own undo-redo buttons, but any button press (or ctr-z) gets sent
directly to CODAP to handle. CODAP will then try to execute an undo
or redo, which may in turn send the request back down to us.

When CODAP sends an undo or redo event back down to us, we will always
try to execute it.