### PR TITLE
Some simulation panel fixes

### DIFF
--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -78,6 +78,7 @@ SimulationStore   = Reflux.createStore
     @nodes = data.nodes
     @settings.modelIsRunnable = @_checkModelIsRunnable()
     @settings.graphHasCollector = @_checkForCollectors()
+    @notifyChange()
 
   onSetDuration: (n) ->
     @settings.duration = Math.max 1, Math.min n, 5000

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -47,9 +47,7 @@ SimulationStore   = Reflux.createStore
       stepUnitsName: unitName
       timeUnitOptions: options
       capNodeValues: false
-      modelIsRunning: false         # currently running?
-      modelReadyToRun: true         # has been reset?
-      # is the model valid?
+      modelIsRunning: false
       modelIsRunnable: @_checkModelIsRunnable()
       graphHasCollector: @_checkForCollectors()
       isRecording: false            # sending data to codap?
@@ -63,15 +61,14 @@ SimulationStore   = Reflux.createStore
 
   onExpandSimulationPanel: ->
     @settings.simulationPanelExpanded = true
-    @settings.modelReadyToRun = true
     @settings.modelIsRunning = true
     SimulationActions.resetSimulation.trigger()
     @notifyChange()
 
   onCollapseSimulationPanel: ->
     @settings.simulationPanelExpanded = false
-    @settings.modelReadyToRun = false
     @settings.modelIsRunning = false
+    @_stopRecording()
     @notifyChange()
 
   onGraphChanged: (data)->
@@ -108,7 +105,7 @@ SimulationStore   = Reflux.createStore
       TimeUnits.defaultUnit # "STEPS" when not specified or not running time interval
 
   _runSimulation: (duration=1)->
-    if @settings.modelIsRunnable and @settings.modelReadyToRun
+    if @settings.modelIsRunnable
       # graph-store listens and will reset the simulation when
       # it is run to clear pre-saved data after first load
       @settings.modelIsRunning = true
@@ -150,7 +147,6 @@ SimulationStore   = Reflux.createStore
 
   onSimulationEnded: ->
     @settings.modelIsRunning = false
-    @settings.modelReadyToRun = true
     @notifyChange()
 
   _startRecording: ->


### PR DESCRIPTION

These commits address state bugs change in the simulation panel.

* should update the recording buttons in the simulation panel when the diagram starts using collectors.
* should stop recording when the diagram gets a collector.
* should stop recording when the simulation panel is closed.

If you have a second to review @sfentress 

Thanks!