### PR TITLE
Switch data versions to use SemVer

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,23 +22,24 @@
     "uuid": "^2.0.1"
   },
   "devDependencies": {
-    "sync-exec": "~0.6.x",
+    "beepbeep": "^1.2.0",
     "browserify": "^9.0.3",
     "chai": "^2.0.0",
-    "sinon": "^1.12.2",
+    "coffee-script": "^1.9.1",
     "coffeeify": "^1.0.0",
+    "event-stream": "^3.3.0",
     "gulp": "^3.8.11",
+    "gulp-coffeelint": "^0.4.0",
     "gulp-concat": "^2.5.2",
+    "gulp-if": "^1.2.5",
+    "gulp-replace": "^0.5.3",
     "gulp-stylus": "^2.0.1",
-    "vinyl-source-stream": "^1.1.0",
     "mocha": "^2.1.0",
     "require-dir": "^0.1.0",
-    "yargs": "^3.6.0",
-    "gulp-replace": "^0.5.3",
-    "gulp-if": "^1.2.5",
-    "coffee-script": "^1.9.1",
-    "gulp-coffeelint": "^0.4.0",
-    "beepbeep": "^1.2.0",
-    "event-stream": "^3.3.0"
+    "semver": "^5.1.0",
+    "sinon": "^1.12.2",
+    "sync-exec": "~0.6.x",
+    "vinyl-source-stream": "^1.1.0",
+    "yargs": "^3.6.0"
   }
 }

--- a/src/code/data/migrations/01_base.coffee
+++ b/src/code/data/migrations/01_base.coffee
@@ -2,7 +2,7 @@
 # FORMAT AFTER THIS TRANSFORM:  in serialized-test-data-1.0.coffee
 
 migration =
-  version: 1.0
+  version: "1.0.0"
   description: "The initial migrations from old mysystem style file format."
   date: "2015-08-12"
 

--- a/src/code/data/migrations/01_base.coffee
+++ b/src/code/data/migrations/01_base.coffee
@@ -10,7 +10,6 @@ migration =
     @updateNodes(data)
     @updateLinks(data)
     @updatePalette(data)
-    data
 
   updateNodes: (data) ->
     data.nodes = _.map (data.nodes or []), (node) ->

--- a/src/code/data/migrations/02_add_relations.coffee
+++ b/src/code/data/migrations/02_add_relations.coffee
@@ -8,7 +8,6 @@ migration =
   doUpdate: (data) ->
     @updateNodes(data)
     @updateLinks(data)
-    data
 
   # Add initialValue if it doesn't exist
   updateNodes: (data) ->

--- a/src/code/data/migrations/02_add_relations.coffee
+++ b/src/code/data/migrations/02_add_relations.coffee
@@ -1,7 +1,7 @@
 Relationship = require '../../models/relationship'
 
 migration =
-  version: 1.1
+  version: "1.1.0"
   description: "Adds initial values and relationships."
   date: "2015-08-13"
 

--- a/src/code/data/migrations/03_add_semi_quant_editing.coffee
+++ b/src/code/data/migrations/03_add_semi_quant_editing.coffee
@@ -1,5 +1,3 @@
-Relationship = require '../../models/relationship'
-
 migration =
   version: "1.2.0"
   description: "Adds initial value for defining node semiquantitatively."
@@ -7,7 +5,6 @@ migration =
 
   doUpdate: (data) ->
     @updateNodes(data)
-    data
 
   # Add initialValue if it doesn't exist
   updateNodes: (data) ->

--- a/src/code/data/migrations/03_add_semi_quant_editing.coffee
+++ b/src/code/data/migrations/03_add_semi_quant_editing.coffee
@@ -1,7 +1,7 @@
 Relationship = require '../../models/relationship'
 
 migration =
-  version: 1.2
+  version: "1.2.0"
   description: "Adds initial value for defining node semiquantitatively."
   date: "2015-09-02"
 

