### PR TITLE
Add minigraphs to nodes

### DIFF
--- a/src/code/data/migrations/12_add_minigraphs_visibility.coffee
+++ b/src/code/data/migrations/12_add_minigraphs_visibility.coffee
@@ -1,0 +1,11 @@
+migration =
+  version: "1.11.0"
+  description: "Adds minigraphs settings"
+  date: "2016-03-15"
+
+  doUpdate: (data) ->
+    data.settings ?= {}
+    data.settings.showMinigraphs ?= false
+
+
+module.exports = _.mixin migration, require './migration-mixin'

--- a/src/code/data/migrations/migrations.coffee
+++ b/src/code/data/migrations/migrations.coffee
@@ -12,6 +12,7 @@ migrations = [
   require "./09_update_duration_settings"
   require "./10_add_speed_and_cap"
   require "./11_simulation_engine_settings"
+  require "./12_add_minigraphs_visibility"
 ]
 
 module.exports =

--- a/src/code/mixins/app-view.coffee
+++ b/src/code/mixins/app-view.coffee
@@ -70,6 +70,8 @@ module.exports =
       editingNode: editingNode
       selectedLink: selectedLink
 
+    @selectionUpdated()
+
   _loadInitialData: ->
     if @props.data?.length > 0
       @props.graphStore.addAfterAuthHandler JSON.parse @props.data

--- a/src/code/models/node.coffee
+++ b/src/code/models/node.coffee
@@ -15,7 +15,8 @@ module.exports = class Node extends GraphPrimitive
   @fields: [
     'title', 'image', 'color', 'paletteItem',
     'initialValue', 'min', 'max',
-    'isAccumulator', 'valueDefinedSemiQuantitatively']
+    'isAccumulator', 'valueDefinedSemiQuantitatively'
+    'frames']
 
   constructor: (nodeSpec={}, key) ->
     super()
@@ -41,6 +42,9 @@ module.exports = class Node extends GraphPrimitive
     @_initialValue = nodeSpec.initialValue ? 50
 
     @color ?= Colors[0].value
+
+    # Values of the previous run. Used for the minigraphs. Not serialized
+    @frames = []
 
   # Scale the value of initialValue such that, if we are in semi-quantitative mode,
   # we always return a value between 0 and 100. Likewise, if we try to set a value while

--- a/src/code/stores/app-settings-store.coffee
+++ b/src/code/stores/app-settings-store.coffee
@@ -4,6 +4,7 @@ ImportActions   = require '../actions/import-actions'
 AppSettingsActions = Reflux.createActions(
   [
     "diagramOnly"
+    "showMinigraphs"
   ]
 )
 
@@ -14,6 +15,7 @@ AppSettingsStore   = Reflux.createStore
     @settings =
       showingSettingsDialog: false
       diagramOnly: HashParams.getParam('simplified')
+      showingMinigraphs: false
 
   onDiagramOnly: (diagramOnly) ->
     @settings.diagramOnly = diagramOnly
@@ -32,6 +34,7 @@ AppSettingsStore   = Reflux.createStore
 
   serialize: ->
     diagramOnly: @settings.diagramOnly
+    showingMinigraphs: @settings.showingMinigraphs
 
 mixin =
   getInitialState: ->

--- a/src/code/stores/app-settings-store.coffee
+++ b/src/code/stores/app-settings-store.coffee
@@ -21,6 +21,10 @@ AppSettingsStore   = Reflux.createStore
     @settings.diagramOnly = diagramOnly
     @notifyChange()
 
+  onShowMinigraphs: (show) ->
+    @settings.showingMinigraphs = show
+    @notifyChange()
+
   notifyChange: ->
     @trigger _.clone @settings
     if @settings.diagramOnly

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -24,7 +24,25 @@ GraphStore  = Reflux.createStore
     @selectionManager   = new SelectionManager()
     PaletteDeleteStore.store.listen @paletteDelete.bind(@)
 
+    SimulationStore.actions.resetSimulation.listen         @resetSimulation.bind(@)
+    SimulationStore.actions.setDuration.listen             @resetSimulation.bind(@)
+    SimulationStore.actions.simulationFramesCreated.listen @updateSimulationData.bind(@)
+
     @codapStandaloneMode = false
+
+  resetSimulation: ->
+    for node in @getNodes()
+      node.frames = []
+    @updateListeners()
+
+  updateSimulationData: (data) ->
+    nodes = @getNodes()
+    for frame in data
+      for node, i in frame.nodes
+        nodes[i].frames.push node.value
+    if AppSettingsStore.store.settings.showingMinigraphs
+      @updateListeners()
+
 
   paletteDelete: (status) ->
     {deleted,paletteItem,replacement} = status

