### PR TITLE
Hide dependent sliders

### DIFF
--- a/src/code/models/node.coffee
+++ b/src/code/models/node.coffee
@@ -106,11 +106,14 @@ module.exports = class Node extends GraphPrimitive
   inNodes: ->
     _.map @inLinks(), (link) -> link.sourceNode
 
-  isDependent: ->
-    for link in @inLinks()
-      if link.relation and link.relation.isDefined
-        return false
-    return true
+  isDependent: (onlyConsiderDefinedRelations) ->
+    if onlyConsiderDefinedRelations
+      for link in @inLinks()
+        if link.relation and link.relation.isDefined
+          return true
+      return false
+    else
+      @inLinks()?.length > 0
 
   checkIsInCycle: ->
     visitedNodes = []
@@ -118,7 +121,7 @@ module.exports = class Node extends GraphPrimitive
 
     visit = (node) ->
       visitedNodes.push node
-      for link in node.outLinks()
+      for link in node.outLinks() when link.relation?.isDefined
         downstreamNode = link.targetNode
         return true if downstreamNode is original
         unless _.contains visitedNodes, downstreamNode
@@ -181,10 +184,10 @@ module.exports = class Node extends GraphPrimitive
     key: @key
 
   canEditInitialValue: ->
-    not @isDependent() or @isAccumulator or @isInCycle
+    not @isDependent(true) or @isAccumulator or @isInCycle
 
   canEditValueWhileRunning: ->
-    not @isDependent()
+    not @isDependent(true)
 
   paletteItemIs: (paletteItem) ->
     paletteItem.uuid is @paletteItem

--- a/src/code/models/node.coffee
+++ b/src/code/models/node.coffee
@@ -107,7 +107,10 @@ module.exports = class Node extends GraphPrimitive
     _.map @inLinks(), (link) -> link.sourceNode
 
   isDependent: ->
-    @inLinks()?.length > 0
+    for link in @inLinks()
+      if link.relation and link.relation.isDefined
+        return false
+    return true
 
   checkIsInCycle: ->
     visitedNodes = []
@@ -178,10 +181,10 @@ module.exports = class Node extends GraphPrimitive
     key: @key
 
   canEditInitialValue: ->
-    @inLinks().length is 0 or @isAccumulator or @isInCycle
+    not @isDependent() or @isAccumulator or @isInCycle
 
   canEditValueWhileRunning: ->
-    @inLinks().length is 0
+    not @isDependent()
 
   paletteItemIs: (paletteItem) ->
     paletteItem.uuid is @paletteItem

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -129,6 +129,7 @@ GraphStore  = Reflux.createStore
       @linkKeys[link.terminalKey()] = link
       @nodeKeys[link.sourceNode.key].addLink(link)
       @nodeKeys[link.targetNode.key].addLink(link)
+    @_graphUpdated()
     @updateListeners()
 
 
@@ -142,6 +143,7 @@ GraphStore  = Reflux.createStore
     delete @linkKeys[link.terminalKey()]
     @nodeKeys[link.sourceNode.key]?.removeLink(link)
     @nodeKeys[link.targetNode.key]?.removeLink(link)
+    @_graphUpdated()
     @updateListeners()
 
 
@@ -169,11 +171,16 @@ GraphStore  = Reflux.createStore
   _addNode: (node) ->
     unless @hasNode node
       @nodeKeys[node.key] = node
+      @_graphUpdated()
       @updateListeners()
 
   _removeNode: (node) ->
     delete @nodeKeys[node.key]
+    @_graphUpdated()
     @updateListeners()
+
+  _graphUpdated: ->
+    node.checkIsInCycle() for key, node of @nodeKeys
 
   moveNodeCompleted: (nodeKey, pos, originalPos) ->
     @endNodeEdit()

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -299,6 +299,7 @@ GraphStore  = Reflux.createStore
         log.info "Change #{key} for #{link.title}"
         link[key] = changes[key]
     @_maybeChangeSelectedItem link
+    @_graphUpdated()
     @updateListeners()
 
   _nameForNode: (node) ->

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -164,6 +164,7 @@ module.exports = NodeView = React.createClass
     )
 
   renderSliderView: ->
+    if not @props.data.canEditInitialValue() then return null
     enabled = not @props.running or @props.data.canEditValueWhileRunning()
     (SliderView
       width: 70

--- a/test/node-list-test.coffee
+++ b/test/node-list-test.coffee
@@ -294,3 +294,30 @@ describe "Graph Topology", ->
       @nodeA.canEditValueWhileRunning().should.equal true
       @nodeB.canEditValueWhileRunning().should.equal false
       @nodeC.canEditValueWhileRunning().should.equal false
+
+  # A -x-> B -> C
+  describe "a graph with undefined relations", ->
+    beforeEach ->
+      @nodeA    = new Node()
+      @nodeB    = new Node({isAccumulator: true})
+      @nodeC    = new Node()
+      @formula  = "1 * in"
+
+      LinkNodes(@nodeA, @nodeB)
+      LinkNodes(@nodeB, @nodeC, @formula)
+
+      graphStore = GraphStore.store
+      graphStore.init()
+      graphStore.addNode @nodeA
+      graphStore.addNode @nodeB
+      graphStore.addNode @nodeC
+
+    it "should mark the nodes that can have initial values edited", ->
+      @nodeA.canEditInitialValue().should.equal true
+      @nodeB.canEditInitialValue().should.equal true
+      @nodeC.canEditInitialValue().should.equal false
+
+    it "should mark the nodes that can have values edited while running", ->
+      @nodeA.canEditValueWhileRunning().should.equal true
+      @nodeB.canEditValueWhileRunning().should.equal true
+      @nodeC.canEditValueWhileRunning().should.equal false


### PR DESCRIPTION
This

1. recognizes if nodes are in a cycle
2. shows enabled sliders before running a simulation for independent nodes, nodes in a cycle, and collectors
3. grays out sliders for nodes in a cycle and collectors during simulation
4. considers any node with only undefined inbound links as being a independent node

and tests are added.

https://www.pivotaltracker.com/story/show/116538381
https://www.pivotaltracker.com/story/show/117075519