### PR TITLE
Add undefined relationships

### DIFF
--- a/src/code/models/relationship.coffee
+++ b/src/code/models/relationship.coffee
@@ -3,9 +3,6 @@ tr   = require "../utils/translate"
 
 module.exports = class Relationship
 
-  @defaultText:       tr "~NODE-RELATION-EDIT.INCREASES"
-  @defaultFormula:    "1 * in"
-  @defaultGraphThumb: "TBD"
   @errValue:          -1
   @defaultFunc: (scope) ->
     scope.in
@@ -17,11 +14,11 @@ module.exports = class Relationship
     log.error "vars=#{vars}"
 
   constructor: (@opts={}) ->
-    @text        = @opts.text       or Relationship.defaultText
-    formula      = @opts.formula    or Relationship.defaultFormula
-    @graphThumb  = @opts.graphThumb or Relationship.defaultGraphThumb
+    @text        = @opts.text
+    formula      = @opts.formula
+    @func        = @opts.func
     @errHandler  = @opts.errHandler or Relationship.defaultErrHandler
-    @func        = @opts.func       or if formula is Relationship.defaultFormula then Relationship.defaultFunc else null
+    @isDefined   = @opts.formula? or @opts.func?
     @hasError    = false
     @setFormula(formula)
 
@@ -30,7 +27,9 @@ module.exports = class Relationship
     @checkFormula()
 
   checkFormula: ->
-    @evaluate(1, 1) #sets the @hasError flag if there is a problem
+    @isDefined   = @opts.formula? or @opts.func?
+    if @isDefined
+      @evaluate(1, 1) #sets the @hasError flag if there is a problem
 
   evaluate: (inV,outV, maxIn=100, maxOut=100)->
     result = Relationship.errValue

--- a/src/code/models/simulation.coffee
+++ b/src/code/models/simulation.coffee
@@ -27,6 +27,7 @@ IntegrationFunction = (incrementAccumulators) ->
   if @isAccumulator
     value = if @previousValue? then @previousValue else @initialValue            # start from our last value
     _.each links, (link) =>
+      return unless link.relation.isDefined
       sourceNode = link.sourceNode
       inV = sourceNode.previousValue
       return unless inV               # we simply ignore nodes with no previous value
@@ -41,13 +42,19 @@ IntegrationFunction = (incrementAccumulators) ->
       value += nextValue
   else
     _.each links, (link) =>
+      if not link.relation.isDefined
+        count--
+        return
       sourceNode = link.sourceNode
       inV = if sourceNode.previousValue? then sourceNode.previousValue else sourceNode.initialValue
       inV = scaleInput(inV, sourceNode, this)
       outV = @previousValue or @initialValue
       nextValue = link.relation.evaluate(inV, outV, link.sourceNode.max, @max)
       value += nextValue
-    value = value / count
+    if count >= 1
+      value = value / count
+    else
+      value = @previousValue or @initialValue       # we had no defined inbound links
 
   # if we need to cap, do it at end of all calculations
   if @capNodeValues

--- a/src/code/utils/lang/us-en.coffee
+++ b/src/code/utils/lang/us-en.coffee
@@ -124,7 +124,7 @@ module.exports =
   "~DOCUMENT.ACTIONS.QUICK_TEST": "Quick-test mode"
   "~DOCUMENT.ACTIONS.UNDO": "Undo"
   "~DOCUMENT.ACTIONS.REDO": "Redo"
-  "~DOCUMENT.ACTIONS.DURATION_INVALID": "You must run for at least one calculation."
+  "~DOCUMENT.ACTIONS.NO_DEFINED_LINKS": "There must be at least one link with a defined relationship."
 
   "~SIMULATION.SIMULATION_SETTINGS": "Simulation Settings"
   "~SIMULATION.DIAGRAM_SETTINGS": "Diagram settings"