--- a/src/code/views/app-view.coffee
+++ b/src/code/views/app-view.coffee
@@ -37,9 +37,11 @@ module.exports = React.createClass
       username: 'Jane Doe'
       filename: tr "~MENU.UNTITLED_MODEL"
 
+  selectionUpdated: ->
+    this.refs.inspectorPanel?.nodeSelectionChanged()
+
   toggleImageBrowser: ->
     @setState showImageBrowser: not @state.showImageBrowser
-
 
   render: ->
     (div {className: 'app'},
@@ -78,6 +80,7 @@ module.exports = React.createClass
           diagramOnly: @state.diagramOnly
           toggleImageBrowser: @toggleImageBrowser
           graphStore: @props.graphStore
+          ref: "inspectorPanel"
         )
         if @state.showingDialog
           (ImageBrowser

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -221,6 +221,7 @@ module.exports = React.createClass
             onDelete: @onNodeDeleted
             graphStore: @props.graphStore
             selectionManager: @props.selectionManager
+            showMinigraph: @state.showingMinigraphs
           })
       )
     )

--- a/src/code/views/inspector-panel-view.coffee
+++ b/src/code/views/inspector-panel-view.coffee
@@ -108,8 +108,9 @@ module.exports = React.createClass
       (LinkRelationInspectorView {link:@props.link, graphStore: @props.graphStore})
 
   # 2015-12-09 NP: Deselection makes inpector panel hide http://bit.ly/1ORBBp2
-  componentWillReceiveProps: (nextProps) ->
-    unless (nextProps.node or nextProps.link)
+  # 2016-03-15 SF: Changed this to a function explicitly called when selection changes
+  nodeSelectionChanged: ->
+    unless (@props.node or @props.link)
       @setState
         nowShowing: null
 

--- a/src/code/views/node-svg-graph-view.coffee
+++ b/src/code/views/node-svg-graph-view.coffee
@@ -1,0 +1,60 @@
+{svg, path, line, text, div, tspan} = React.DOM
+
+SimulationStore = require '../stores/simulation-store'
+
+module.exports = NodeSvgGraphView = React.createClass
+  displayName: 'NodeSvgGraphView'
+  mixins: [ SimulationStore.mixin ]
+
+  getDefaultProps: ->
+    width: 46
+    height: 46
+    strokeWidth: 3
+    min: 0
+    max: 100
+    data: []
+
+  invertPoint: (point) ->
+    {x: point.x, y: @props.height - point.y}
+
+  graphMapPoint: (point) ->
+    x = point.x * (@props.width + 1)
+    y = point.y * (@props.height + 1)
+    @invertPoint x:x, y:y
+
+  pointsToPath: (points)->
+    return "" unless points.length
+    data = _.map points, (p) => @graphMapPoint(p)
+    data = _.map data,   (p) -> "#{p.x} #{p.y}"
+    data = data.join " L "
+    "M #{data}"
+
+  getPathPoints: ->
+    max = @props.max
+    min = @props.min
+
+    data = @props.data
+
+    for point in data
+      if point > max then max = point
+      if point < min then min = point
+
+    rangex = @state.duration - 1
+    rangey = max - min
+
+    data = _.map data, (d, i) ->
+      x = i / rangex
+      y = d / rangey
+      {x: x, y: y}
+    data
+
+  renderLineData: ->
+    data = @pointsToPath(@getPathPoints())
+    (path {d: data, strokeWidth: @props.strokeWidth, stroke: "#a1d083", fill: "none"})
+
+  render: ->
+    (div {},
+      (svg {width: @props.width, height: @props.height},
+        @renderLineData()
+      )
+    )

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -3,6 +3,7 @@ tr = require "../utils/translate"
 
 SquareImage = React.createFactory require "./square-image-view"
 SliderView  = React.createFactory require "./value-slider-view"
+GraphView   = React.createFactory require "./node-svg-graph-view"
 CodapConnect = require '../models/codap-connect'
 DEFAULT_CONTEXT_NAME = 'building-models'
 
@@ -190,6 +191,19 @@ module.exports = NodeView = React.createClass
       classes.push "link-target"
     classes.join " "
 
+  renderNodeInternal: ->
+    if @props.showMinigraph
+      (GraphView {
+        min: @props.data.min
+        max: @props.data.max
+        data: @props.data.frames
+      })
+    else
+      (SquareImage {
+        image: @props.data.image,
+        ref: "thumbnail"
+      })
+
 
   render: ->
     style =
