### PR TITLE
Add cache-busting query to app.js and app.css

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -12,21 +12,23 @@ var argv = require('yargs').argv,
       tag: gitTags.split('-')[0],
       commiter: gitLog.split(" ")[2],
       commit: gitLog.split(" ")[1]
-    };
+    },
     buildInfoString = (buildInfo.date + " " +
       buildInfo.tag + " " +
       buildInfo.commit + " " +
-      buildInfo.commiter).replace(/\n|\r/g,"");
+      buildInfo.commiter).replace(/\n|\r/g,""),
+    commitString = buildInfo.commit,
+
     src = './src';
 
 var dest  = production ? './dist' : './dev';
-
 
 module.exports = {
   production: production,
   environment: environment,
   buildInfo: buildInfo,
   buildInfoString: buildInfoString,
+  commitString: commitString,
   css: {
     watch: src + '/stylus/**/*.styl',
     src: src + '/stylus/**/app.styl',

--- a/gulp/tasks/assets.js
+++ b/gulp/tasks/assets.js
@@ -1,6 +1,7 @@
 var gulp        = require('gulp');
 var production  = require('../config').production;
 var buildInfo   = require('../config').buildInfoString;
+var commit      = require('../config').commitString;
 var environment = require('../config').environment;
 var config      = require('../config').assets;
 var gulpif      = require('gulp-if');
@@ -14,6 +15,7 @@ var isHTML = function (file) {
 gulp.task('assets', function() {
   return gulp.src(config.src)
     .pipe(gulpif(isHTML, replace(/__BUILD_INFO__/g,  buildInfo)))
+    .pipe(gulpif(isHTML, replace(/__COMMIT__/g,  commit)))
     .pipe(gulpif(isHTML, replace(/__ENVIRONMENT__/g, environment)))
     .pipe(gulp.dest(config.dest));
 });

--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -28,7 +28,7 @@
   </script>
 
   <!-- <script type="text/javascript"> atatus.config('3aefe626ce09488db16c70d9e10fea9a').install(); </script> -->
-  <link rel="stylesheet" href="css/app.css">
+  <link rel="stylesheet" href="css/app.css?v=__COMMIT__">
   <link rel="stylesheet" href="codap-ivy-fonts.css">
 </head>
 <body>
@@ -37,7 +37,7 @@
   </div>
   <script src="js/jsPlumb.js"></script>
   <script src="js/globals.js"></script>
-  <script src="js/app.js"></script>
+  <script src="js/app.js?v=__COMMIT__"></script>
   <script type="text/javascript" charset="utf-8">
     if(self == top) {
       // redirect to CFM wrapper if we have none

--- a/src/assets/sage.html
+++ b/src/assets/sage.html
@@ -4,8 +4,8 @@
 
     <!-- Cloud File Manager -->
     <script type="text/javascript" src="//concord-consortium.github.io/cloud-file-manager/js/globals.js"></script>
-    <script type="text/javascript" src="//concord-consortium.github.io/cloud-file-manager/js/app.js"></script>
-    <link rel="stylesheet" href="//concord-consortium.github.io/cloud-file-manager/css/app.css">
+    <script type="text/javascript" src="//concord-consortium.github.io/cloud-file-manager/js/app.js?v=__COMMIT__"></script>
+    <link rel="stylesheet" href="//concord-consortium.github.io/cloud-file-manager/css/app.css?v=__COMMIT__">
 
   </head>
   <body>


### PR DESCRIPTION
@knowuh This is a straw-man idea for cache-busting, using query parameters on app.js and app.css that are unique per deployment (i.e. request `app.js?v={COMMIT_SHA}`).

There may well be other methods of dealing with this. Thoughts/conversation appreciated.

https://www.pivotaltracker.com/story/show/134090627