--- a/src/code/data/migrations/04_add_min_max.coffee
+++ b/src/code/data/migrations/04_add_min_max.coffee
@@ -1,7 +1,7 @@
 Relationship = require '../../models/relationship'
 
 migration =
-  version: 1.3
+  version: "1.3.0"
   description: "Adds min and max values for nodes."
   date: "2015-09-03"
 

--- a/src/code/data/migrations/04_add_min_max.coffee
+++ b/src/code/data/migrations/04_add_min_max.coffee
@@ -1,5 +1,3 @@
-Relationship = require '../../models/relationship'
-
 migration =
   version: "1.3.0"
   description: "Adds min and max values for nodes."
@@ -7,7 +5,6 @@ migration =
 
   doUpdate: (data) ->
     @updateNodes(data)
-    data
 
   # Add initialValue if it doesn't exist
   updateNodes: (data) ->

--- a/src/code/data/migrations/05_add_settings_and_cap.coffee
+++ b/src/code/data/migrations/05_add_settings_and_cap.coffee
@@ -1,7 +1,7 @@
 Relationship = require '../../models/relationship'
 
 migration =
-  version: 1.4
+  version: "1.4.0"
   description: "Adds settings object and cap default."
   date: "2015-09-17"
 

--- a/src/code/data/migrations/05_add_settings_and_cap.coffee
+++ b/src/code/data/migrations/05_add_settings_and_cap.coffee
@@ -1,5 +1,3 @@
-Relationship = require '../../models/relationship'
-
 migration =
   version: "1.4.0"
   description: "Adds settings object and cap default."
@@ -8,6 +6,5 @@ migration =
   doUpdate: (data) ->
     data.settings ?= {}
     data.settings.capNodeValues ?= false
-    data
 
 module.exports = _.mixin migration, require './migration-mixin'

--- a/src/code/data/migrations/06_add_palette_references.coffee
+++ b/src/code/data/migrations/06_add_palette_references.coffee
@@ -10,7 +10,6 @@ migration =
   doUpdate: (data) ->
     @updatePalette(data)
     @updateNodes(data)
-    data
 
   updatePalette: (data) ->
     _.each data.palette, (paletteItem) ->

--- a/src/code/data/migrations/06_add_palette_references.coffee
+++ b/src/code/data/migrations/06_add_palette_references.coffee
@@ -3,7 +3,7 @@ uuid = require 'uuid'
 imageToUUIDMap= {}
 
 migration =
-  version: 1.5
+  version: "1.5.0"
   description: "Nodes reference PaletteItems"
   date: "2015-09-16"
 

--- a/src/code/data/migrations/07_add_diagram_only_setting.coffee
+++ b/src/code/data/migrations/07_add_diagram_only_setting.coffee
@@ -1,7 +1,7 @@
 Relationship = require '../../models/relationship'
 
 migration =
-  version: 1.6
+  version: "1.6.0"
   description: "Adds diagramOnly setting. Default == false"
   date: "2015-09-22"
 

--- a/src/code/data/migrations/07_add_diagram_only_setting.coffee
+++ b/src/code/data/migrations/07_add_diagram_only_setting.coffee
@@ -1,5 +1,3 @@
-Relationship = require '../../models/relationship'
-
 migration =
   version: "1.6.0"
   description: "Adds diagramOnly setting. Default == false"
@@ -8,6 +6,5 @@ migration =
   doUpdate: (data) ->
     data.settings ?= {}
     data.settings.diagramOnly ?= false
-    data
 
 module.exports = _.mixin migration, require './migration-mixin'

--- a/src/code/data/migrations/08_add_simulation_settings.coffee
+++ b/src/code/data/migrations/08_add_simulation_settings.coffee
@@ -1,4 +1,3 @@
-Relationship = require '../../models/relationship'
 TimeUnits = require '../../utils/time-units'
 
 migration =

