### PR TITLE
Improve codap streaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,16 +11,16 @@
     "test": "./node_modules/mocha/bin/mocha"
   },
   "dependencies": {
-    "iframe-phone": "^1.1.3",
-    "jquery": "^2.1.3",
-    "jquery-ui": "^1.10.5",
-    "lodash": "^3.3.0",
-    "loglevel": "^1.2.0",
-    "mathjs": "^1.7.0",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7",
-    "reflux": "^0.2.7",
-    "uuid": "^2.0.1"
+    "iframe-phone": "1.1.3",
+    "jquery": "2.1.3",
+    "jquery-ui": "1.10.5",
+    "lodash": "3.3.0",
+    "loglevel": "1.2.0",
+    "mathjs": "1.7.0",
+    "react": "0.14.7",
+    "react-dom": "0.14.7",
+    "reflux": "0.2.7",
+    "uuid": "2.0.1"
   },
   "devDependencies": {
     "beepbeep": "^1.2.0",

--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -57,6 +57,7 @@ module.exports = class CodapConnect
               {
                 name: tr '~CODAP.SIMULATION.STEPS'
                 type: 'numeric'
+                formula: 'count(Steps)'
                 description: tr '~CODAP.SIMULATION.STEPS.DESCRIPTION'
                 precision: 0
               }
@@ -75,7 +76,7 @@ module.exports = class CodapConnect
       action: 'openCase'
       args: {
         collection: 'Simulation',
-        values: [null, 0]
+        values: [null, null]
       }
     }, (result) =>
       if result?.success
@@ -132,24 +133,25 @@ module.exports = class CodapConnect
       _.each frame.nodes, (n) -> sample.push n.value
       sample
 
-    # Send the data
-    @codapPhone.call
-      action: 'createCases'
-      args: {
-        collection: 'Samples',
-        parent: @currentCaseID,
-        values: sampleData
-      }
+    # Send the data, if any
+    if sampleData.length > 0
+      @codapPhone.call
+        action: 'createCases'
+        args: {
+          collection: 'Samples',
+          parent: @currentCaseID,
+          values: sampleData
+        }
 
     # Update the parent case with the current number of steps
-    @stepsInCurrentCase += sampleData.length
-    @codapPhone.call
-      action: 'updateCase'
-      args: {
-        collection: 'Simulation',
-        caseID: @currentCaseID
-        values: [null, @stepsInCurrentCase]
-      }
+#    @stepsInCurrentCase += sampleData.length
+#    @codapPhone.call
+#      action: 'updateCase'
+#      args: {
+#        collection: 'Simulation',
+#        caseID: @currentCaseID
+#        values: [null, @stepsInCurrentCase]
+#      }
 
   _sendUndoToCODAP: ->
     @codapPhone.call


### PR DESCRIPTION
Fixes bug: https://www.pivotaltracker.com/story/show/121420841

We found that Sage modeler was (a) issuing createCases requests to CODAP sometimes sending zero cases, and (b) updating a row in the parent table unnecessarily. The value that was being updated was the count of the child cases, a value that could be captured with a formula. So, we change the definition of the attribute to include the formula and comment out the update altogether.

There is still a lot of unnecessary chatter between Sage and CODAP, the removal of which could improve things some more. For example, CODAP sends many clearUndo and clearRedo requests, that it should not. But, on a reasonable machine, CODAP can keep up with graph updates, while a
run is executing and the slider is being manipulated.

To get a working build I had to adjust the dependencies in package.json.