### PR TITLE
Vertical slider

### DIFF
--- a/src/assets/codap-ivy-fonts.css
+++ b/src/assets/codap-ivy-fonts.css
@@ -23,10 +23,6 @@
 	-moz-osx-font-smoothing: grayscale;
 }
 
-.rotated {
-	writing-mode: vertical-rl;
-}
-
 .icon-codap-table2:before {
 	content: "\31";
 }

--- a/src/assets/codap-ivy-fonts.css
+++ b/src/assets/codap-ivy-fonts.css
@@ -23,6 +23,10 @@
 	-moz-osx-font-smoothing: grayscale;
 }
 
+.rotated {
+	writing-mode: vertical-rl;
+}
+
 .icon-codap-table2:before {
 	content: "\31";
 }

--- a/src/assets/test.html
+++ b/src/assets/test.html
@@ -8,6 +8,7 @@
   <meta name="build-info" content="__BUILD_INFO__" >
   <meta name="environment" content="__ENVIRONMENT__" >
   <link rel="stylesheet" href="css/app.css">
+  <link rel="stylesheet" href="codap-ivy-fonts.css">
 </head>
 <body>
   <div class="test-container">
@@ -21,7 +22,6 @@
       window.testComponent = (domID) -> React.render myView({}), domID
     </div>
   </div>
-  <script src="https://apis.google.com/js/client.js"></script>
   <script src="js/jsPlumb.js"></script>
   <script src="js/globals.js"></script>
   <script src="js/app.js"></script>

--- a/src/code/utils/js-plumb-diagram-toolkit.coffee
+++ b/src/code/utils/js-plumb-diagram-toolkit.coffee
@@ -60,7 +60,7 @@ module.exports = class DiagramToolkit
       isSource: true
       dropOptions:
         activeClass: "dragActive"
-      anchor: "Center"
+      anchor: "Bottom"
       connectorStyle : { strokeStyle:"#666" }
       endpoint: @_endpointOptions("Rectangle", 19, 'node-link-button')
       connectorOverlays: [["Arrow", {location:1.0, width:10, length:10}]]
@@ -168,17 +168,17 @@ module.exports = class DiagramToolkit
     paintStyle = @_paintStyle LinkColors.default
     paintStyle.outlineColor = "none"
     paintStyle.outlineWidth = 4
-    
+
     startColor = LinkColors.default
     finalColor = LinkColors.default
     fixedColor = LinkColors.default
     fadedColor = LinkColors.defaultFaded
     changeIndicator = ''
-    
+
     thickness = Math.abs(opts.magnitude)
     if (!thickness)
       thickness = 1
-    
+
     if opts.isDashed
       paintStyle.dashstyle = "4 2"
       fixedColor = fixedColor = LinkColors.dashed
@@ -200,7 +200,7 @@ module.exports = class DiagramToolkit
 
     paintStyle.lineWidth = thickness
     startColor = finalColor
-    
+
     if (opts.useGradient)
       startColor = finalColor = fixedColor
       if opts.gradual < 0
@@ -208,13 +208,13 @@ module.exports = class DiagramToolkit
       if opts.gradual > 0
         startColor = fadedColor
       paintStyle.gradient = @_gradient startColor, finalColor
-      
+
     paintStyle.strokeStyle = fixedColor
     paintStyle.vertical = true
-    
+
     variableWidthMagnitude = 0
     arrowFoldback = 0.6
-    
+
     if (opts.gradual && opts.useVariableThickness)
       variableWidthMagnitude = @lineWidthVariation * opts.gradual
       arrowFoldback = 0.8
@@ -236,7 +236,7 @@ module.exports = class DiagramToolkit
     connection.bind 'click', @handleClick.bind @
     connection.bind 'dblclick', @handleDoubleClick.bind @
     connection.linkModel = opts.linkModel
-    
+
     @kit.importDefaults
       Connector: ["Bezier", {curviness: 60, variableWidth: null}]
 

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -268,7 +268,9 @@ module.exports = React.createClass
             graphStore: @props.graphStore
             selectionManager: @props.selectionManager
             showMinigraph: @state.showingMinigraphs
-            showGraphButton: @props.graphStore.codapStandaloneMode and not @state.diagramOnly
+            # showGraphButton: @props.graphStore.codapStandaloneMode and not @state.diagramOnly
+            # for now, show graph button whenever we are in simulation mode
+            showGraphButton: not @state.diagramOnly
           })
       )
     )