--- a/src/code/data/migrations/08_add_simulation_settings.coffee
+++ b/src/code/data/migrations/08_add_simulation_settings.coffee
@@ -2,7 +2,7 @@ Relationship = require '../../models/relationship'
 TimeUnits = require '../../utils/time-units'
 
 migration =
-  version: 1.7
+  version: "1.7.0"
   description: "Adds Simulation settings"
   date: "2015-10-02"
 

--- a/src/code/data/migrations/09_update_duration_settings.coffee
+++ b/src/code/data/migrations/09_update_duration_settings.coffee
@@ -2,7 +2,7 @@ Relationship = require '../../models/relationship'
 TimeUnits = require '../../utils/time-units'
 
 migration =
-  version: 1.8
+  version: "1.8.0"
   description: "Updates duration settings"
   date: "2015-10-14"
 

--- a/src/code/data/migrations/09_update_duration_settings.coffee
+++ b/src/code/data/migrations/09_update_duration_settings.coffee
@@ -1,6 +1,3 @@
-Relationship = require '../../models/relationship'
-TimeUnits = require '../../utils/time-units'
-
 migration =
   version: "1.8.0"
   description: "Updates duration settings"

--- a/src/code/data/migrations/10_add_speed_and_cap.coffee
+++ b/src/code/data/migrations/10_add_speed_and_cap.coffee
@@ -1,6 +1,3 @@
-Relationship = require '../../models/relationship'
-TimeUnits = require '../../utils/time-units'
-
 migration =
   version: "1.9.0"
   description: "Adds simulation speed and capNodeValues settings"

--- a/src/code/data/migrations/10_add_speed_and_cap.coffee
+++ b/src/code/data/migrations/10_add_speed_and_cap.coffee
@@ -2,7 +2,7 @@ Relationship = require '../../models/relationship'
 TimeUnits = require '../../utils/time-units'
 
 migration =
-  version: 1.9
+  version: "1.9.0"
   description: "Adds simulation speed and capNodeValues settings"
   date: "2015-10-14"
 

--- a/src/code/data/migrations/11_simulation_engine_settings.coffee
+++ b/src/code/data/migrations/11_simulation_engine_settings.coffee
@@ -2,7 +2,7 @@ Relationship = require '../../models/relationship'
 TimeUnits = require '../../utils/time-units'
 
 migration =
-  version: 1.95
+  version: "1.10.0"
   description: "Adds simulation engine settings"
   date: "2016-01-16"
 

--- a/src/code/data/migrations/11_simulation_engine_settings.coffee
+++ b/src/code/data/migrations/11_simulation_engine_settings.coffee
@@ -1,6 +1,3 @@
-Relationship = require '../../models/relationship'
-TimeUnits = require '../../utils/time-units'
-
 migration =
   version: "1.10.0"
   description: "Adds simulation engine settings"

--- a/src/code/data/migrations/migration-mixin.coffee
+++ b/src/code/data/migrations/migration-mixin.coffee
@@ -1,10 +1,15 @@
 # Implement version: xx and doUpdate: (data) ->  in your migrations.
 # and mixin this module
 
+semver = require "semver"
+
 module.exports =
-  # TODO: possibly use semver https://github.com/npm/node-semver
   needsUpdate: (data) ->
-    (data.version or 0) < @version
+    version = data.version || "0.0.0"
+
+    if typeof version is "number" then version = @_semverize(version)
+
+    semver.gt(@version, version)
 
   name: ->
     "#{@version} – #{@date} : #{@description}"
@@ -17,3 +22,12 @@ module.exports =
     else
       log.info "  skipped : #{@name()}"
     data
+
+  # Change x.y to "x.y.0". The only annoyance is we have to special-case 1.95,
+  # as this was supposed to be < 1.10.0
+  _semverize: (v) ->
+    if (v is 1.95)
+      return "1.9.5"
+    else
+      return v + ".0"
+