--- a/src/code/utils/lang/us-en.coffee
+++ b/src/code/utils/lang/us-en.coffee
@@ -38,7 +38,7 @@ module.exports =
 
   # views/relation-inspector-view.coffee
   "~NODE-RELATION-EDIT.DEFINING_WITH_WORDS": "You are defining relationships with graphs. Switch to define with equations."
-
+  "~NODE-RELATION-EDIT.UNSELECTED": "Select an option..."
   "~NODE-RELATION-EDIT.AN_INCREASE_IN": "An increase in"
   "~NODE-RELATION-EDIT.CAUSES": "causes"
   "~NODE-RELATION-EDIT.TO": "to"

--- a/src/code/views/link-relation-view.coffee
+++ b/src/code/views/link-relation-view.coffee
@@ -55,21 +55,30 @@ module.exports = LinkRelationView = React.createClass
     id = parseInt @refs.scalar.value
     RelationFactory.scalars[id]
 
-  renderVector: (increaseOrDecrease)->
+  renderVectorPulldown: (increaseOrDecrease)->
     options = _.map RelationFactory.vectors, (opt, i) ->
       (option {value: opt.id, key: i}, opt.text)
+
+    if not increaseOrDecrease?
+      options.unshift (option {key: "placeholder", value: "unselected", disabled: "disabled"},
+        tr "~NODE-RELATION-EDIT.UNSELECTED")
+      currentOption = "unselected"
+    else
+      currentOption = increaseOrDecrease.id
+
     (div {className: "bb-select"},
       (span {}, "#{tr "~NODE-RELATION-EDIT.TO"} ")
-      (select {value: increaseOrDecrease.id, className:"", ref: "vector", onChange: @updateRelation},
+      (select {value: currentOption, className:"", ref: "vector", onChange: @updateRelation},
       options)
     )
 
-  renderScalar:(amount) ->
+  renderScalarPulldown:(amount) ->
     options = _.map RelationFactory.scalars, (opt, i) ->
       (option {value: opt.id, key: i}, opt.text)
+    currentOption = amount?.id ? 0
     (div {className: "bb-select"},
       (span {}, "#{tr "~NODE-RELATION-EDIT.BY"} ")
-      (select {value: amount.id, className:"", ref: "scalar", onChange: @updateRelation},
+      (select {value: currentOption, className:"", ref: "scalar", onChange: @updateRelation, disabled: if amount then false else "disabled"},
         options
       )
     )
@@ -83,10 +92,10 @@ module.exports = LinkRelationView = React.createClass
       (div {className: 'top'},
         (QuantStart {source: source, target: target})
         (div {className: 'full'},
-          @renderVector(vector)
+          @renderVectorPulldown(vector)
         )
         (div {className: 'full'},
-          @renderScalar(scalar)
+          @renderScalarPulldown(scalar)
         )
       )
       (div {className: 'bottom'},

--- a/src/code/views/relation-inspector-view.coffee
+++ b/src/code/views/relation-inspector-view.coffee
@@ -15,7 +15,9 @@ module.exports = RelationInspectorView = React.createClass
 
   renderTabforLink: (link) ->
     relationView = (LinkRelationView {link: link, graphStore: @props.graphStore})
-    (Tabber.Tab {label: (link.sourceNode.title), component: relationView})
+    label = if link.relation.isDefined then "☑ " else "☐ "
+    label += link.sourceNode.title
+    (Tabber.Tab {label: label, component: relationView})
 
   renderNodeRelationInspector: ->
     tabs = _.map @props.node.inLinks(), (link) => @renderTabforLink(link)

--- a/src/code/views/simulation-run-panel-view.coffee
+++ b/src/code/views/simulation-run-panel-view.coffee
@@ -26,6 +26,7 @@ module.exports = React.createClass
     if @state.simulationPanelExpanded then wrapperClasses += " expanded"
 
     runButtonClasses = "button"
+    if not @state.modelIsRunnable then runButtonClasses += " disabled error"
     if not @state.modelReadyToRun then runButtonClasses += " disabled"
 
     resetButtonClasses = "button"

--- a/src/code/views/svg-graph-view.coffee
+++ b/src/code/views/svg-graph-view.coffee
@@ -3,7 +3,6 @@ math = require 'mathjs'  # For formula parsing...
 module.exports = SvgGraphView = React.createClass
   displayName: 'SvgGraphView'
   getDefaultProps: ->
-    formula: "in ^ 2 * -2 + 5"
     width: 200
     height: 200
     strokeWidth: 3
@@ -84,10 +83,14 @@ module.exports = SvgGraphView = React.createClass
     (div {className: 'svgGraphView'},
       (svg {width: @props.width, height: @props.height},
         @renderAxisLines()
-        @renderLineData()
+        if @props.formula then @renderLineData()
         @renderXLabel()
         @renderYLabel()
       )
+      if not @props.formula
+        (div {className: 'unknown-graph'},
+          "?"
+        )
     )
 
 # TO DEBUG THIS VIEW:

--- a/src/stylus/components/simulation-run-panel.styl
+++ b/src/stylus/components/simulation-run-panel.styl
@@ -45,5 +45,7 @@
       cursor default
       i
         cursor default
+    &.error
+      background-color light-red
     &:hover:not(.disabled)
       background-color dark-gray

--- a/src/stylus/components/svg-graph-view.styl
+++ b/src/stylus/components/svg-graph-view.styl
@@ -1,4 +1,5 @@
 .SvgGraphView
+  position absolute
   svg
     path
       stroke-linecap round
@@ -22,3 +23,9 @@
       &.xLabel
         fill green-blue
         font-size 16
+
+  .unknown-graph
+    position absolute
+    font-size 2em
+    top 43px
+    left 68px

--- a/test/migrations-test.coffee
+++ b/test/migrations-test.coffee
@@ -1,6 +1,9 @@
 Migrations     = require "../src/code/data/migrations/migrations"
 originalData   = require "./serialized-test-data/v-0.1"
 
+chai   = require('chai')
+expect = chai.expect
+
 describe "Migrations",  ->
   describe "update", ->
     beforeEach ->
@@ -41,8 +44,8 @@ describe "Migrations",  ->
       it "should have valid relationship values", ->
         for link in @result.links
           link.relation.should.exist
-          link.relation.text.should.exist
-          link.relation.formula.should.exist
+          expect(link.relation.text).to.be.undefined
+          expect(link.relation.formula).to.be.undefined
 
     describe "v-1.2 node changes", ->
       it "should have initial node values", ->

--- a/test/relationship-test.coffee
+++ b/test/relationship-test.coffee
@@ -20,10 +20,11 @@ describe "relationship", ->
     beforeEach ->
       @arguments = {}
     describe "using the defaults", ->
-      it "should make a working relationship", ->
+      it "should make an undefined relationship", ->
         undertest = new Relationship(@arguments)
-        undertest.text.should.equal "increase"
-        undertest.formula.should.equal "1 * in"
+        undertest.isDefined.should.equal false
+        expect(undertest.text).to.be.undefined
+        expect(undertest.formula).to.be.undefined
 
   describe "evaluate", ->
     describe "a simple formula", ->
@@ -31,6 +32,9 @@ describe "relationship", ->
         @inFormula = "2 * in ^ 2 + out"
         @arguments = {formula: @inFormula}
         @undertest = new Relationship(@arguments)
+
+      it "should be defined", ->
+        @undertest.isDefined.should.equal true
 
       it "should do the math correctly", ->
         @undertest.evaluate(2,2).should.equal 10


### PR DESCRIPTION
This adds the notion of a relationship that can be undefined. All links start out with undefined relationships, and the user must select an option from the relation editing panel to define it.

A model can run when there are undefined relationships (it treats them as not existing), but there now must be at least one defined relationship for the model to run.