--- a/src/code/views/node-svg-graph-view.coffee
+++ b/src/code/views/node-svg-graph-view.coffee
@@ -7,8 +7,8 @@ module.exports = NodeSvgGraphView = React.createClass
   mixins: [ SimulationStore.mixin ]
 
   getDefaultProps: ->
-    width: 46
-    height: 46
+    width: 48
+    height: 48
     strokeWidth: 3
     min: 0
     max: 100
@@ -50,7 +50,7 @@ module.exports = NodeSvgGraphView = React.createClass
 
   renderLineData: ->
     data = @pointsToPath(@getPathPoints())
-    (path {d: data, strokeWidth: @props.strokeWidth, stroke: "#a1d083", fill: "none"})
+    (path {d: data, strokeWidth: @props.strokeWidth, stroke: "#e99373", fill: "none"})
 
   render: ->
     (div {},

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -164,13 +164,13 @@ module.exports = NodeView = React.createClass
     )
 
   renderSliderView: ->
-    if not @props.data.canEditInitialValue() then return null
     enabled = not @props.running or @props.data.canEditValueWhileRunning()
     (SliderView
       horizontal: false
       filled: true
       height: 44
       width: 15
+      showHandle: @props.data.canEditInitialValue()
       showLabels: false
       onValueChange: @changeValue
       value: @props.data.initialValue

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -167,7 +167,11 @@ module.exports = NodeView = React.createClass
     if not @props.data.canEditInitialValue() then return null
     enabled = not @props.running or @props.data.canEditValueWhileRunning()
     (SliderView
-      width: 70
+      horizontal: false
+      filled: true
+      height: 44
+      width: 15
+      showLabels: false
       onValueChange: @changeValue
       value: @props.data.initialValue
       displaySemiQuant: @props.data.valueDefinedSemiQuantitatively
@@ -198,10 +202,9 @@ module.exports = NodeView = React.createClass
     classes.join " "
 
   nodeSliderClasses: ->
-    classes = ['bottom','centered-block']
     if @props.simulating and @props.data.canEditInitialValue()
-      classes.push 'slider'
-    classes.join " "
+      "slider"
+    else ""
 
   renderNodeInternal: ->
     if @props.showMinigraph
@@ -225,36 +228,38 @@ module.exports = NodeView = React.createClass
 
     (div { className: @nodeClasses(), ref: "node", style: style},
       (div {className: @linkTargetClasses(), "data-node-key": @props.nodeKey},
-        (div {className: "actions"},
-          (div {className: "connection-source action-circle icon-codap-link", "data-node-key": @props.nodeKey})
-          if @props.selected and @props.showGraphButton
-            (div {
-              className: "graph-source action-circle icon-codap-graph",
-              onClick: (=> @handleGraphClick @props.data.title)
-            })
-        )
-
-        (div {className: @topClasses(), "data-node-key": @props.nodeKey},
-          (div {
-            className: "img-background"
-            onClick: (=> @handleSelected true)
-            onTouchend: (=> @handleSelected true)
-            },
-            @renderNodeInternal()
+        (div {},
+          (div {className: "actions"},
+            (div {className: "connection-source action-circle icon-codap-link", "data-node-key": @props.nodeKey})
+            if @props.selected and @props.showGraphButton
+              (div {
+                className: "graph-source action-circle icon-codap-graph",
+                onClick: (=> @handleGraphClick @props.data.title)
+              })
           )
-          (NodeTitle {
-            isEditing: @props.editTitle
-            title: @props.data.title
-            onChange: @changeTitle
-            onStopEditing: @stopEditing
-            onStartEditing: @startEditing
-          })
+
+          (div {className: @topClasses(), "data-node-key": @props.nodeKey},
+            (div {
+              className: "img-background"
+              onClick: (=> @handleSelected true)
+              onTouchend: (=> @handleSelected true)
+              },
+              @renderNodeInternal()
+            )
+            (NodeTitle {
+              isEditing: @props.editTitle
+              title: @props.data.title
+              onChange: @changeTitle
+              onStopEditing: @stopEditing
+              onStartEditing: @startEditing
+            })
+          )
         )
         (div {className: @nodeSliderClasses() ,"data-node-key": @props.nodeKey},
           if @props.simulating
-            (div {className: 'centered-block'},
-              if not @props.data.valueDefinedSemiQuantitatively
-                @renderValue()
+            (div {},
+              # if not @props.data.valueDefinedSemiQuantitatively
+              #   @renderValue()     # not sure if we plan to render value
               @renderSliderView()
             )
         )

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -231,7 +231,7 @@ module.exports = NodeView = React.createClass
         (div {},
           (div {className: "actions"},
             (div {className: "connection-source action-circle icon-codap-link", "data-node-key": @props.nodeKey})
-            if @props.selected and @props.showGraphButton
+            if @props.showGraphButton
               (div {
                 className: "graph-source action-circle icon-codap-graph",
                 onClick: (=> @handleGraphClick @props.data.title)

--- a/src/code/views/svg-graph-view.coffee
+++ b/src/code/views/svg-graph-view.coffee
@@ -13,7 +13,7 @@ module.exports = SvgGraphView = React.createClass
     link: null
 
   drawing: false
-  
+
   getInitialState: ->
     currentData: null
     pointPathData: null
@@ -29,7 +29,7 @@ module.exports = SvgGraphView = React.createClass
     isDefined = @props.link.relation.isDefined
     formula = @props.link.relation.formula
     newCustomData = false
-    
+
     if @props.link.relation.isCustomRelationship or (currentData? and isDefined)
       canDraw = true
       formula = null
@@ -47,14 +47,14 @@ module.exports = SvgGraphView = React.createClass
         @updatePointData null, currentData
       else if formula?
         @updatePointData formula, null
-    
+
   componentWillReceiveProps: (newProps) ->
     if newProps
       canDraw = false
       currentData = newProps.link.relation.customData
       isDefined = newProps.link.relation.isDefined
       formula = newProps.link.relation.formula
-      
+
       if newProps.link.relation.isCustomRelationship or (currentData? and isDefined)
         canDraw = true
         if not isDefined
@@ -67,7 +67,7 @@ module.exports = SvgGraphView = React.createClass
         canDraw = false
         newCustomData = false
         currentData = null
-      
+
       @setState {
         currentData: currentData,
         pointPathData: null,
@@ -77,7 +77,7 @@ module.exports = SvgGraphView = React.createClass
       }
 
       @updatePointData formula, currentData
-        
+
   updatePointData: (formula, currentData) ->
     if not currentData? and formula?
       currentData = @loadCustomDataFromFormula formula
@@ -103,14 +103,14 @@ module.exports = SvgGraphView = React.createClass
     x = point.x * width + xOffset
     y = point.y * height + yOffset
     @invertPoint x:x, y:y
-    
+
   findClosestPoint:(path, pointX, pointY) ->
     graphOrigin = @graphMapPoint {x:0, y:0}
     x = pointX - $(path).offset().left
     y = pointX - $(path).offset().top
     p = {x: x, y: y}
     p
-    
+
   pointsToPath: (points)->
     data = _.map points, (p) => @graphMapPoint(p)
     data = _.map data,   (p) -> "#{p.x} #{p.y}"
@@ -178,7 +178,7 @@ module.exports = SvgGraphView = React.createClass
         (path {className: 'data', d:data, strokeWidth:@props.strokeWidth, strokeDasharray:@props.strokeDasharray})
       else
         (path {className: 'data', d:data, strokeWidth:@props.strokeWidth})
-    
+
   startDrawCurve: (evt) ->
     # can only draw on custom relationships
     if @state.canDraw
@@ -190,12 +190,12 @@ module.exports = SvgGraphView = React.createClass
         newCustomData = false
         @setState {newCustomData: newCustomData}
       @drawCurve(evt)
-    
+
   drawCurve: (evt) ->
     if @drawing and not @state.newCustomData
       evt.preventDefault()
       scaledCoords = @pointToScaledCoords(evt)
-      
+
       if scaledCoords.x >= 0 && scaledCoords.x <= 100 && scaledCoords.y >= 0 && scaledCoords.y <= 100
         newData = _.map @state.currentData, (d) ->
           x = d[0]
@@ -210,19 +210,19 @@ module.exports = SvgGraphView = React.createClass
       @drawing = false
       #update relation with custom data
       @updateRelationCustomData(@state.currentData)
-    
+
   pointToScaledCoords: (evt) ->
     rect = evt.target.getBoundingClientRect()
     coords = {x: rect.width - (rect.right-evt.clientX), y: rect.bottom - evt.clientY}
     scaledCoords = {x: Math.round(coords.x / rect.width * 100), y: Math.round(coords.y / rect.height * 100)}
     scaledCoords
-    
+
   updateRelationCustomData: (customData) ->
     link = @props.link
     link.relation.customData = customData
     link.relation.isDefined = customData?
     @props.graphStore.changeLink(link, {relation: link.relation})
-  
+
   render: ->
     drawClass = 'draw-graph'
     if @state.canDraw then drawClass += ' drawing'
@@ -240,14 +240,14 @@ module.exports = SvgGraphView = React.createClass
           )
       )
     )
-    
+
 # TO DEBUG THIS VIEW:
-RelationFactory = require "../models/relation-factory"
-myView = React.createFactory SvgGraphView
-window.testComponent = (domID) ->
-  ReactDOM.render myView({
-    width: 200
-    height: 200
-    yLabel: "this node"
-    xLabel: "input a"
-  }), domID
+# RelationFactory = require "../models/relation-factory"
+# myView = React.createFactory SvgGraphView
+# window.testComponent = (domID) ->
+#   ReactDOM.render myView({
+#     width: 200
+#     height: 200
+#     yLabel: "this node"
+#     xLabel: "input a"
+#   }), domID

--- a/src/code/views/value-slider-view.coffee
+++ b/src/code/views/value-slider-view.coffee
@@ -287,4 +287,4 @@ Demo = React.createClass
         onRangeChange: @onRangeChange
     )
 
-# window.testComponent = (domID) -> ReactDOM.render React.createElement(Demo,{}), domID
+window.testComponent = (domID) -> ReactDOM.render React.createElement(Demo,{}), domID

--- a/src/code/views/value-slider-view.coffee
+++ b/src/code/views/value-slider-view.coffee
@@ -267,7 +267,7 @@ ValueSlider = React.createClass
     style =
       padding: "0px"
       border: "0px"
-      width: @props.width + (if not @props.horizontal then lengendHeight else 0)
+      width: @props.width + (if not @props.horizontal and not @props.filled then lengendHeight else 0)
       height: @props.height + (if @props.horizontal then lengendHeight else 0)
     classNames = "value-slider"
     if not @props.horizontal then classNames += " vertical"

--- a/src/code/views/value-slider-view.coffee
+++ b/src/code/views/value-slider-view.coffee
@@ -142,8 +142,12 @@ ValueSlider = React.createClass
     if not @props.displaySemiQuant
       label = @renderNumber()
     else label = null
+
+    classNames = "icon-codap-smallSliderLines"
+    if not @props.horizontal then classNames += " rotated"
+
     (div {className: "value-slider-handle", style: style, ref: "handle"},
-      (i {className: "icon-codap-smallSliderLines"})
+      (i {className: classNames})
       ( label )
     )
 

--- a/src/code/views/value-slider-view.coffee
+++ b/src/code/views/value-slider-view.coffee
@@ -39,9 +39,7 @@ ValueSlider = React.createClass
     "editing-max": false
 
   updateValue: (locValue,dragging) ->
-    console.log("locValue = "+locValue)
     value = @valueFromSliderUI(locValue)
-    console.log("  value = "+value)
     @props.onValueChange value
 
   updateRange: (property, value) ->

--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -10,7 +10,7 @@ $node-design-height = 94px
 
 .elm
   box-sizing border-box
-  border-top 6px solid transparent
+  border-top 13px solid transparent
   background-color transparent
   height auto
 
@@ -82,8 +82,9 @@ $node-design-height = 94px
     min-height 10px
   .action-circle
     position absolute
+    cursor pointer
     background-color light-blue
-    right -12px
+    right 3px
     border-radius 30px
     padding 5px
     color white
@@ -95,7 +96,7 @@ $node-design-height = 94px
       opacity 1
 
   .connection-source
-    top 5px
+    top -10px
 
   .graph-source
     top 35px
@@ -182,9 +183,10 @@ $node-design-height = 94px
       opacity 0.9
 .node-link-button
   opacity 0.0
+  cursor pointer
 
 .node-link-target
-  margin-top -3px
+  margin-top 7px
   background-color transparent
   z-index -2
 

--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -11,10 +11,10 @@ $node-design-height = 94px
 .elm
   box-sizing border-box
   border-top 6px solid transparent
-  background-color transparent  
+  background-color transparent
   height auto
-  
-  
+
+
   .top
     height auto
     margin-top 6px
@@ -26,7 +26,7 @@ $node-design-height = 94px
     width $big-elm-width
   .debugging
     opacity 0.5
-    
+
   input
     -moz-user-select text
     -webkit-user-select text
@@ -110,7 +110,7 @@ $node-design-height = 94px
   &.selected
     box-shadow 0px 0px 3px hsla(0,0,0,0.3)
     background-color white
-    
+
     .bottom
       border-radius 0px 0px 5px 5px
       box-sizing content-box
@@ -163,6 +163,8 @@ $node-design-height = 94px
 
   .value-slider
     margin 0px
+    margin-left: -16px
+    margin-top: 13px
 
   .delete-box
     margin 2px
@@ -193,11 +195,12 @@ $node-design-height = 94px
     -webkit-box-shadow 0px 0px 30px 0px rgba(255,179,0,1)
     -moz-box-shadow 0px 0px 30px 0px rgba(255,179,0,1)
     box-shadow 0px 0px 30px 0px rgba(255,179,0,1)
-    
+
 .link-target
   margin-top 6px
   margin-bottom 6px
   height $node-design-height
+  display: flex
   &.simulate
     height auto
 

--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -84,7 +84,7 @@ $node-design-height = 94px
     position absolute
     cursor pointer
     background-color light-blue
-    right 3px
+    top -10px
     border-radius 30px
     padding 5px
     color white
@@ -96,11 +96,10 @@ $node-design-height = 94px
       opacity 1
 
   .connection-source
-    top -10px
+    right 3px
 
   .graph-source
-    top 35px
-    font-size 12px
+    right 60px
   .top
     height 72px
   .bottom

--- a/src/stylus/components/value-slider.styl
+++ b/src/stylus/components/value-slider.styl
@@ -99,7 +99,7 @@ orange-fill = #e99373
       width 0
       height 2px
       border-top 3px solid transparent
-      border-right 5px solid orange-fill
+      border-right 6px solid orange-fill
       border-bottom 3px solid transparent
 
     .slider-line

--- a/src/stylus/components/value-slider.styl
+++ b/src/stylus/components/value-slider.styl
@@ -91,6 +91,17 @@ orange-fill = #e99373
       background-color orange-fill
       orange-fill
 
+    .value-slider-handle:before
+      content ""
+      position absolute
+      right 100%
+      top 3px
+      width 0
+      height 2px
+      border-top 3px solid transparent
+      border-right 5px solid orange-fill
+      border-bottom 3px solid transparent
+
     .slider-line
       stroke gray-fill
       fill none

--- a/src/stylus/components/value-slider.styl
+++ b/src/stylus/components/value-slider.styl
@@ -11,6 +11,7 @@
   .svg-background
     position relative
   .value-slider-handle
+    z-index 2
     cursor pointer
     position absolute
     box-sizing border-box
@@ -62,6 +63,13 @@
       box-shadow 1px 1px 3px -2px rgba(0,0,0,0.75)
     input
       width 100px
+
+  &.vertical
+    .legend
+      top -4%
+      height 110%
+      display flex
+      flex-direction column
 
   &.disabled
     .slider-line

--- a/src/stylus/components/value-slider.styl
+++ b/src/stylus/components/value-slider.styl
@@ -114,3 +114,8 @@ orange-fill = #e99373
 
         &.cap
           stroke-linecap round
+
+// handle icon
+.rotated {
+  writing-mode: vertical-rl;
+}

--- a/src/stylus/components/value-slider.styl
+++ b/src/stylus/components/value-slider.styl
@@ -1,3 +1,6 @@
+gray-fill   = #dbdbea
+orange-fill = #e99373
+
 .value-slider
   position relative
   margin 1em
@@ -82,3 +85,21 @@
       background-color #DDD
     .legend
       color rgba(1, 136, 158, 0.42)
+
+  &.filled
+    .value-slider-handle
+      background-color orange-fill
+      orange-fill
+
+    .slider-line
+      stroke gray-fill
+      fill none
+      stroke-width 8
+      stroke-linecap round
+
+      &.fill-line
+        stroke orange-fill
+        stroke-linecap butt
+
+        &.cap
+          stroke-linecap round


### PR DESCRIPTION
This adds a thermometer-style vertical slider to the right, and moves the two existing action circle.

The slider view now has many more options for horizontal, vertical, fillable and not. This is probably useless, as we are no longer using it anywhere else, now that the speed slider has gone, but we might as well keep it until maintaining these options becomes too painful.

The slider is shorter than what @ddamelin's mockups showed, as the apparent intent in the mockups was to make the thermometer level to be exactly aligned with the minigraph.

[#132117711] https://www.pivotaltracker.com/story/show/132117711
[#132832351] https://www.pivotaltracker.com/story/show/132832351
[#132117775] https://www.pivotaltracker.com/story/show/132117775