--- a/src/code/data/migrations/migrations.coffee
+++ b/src/code/data/migrations/migrations.coffee
@@ -26,4 +26,4 @@ module.exports =
     @lastMigration().version
 
   lastMigration: ->
-    _.max migrations, (m) -> m.version
+    migrations[migrations.length-1]

--- a/test/loading-serialization-test.coffee
+++ b/test/loading-serialization-test.coffee
@@ -83,7 +83,7 @@ describe "Serialization and Loading", ->
         model.nodes.should.exist
         model.links.should.exist
 
-        model.version.should.equal 1.95
+        model.version.should.equal "1.10.0"
         model.nodes.length.should.equal 2
         model.links.length.should.equal 1
 

--- a/test/migrations-test.coffee
+++ b/test/migrations-test.coffee
@@ -7,8 +7,8 @@ describe "Migrations",  ->
       @result = Migrations.update(originalData)
 
     describe "the final version number", ->
-      it "should be 1.95", ->
-        @result.version.should.equal 1.95
+      it "should be 1.10.0", ->
+        @result.version.should.equal "1.10.0"
 
     describe "the nodes", ->
       it "should have two nodes", ->
@@ -72,7 +72,7 @@ describe "Migrations",  ->
           it "should have speed setting", ->
             @result.settings.simulation.speed.should.equal 4
 
-        describe "v-1.95 changes", ->
+        describe "v-1.10 changes", ->
           it "should have newIntegration setting", ->
             @result.settings.simulation.newIntegration.should.equal false
 

--- a/test/migrations-test.coffee
+++ b/test/migrations-test.coffee
@@ -14,67 +14,10 @@ describe "Migrations",  ->
       it "should have two nodes", ->
         @result.nodes.length.should.equal 2
 
-      describe "the node structure", ->
-        it "should have key: and data: attributes", ->
-          for node in @result.nodes
-            node.key.should.exist
-            node.data.should.exist
-
-        describe "v-1.1 node changes", ->
-          it "should have initial node values", ->
-            for node in @result.nodes
-              node.data.initialValue.should.exist
-              node.data.isAccumulator.should.exist
-              node.data.isAccumulator.should.equal false
-
-        describe "v-1.2 node changes", ->
-          it "should have initial node values", ->
-            for node in @result.nodes
-              node.data.valueDefinedSemiQuantitatively.should.exist
-              node.data.valueDefinedSemiQuantitatively.should.equal true
-
-        describe "v-1.3 node changes", ->
-          it "should have initial node values", ->
-            for node in @result.nodes
-              node.data.min.should.equal 0
-              node.data.max.should.equal 100
-
-        describe "v-1.4 changes", ->
-          it "should have settings and cap value", ->
-            # Removed or changed in 1.9:
-            # @result.settings.capNodeValues.should.equal false
-
-        describe "v-1.5 changes", ->
-          it "should have settings and cap value", ->
-            for node in @result.nodes
-              node.data.image.should.not.be.null
-              node.data.paletteItem.should.not.be.null
-
-        describe "v-1.6 changes", ->
-          it "should have diagramOnly setting", ->
-            @result.settings.diagramOnly.should.equal false
-
-        describe "v-1.7 changes", ->
-          it "should have settings for the simulation", ->
-            @result.settings.simulation.should.exist
-            # Removed or changed in 1.8:
-            # @result.settings.simulation.period.should.equal 10
-            # @result.settings.simulation.stepSize.should.equal 1
-            # @result.settings.simulation.periodUnits.should.equal "YEAR"
-            # @result.settings.simulation.stepUnits.should.equal "YEAR"
-
-        describe "v-1.8 changes", ->
-          it "should have settings for the simulation", ->
-            @result.settings.simulation.duration.should.equal 10
-            @result.settings.simulation.stepUnits.should.equal "STEP"
-
-        describe "v-1.9 changes", ->
-          it "should have speed setting", ->
-            @result.settings.simulation.speed.should.equal 4
-
-        describe "v-1.10 changes", ->
-          it "should have newIntegration setting", ->
-            @result.settings.simulation.newIntegration.should.equal false
+      it "should have key: and data: attributes", ->
+        for node in @result.nodes
+          node.key.should.exist
+          node.data.should.exist
 
     describe "the palette", ->
       it "should exist", ->
