### PR TITLE
Record simulation changes

### DIFF
--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -29,8 +29,10 @@ module.exports = class CodapConnect
     GraphStore = require '../stores/graph-store'
     @graphStore = GraphStore.store
 
-    SimulationStore.actions.recordingDidStart.listen       @_openNewCase.bind(@)
-    SimulationStore.actions.recordingDidEnd.listen @_sendSimulationData.bind(@)
+    SimulationStore.actions.recordingDidEnd.listen SimulationStore.actions.recordingDidStart.listen
+    SimulationStore.actions.simulationFramesCreated.listen
+    @_openNewCase.bind(@)
+    @_sendSimulationData.bind(@)
     CodapActions.sendUndoToCODAP.listen @_sendUndoToCODAP.bind(@)
     CodapActions.sendRedoToCODAP.listen @_sendRedoToCODAP.bind(@)
 

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -24,7 +24,6 @@ GraphStore  = Reflux.createStore
     @selectionManager   = new SelectionManager()
     PaletteDeleteStore.store.listen @paletteDelete.bind(@)
 
-    SimulationStore.actions.runSimulation.listen           @resetSimulation.bind(@)
     SimulationStore.actions.resetSimulation.listen         @resetSimulation.bind(@)
     SimulationStore.actions.setDuration.listen             @resetSimulation.bind(@)
     SimulationStore.actions.simulationFramesCreated.listen @updateSimulationData.bind(@)

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -13,9 +13,9 @@ SimulationActions = Reflux.createActions(
     "resetSimulation"
     "setDuration"
     "setStepUnits"
-    "setSpeed"
     "simulationStarted"
     "simulationFramesCreated"
+    "recordingFramesCreated"
     "simulationEnded"
     "capNodeValues"
     "recordStream"
@@ -78,7 +78,9 @@ SimulationStore   = Reflux.createStore
     @nodes = data.nodes
     @settings.modelIsRunnable = @_checkModelIsRunnable()
     @settings.graphHasCollector = @_checkForCollectors()
-    @_runSimulation()
+    # TODO:  This can't go here: We want this for 'real time' simulations
+    # But we need something with better granularity.
+    # @_runSimulation()
 
   onSetDuration: (n) ->
     @settings.duration = Math.max 1, Math.min n, 5000
@@ -93,11 +95,6 @@ SimulationStore   = Reflux.createStore
     _.merge @settings, data.settings.simulation
     @notifyChange()
 
-  onSetSpeed: (s) ->
-    @settings.speed = s
-    if @currentSimulation
-      @currentSimulation.setSpeed s
-    @notifyChange()
 
   onCapNodeValues: (cap) ->
     @settings.capNodeValues = cap
@@ -106,12 +103,11 @@ SimulationStore   = Reflux.createStore
   onRunSimulation: ->
     @_runSimulation()
 
-  _runSimulation: ->
+  _runSimulation: (duration=1)->
     if @settings.modelIsRunnable and @settings.modelReadyToRun
       # graph-store listens and will reset the simulation when
       # it is run to clear pre-saved data after first load
       @settings.modelIsRunning = true
-      duration = 1
       if @settings.graphHasCollector
         duration = @settings.duration
       @notifyChange()
@@ -120,14 +116,17 @@ SimulationStore   = Reflux.createStore
         duration: duration
         speed: @settings.speed
         capNodeValues: @settings.capNodeValues
-
-        # Simulation events get triggered as Actions here, and are
-        # available to anyone who listens to this store
-        onFrames: (frames) ->
+        # TODO: I am not sure if we care about these events anymore
+        # now that recording is decoupled from simulation...
+        onFrames: (frames) =>
           SimulationActions.simulationFramesCreated(frames)
+          if @settings.isRecording
+            SimulationActions.recordingFramesCreated(frames)
 
-        onStart: (nodeNames) ->
+        onStart: (nodeNames) =>
           SimulationActions.simulationStarted(nodeNames)
+          if @settings.isRecording
+            SimulationActions.recordingDidStart(nodeNames)
         onEnd: ->
           SimulationActions.simulationEnded()
 
@@ -142,15 +141,22 @@ SimulationStore   = Reflux.createStore
     @settings.modelReadyToRun = true
     @notifyChange()
 
-  onStopRecording: ->
+  _startRecording: ->
+    @settings.isRecording = true
+
+  _stopRecording: ->
     @settings.isRecording = false
     @settings.isRecordingOne = false
     @settings.isRecordingStream = false
     @settings.isRecordingPeriod = false
+    SimulationActions.recordingDidEnd()
+
+  onStopRecording: ->
+    @_stopRecording()
     @notifyChange()
 
   onRecordOne: ->
-    @settings.isRecording = true
+    @_startRecording()
     @settings.isRecordingOne = true
     stopRecording = ->
       SimulationActions.stopRecording()
@@ -158,13 +164,14 @@ SimulationStore   = Reflux.createStore
     @notifyChange()
 
   onRecordStream: ->
-    @settings.isRecording = true
+    @_startRecording()
     @settings.isRecordingStream = true
     @notifyChange()
 
   onRecordPeriod: ->
-    @settings.isRecording = true
+    @_startRecording()
     @settings.isRecordingPeriod = true
+    @_runSimulation(@settings.duration)
     stopRecording = ->
       SimulationActions.stopRecording()
     @timeout = setTimeout(stopRecording, 500)

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -66,6 +66,7 @@ SimulationStore   = Reflux.createStore
     @settings.simulationPanelExpanded = true
     @settings.modelReadyToRun = true
     @settings.modelIsRunning = true
+    SimulationActions.resetSimulation.trigger()
     @notifyChange()
 
   onCollapseSimulationPanel: ->
@@ -78,9 +79,6 @@ SimulationStore   = Reflux.createStore
     @nodes = data.nodes
     @settings.modelIsRunnable = @_checkModelIsRunnable()
     @settings.graphHasCollector = @_checkForCollectors()
-    # TODO:  This can't go here: We want this for 'real time' simulations
-    # But we need something with better granularity.
-    # @_runSimulation()
 
   onSetDuration: (n) ->
     @settings.duration = Math.max 1, Math.min n, 5000
@@ -116,8 +114,7 @@ SimulationStore   = Reflux.createStore
         duration: duration
         speed: @settings.speed
         capNodeValues: @settings.capNodeValues
-        # TODO: I am not sure if we care about these events anymore
-        # now that recording is decoupled from simulation...
+
         onFrames: (frames) =>
           SimulationActions.simulationFramesCreated(frames)
           if @settings.isRecording
@@ -127,6 +124,7 @@ SimulationStore   = Reflux.createStore
           SimulationActions.simulationStarted(nodeNames)
           if @settings.isRecording
             SimulationActions.recordingDidStart(nodeNames)
+
         onEnd: ->
           SimulationActions.simulationEnded()
 

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -102,7 +102,7 @@ SimulationStore   = Reflux.createStore
     @_runSimulation()
 
   stepUnits: () ->
-    if @isRecordingPeriod
+    if @settings.isRecordingPeriod
       @settings.stepUnits
     else
       TimeUnits.defaultUnit # "STEPS" when not specified or not running time interval

--- a/src/code/utils/time-units.coffee
+++ b/src/code/utils/time-units.coffee
@@ -17,7 +17,7 @@ module.exports =
 
   units: _.keys(units)
 
-  defaultUnit: "DAY"
+  defaultUnit: "STEP"
 
   toString: (unit, plural) ->
     number = if plural then ".PLURAL" else ""

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -1,6 +1,7 @@
 {input, div, i, img, span, label} = React.DOM
 tr = require "../utils/translate"
 
+SimulationActions = require("../stores/simulation-store").actions
 SquareImage = React.createFactory require "./square-image-view"
 SliderView  = React.createFactory require "./value-slider-view"
 GraphView   = React.createFactory require "./node-svg-graph-view"
@@ -139,6 +140,7 @@ module.exports = NodeView = React.createClass
 
   changeValue: (newValue) ->
     @props.graphStore.changeNodeWithKey(@props.nodeKey, {initialValue:newValue})
+    SimulationActions.runSimulation()
 
   changeTitle: (newTitle) ->
     @props.graphStore.startNodeEdit()

--- a/test/loading-serialization-test.coffee
+++ b/test/loading-serialization-test.coffee
@@ -62,7 +62,7 @@ describe "Serialization and Loading", ->
       @graphStore = GraphStore.store
       @graphStore.init()
 
-      @nodeA = new Node({title: "a", x:10, y:15, paletteItem:"uuid-dingo"}, 'a')
+      @nodeA = new Node({title: "a", x:10, y:15, paletteItem:"uuid-dingo", frames:[] }, 'a')
       @nodeB = new Node({title: "b", x:20, y:25, paletteItem:"uuid-bee", frames: [50]}, 'b')
       @linkA = new Link({
         sourceNode: @nodeA

--- a/test/simulation-test.coffee
+++ b/test/simulation-test.coffee
@@ -26,6 +26,7 @@ Relationship   = requireModel 'relationship'
 requireStore = (name) -> require "#{__dirname}/../src/code/stores/#{name}"
 
 GraphStore        = requireStore('graph-store').store
+SimulationStore   = requireStore('simulation-store').store
 SimulationActions = requireStore('simulation-store').actions
 
 CodapConnect   = requireModel 'codap-connect'
@@ -40,6 +41,16 @@ LinkNodes = (sourceNode, targetNode, formula) ->
       formula: formula
   sourceNode.addLink(link)
   targetNode.addLink(link)
+
+
+asyncListenTest = (done, action, func) ->
+  stopListening = action.listen (args) ->
+    try
+      func.apply(null, arguments)
+      done()
+    catch ex
+      done(ex)
+    stopListening()
 
 describe "Simulation", ->
   beforeEach ->
@@ -247,8 +258,8 @@ describe "Simulation", ->
 
 describe "The SimulationStore, with a network in the GraphStore", ->
   beforeEach ->
-    sandbox = Sinon.sandbox.create()
-    sandbox.stub(CodapConnect, "instance", ->
+    @sandbox = Sinon.sandbox.create()
+    @sandbox.stub(CodapConnect, "instance", ->
       return {
         sendUndoableActionPerformed: -> return ''
       }
@@ -271,28 +282,18 @@ describe "The SimulationStore, with a network in the GraphStore", ->
   describe "for a fast simulation for 10 iterations", ->
 
     beforeEach ->
-      SimulationActions.resetSimulation.trigger()
-      SimulationActions.setSpeed.trigger(4)
       SimulationActions.setDuration.trigger(10)
 
+    it "should call recordingDidStart with the node names", (done) ->
+      asyncListenTest done, SimulationActions.recordingDidStart, (nodeNames) ->
+        nodeNames.should.eql ["A", "B"]
 
-    it "should call simulationStarted with the node names", (done) ->
-      # calledback is an annoyance to prevent later tests from triggering this
-      # listener again, and raising multiple-done() Mocha error
-      calledback = false
-
-      SimulationActions.simulationStarted.listen (nodeNames) ->
-        if not calledback
-          nodeNames.should.eql ["A", "B"]
-          done()
-        calledback = true
-
-      SimulationActions.runSimulation()
+      SimulationActions.recordPeriod()
 
     it "should call simulationFramesCreated with all the step values", (done) ->
-      calledback = false
-      SimulationActions.simulationFramesCreated.listen (data) ->
-        if not calledback
+
+      asyncListenTest done, SimulationActions.recordingFramesCreated, (data) ->
+
           data.length.should.equal 10
 
           frame0 = data[0]
@@ -303,29 +304,20 @@ describe "The SimulationStore, with a network in the GraphStore", ->
           frame9.time.should.equal 10
           frame9.nodes.should.eql [ { title: 'A', value: 10 }, { title: 'B', value: 1 } ]
 
-          done()
-
-        calledback = true
-
-      SimulationActions.runSimulation()
+      SimulationActions.recordPeriod()
 
   describe "for a slow simulation for 3 iterations", ->
 
     beforeEach ->
-      SimulationActions.resetSimulation()
       SimulationActions.setDuration.trigger(3)
-      SimulationActions.setSpeed.trigger(3)
 
-    it "should call simulationFramesCreated several times, with 3 frames total", (done) ->
-      totalCallbacks = 0
-      totalFrames = 0
-      SimulationActions.simulationFramesCreated.listen (data) ->
-        totalCallbacks++
-        totalFrames += data.length
+    it "should call simulationFramesCreated with 3 frames", (done) ->
+      testF = (data) ->
+        size = data.length
+        size.should.eql(3)
 
-      SimulationActions.simulationEnded.listen ->
-        expect(totalFrames).to.equal 3
-        expect(totalCallbacks).to.be.above 1
-        done()
+      asyncListenTest done, SimulationActions.recordingFramesCreated, testF
+      SimulationActions.recordPeriod()
 
-      SimulationActions.runSimulation()
+
+


### PR DESCRIPTION
An in-progress branch.

'Simulation' is been decoupled from sending to CODAP in this branch.  It also includes an improvement to how we are listening to simulation changes in the simulation tests.

Here are some related PT stories:

User can collect a single data point and send it to CODAP when there are no collectors.
https://www.pivotaltracker.com/story/show/133207443

User can turn on "recording" to send a stream of data when no collectors are present.
https://www.pivotaltracker.com/story/show/133207187