@@ -215,7 +229,7 @@ module.exports = NodeView = React.createClass
             onClick: (=> @handleSelected true)
             onTouchend: (=> @handleSelected true)
             },
-            (SquareImage {image: @props.data.image, ref: "thumbnail"})
+            @renderNodeInternal()
           )
           (NodeTitle {
             isEditing: @props.editTitle

--- a/src/code/views/simulation-inspector-view.coffee
+++ b/src/code/views/simulation-inspector-view.coffee
@@ -23,6 +23,9 @@ module.exports = React.createClass
   setDiagramOnly: (e) ->
     AppSettingsStore.actions.diagramOnly e.target.checked
 
+  setShowingMinigraphs: (e) ->
+    AppSettingsStore.actions.showMinigraphs e.target.checked
+
   render: ->
     runPanelClasses = "run-panel"
     if not @state.diagramOnly then runPanelClasses += " expanded"
@@ -66,7 +69,7 @@ module.exports = React.createClass
           )
         )
         (div {className: "row"},
-          (input {type: 'checkbox', value: 'show-mini', checked: @props.showMiniGraphs})
+          (input {type: 'checkbox', value: 'show-mini', checked: @state.showingMinigraphs, onChange: @setShowingMinigraphs})
           (label {}, tr '~DOCUMENT.ACTIONS.SHOW_MINI_GRAPHS')
         )
         (div {className: "row"},

--- a/test/loading-serialization-test.coffee
+++ b/test/loading-serialization-test.coffee
@@ -83,7 +83,7 @@ describe "Serialization and Loading", ->
         model.nodes.should.exist
         model.links.should.exist
 
-        model.version.should.equal "1.10.0"
+        model.version.should.equal "1.11.0"
         model.nodes.length.should.equal 2
         model.links.length.should.equal 1
 

--- a/test/loading-serialization-test.coffee
+++ b/test/loading-serialization-test.coffee
@@ -129,9 +129,11 @@ describe "Serialization and Loading", ->
 
       it "should be able to serialize the settings", ->
         AppSettingsStore.store.settings.diagramOnly = true
+        AppSettingsStore.store.settings.showingMinigraphs = true
         jsonString = @graphStore.toJsonString(@fakePalette)
         model = JSON.parse jsonString
         model.settings.diagramOnly.should.equal true
+        model.settings.showingMinigraphs.should.equal true
 
       it "should be able to serialize the simulation settings", ->
         SimulationStore.store.settings.duration = 15
@@ -160,9 +162,10 @@ describe "Serialization and Loading", ->
 
     it "should read the settings without error", ->
       data = JSON.parse(@serializedForm)
-      data.settings = {diagramOnly: true}
+      data.settings = {diagramOnly: true, showMinigraphs: true}
       @graphStore.loadData(data)
       AppSettingsStore.store.settings.diagramOnly.should.equal true
+      AppSettingsStore.store.settings.showMinigraphs.should.equal true
 
     it "nodes should have paletteItem properties after loading", ->
       data = JSON.parse(@serializedForm)

--- a/test/migrations-test.coffee
+++ b/test/migrations-test.coffee
@@ -7,8 +7,8 @@ describe "Migrations",  ->
       @result = Migrations.update(originalData)
 
     describe "the final version number", ->
-      it "should be 1.10.0", ->
-        @result.version.should.equal "1.10.0"
+      it "should be 1.11.0", ->
+        @result.version.should.equal "1.11.0"
 
     describe "the nodes", ->
       it "should have two nodes", ->
@@ -96,4 +96,8 @@ describe "Migrations",  ->
     describe "v-1.10 changes", ->
       it "should have newIntegration setting", ->
         @result.settings.simulation.newIntegration.should.equal false
+
+    describe "v-1.11.0 changes", ->
+      it "should have minigraphs setting", ->
+        @result.settings.showMinigraphs.should.equal false
 


### PR DESCRIPTION
With this change, the `GraphStore` listens to the simulation events, and pushes frame data into
each `Node` object when we have new simulation data.

With this data, we can swap out the internal node image for a new `node-svg-graph-view` when the minigraph checkbox is checked.

The minigraph state is loaded and serialized, but the frame data is not.

Note that we see some similar speed issues as CODAP when we manipulate the slider while the
model is running. Now that this effect is local, we can more easily profile what's going on.

@knowuh or @dougmartin can you take a look sometime when you have a moment?