@@ -84,18 +27,73 @@ describe "Migrations",  ->
           pitem.key is "img/nodes/blank.png"
         blank.should.exist
 
-      describe "v-1.5 changes", ->
-        it "paletteItems should have a uuid", ->
-          for paletteItem in @result.palette
-            paletteItem.uuid.should.not.be.null
-
     describe "the links", ->
       it "should have one link", ->
         @result.links.length.should.equal 1
 
-      describe "v-1.1 link changes", ->
-        it "should have valid relationship values", ->
-          for link in @result.links
-            link.relation.should.exist
-            link.relation.text.should.exist
-            link.relation.formula.should.exist
+    describe "v-1.1 changes", ->
+      it "should have initial node values", ->
+        for node in @result.nodes
+          node.data.initialValue.should.exist
+          node.data.isAccumulator.should.exist
+          node.data.isAccumulator.should.equal false
+
+      it "should have valid relationship values", ->
+        for link in @result.links
+          link.relation.should.exist
+          link.relation.text.should.exist
+          link.relation.formula.should.exist
+
+    describe "v-1.2 node changes", ->
+      it "should have initial node values", ->
+        for node in @result.nodes
+          node.data.valueDefinedSemiQuantitatively.should.exist
+          node.data.valueDefinedSemiQuantitatively.should.equal true
+
+    describe "v-1.3 node changes", ->
+      it "should have initial node values", ->
+        for node in @result.nodes
+          node.data.min.should.equal 0
+          node.data.max.should.equal 100
+
+    describe "v-1.4 changes", ->
+      it "should have settings and cap value", ->
+        # Removed or changed in 1.9:
+        # @result.settings.capNodeValues.should.equal false
+
+    describe "v-1.5 changes", ->
+      it "should have images and paletteItems for nodes", ->
+        for node in @result.nodes
+          node.data.image.should.not.be.null
+          node.data.paletteItem.should.not.be.null
+
+      it "paletteItems should have a uuid", ->
+        for paletteItem in @result.palette
+          paletteItem.uuid.should.not.be.null
+
+    describe "v-1.6 changes", ->
+      it "should have diagramOnly setting", ->
+        @result.settings.diagramOnly.should.equal false
+
+    describe "v-1.7 changes", ->
+      it "should have settings for the simulation", ->
+        @result.settings.simulation.should.exist
+        # Removed or changed in 1.8:
+        # @result.settings.simulation.period.should.equal 10
+        # @result.settings.simulation.stepSize.should.equal 1
+        # @result.settings.simulation.periodUnits.should.equal "YEAR"
+        # @result.settings.simulation.stepUnits.should.equal "YEAR"
+
+    describe "v-1.8 changes", ->
+      it "should have settings for the simulation", ->
+        @result.settings.simulation.duration.should.equal 10
+        @result.settings.simulation.stepUnits.should.equal "STEP"
+
+    describe "v-1.9 changes", ->
+      it "should have speed setting", ->
+        @result.settings.simulation.speed.should.equal 4
+
+    describe "v-1.10 changes", ->
+      it "should have newIntegration setting", ->
+        @result.settings.simulation.newIntegration.should.equal false
+


### PR DESCRIPTION
@knowuh This updates all our old migration numbers to SemVer.

I can't see a problem with updating our old migration numbers. We convert the versions in the saved doc to their equivalent semvers before deciding to update, so we shouldn't run any migrations twice. However, I may be missing something.