### PR TITLE
Gray mini graphs and slider bars when not recording.

### DIFF
--- a/src/code/models/node.coffee
+++ b/src/code/models/node.coffee
@@ -42,7 +42,7 @@ module.exports = class Node extends GraphPrimitive
     @_max = nodeSpec.max ? SEMIQUANT_MAX
     @_initialValue = nodeSpec.initialValue ? 50
 
-    @color ?= Colors[0].value
+    @color ?= Colors.choices[0].value
 
     @isInCycle = false      # we always initalize with no links, so we can't be in cycle
 

--- a/src/code/utils/colors.coffee
+++ b/src/code/utils/colors.coffee
@@ -1,12 +1,25 @@
 tr = require './translate'
-module.exports =
-  [
+
+colors =
+  yellow:
     name: tr("~COLOR.YELLOW")
     value: "#f7be33"
-  ,
+  darkBlue:
     name: tr("~COLOR.DARK_BLUE")
     value: "#105262"
-  ,
+  medBlue:
     name: tr("~COLOR.MED_BLUE")
     value: "#72c0cc"
-  ]
+  lightGray:
+    name: tr("~COLOR.LIGHT_GRAY")
+    value: "#aaa"
+  darkGray:
+    name: tr("~COLOR.DARK_GRAY")
+    value: "#444"
+  data:
+    name: tr("~COLOR.DATA")
+    value: "#e99373"
+
+module.exports =
+  colors: colors
+  choices: [colors.yellow, colors.darkBlue, colors.medBlue]

--- a/src/code/utils/lang/us-en.coffee
+++ b/src/code/utils/lang/us-en.coffee
@@ -111,6 +111,9 @@ module.exports =
   "~COLOR.DARK_BLUE": "Dark Blue"
   "~COLOR.LIGHT_BLUE": "Light Blue"
   "~COLOR.MED_BLUE": "Blue"
+  "~COLOR.DARK_GRAY": "Dark Gray"
+  "~COLOR.LIGHT_GRAY": "Light Gray"
+  "~COLOR.DATA": "Codap Orange"
 
   # google-file-interface
   "~FILE.CHECKING_AUTH": "Checking authorization..."

--- a/src/code/views/color-picker-view.coffee
+++ b/src/code/views/color-picker-view.coffee
@@ -1,6 +1,6 @@
 {div} = React.DOM
 tr = require '../utils/translate'
-Colors = require '../utils/colors'
+Color = require '../utils/colors'
 
 ColorChoice = React.createFactory React.createClass
   displayName: 'ColorChoice'
@@ -42,6 +42,6 @@ module.exports = React.createClass
 
   render: ->
     (div {className: @className(), onClick: @toggleOpen},
-      for color in Colors
+      for color in Color.choices
         (ColorChoice {key: color.name, color: color, selected: @props.selected, onChange: @select})
     )

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -1,6 +1,7 @@
 Node             = React.createFactory require './node-view'
 NodeModel        = require '../models/node'
 Importer         = require '../utils/importer'
+Color            = require '../utils/colors'
 DiagramToolkit   = require '../utils/js-plumb-diagram-toolkit'
 dropImageHandler = require '../utils/drop-image-handler'
 tr               = require '../utils/translate'
@@ -250,12 +251,17 @@ module.exports = React.createClass
     @props.selectionManager.clearSelection()
 
   render: ->
+    dataColor = Color.colors.lightGray.value
+    if @state.isRecording
+      dataColor = Color.colors.data.value
+
     (div {className: "graph-view #{if @state.canDrop then 'can-drop' else ''}", ref: 'linkView', onDragOver: @onDragOver, onDrop: @onDrop, onDragLeave: @onDragLeave},
       (div {className: 'container', ref: 'container', onClick: @onContainerClicked},
         for node in @state.nodes
           (Node {
             key: node.key
             data: node
+            dataColor: dataColor
             selected: @state.selectedNode is node
             simulating: @state.simulationPanelExpanded
             running: @state.modelIsRunning

--- a/src/code/views/node-svg-graph-view.coffee
+++ b/src/code/views/node-svg-graph-view.coffee
@@ -13,6 +13,7 @@ module.exports = NodeSvgGraphView = React.createClass
     min: 0
     max: 100
     data: []
+    color: '#aaa'
 
   invertPoint: (point) ->
     {x: @props.width - point.x, y: @props.height - point.y}
@@ -50,7 +51,7 @@ module.exports = NodeSvgGraphView = React.createClass
 
   renderLineData: ->
     data = @pointsToPath(@getPathPoints())
-    (path {d: data, strokeWidth: @props.strokeWidth, stroke: "#e99373", fill: "none"})
+    (path {d: data, strokeWidth: @props.strokeWidth, stroke: @props.color, fill: "none"})
 
   render: ->
     (div {},

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -110,6 +110,7 @@ module.exports = NodeView = React.createClass
     selected: false
     simulating: false
     value: null
+    dataColor: "#aaa"
     data:
       title: "foo"
       x: 10
@@ -196,6 +197,7 @@ module.exports = NodeView = React.createClass
       enabled: enabled
       onSliderDragStart: @handleSliderDragStart
       onSliderDragEnd: @handleSliderDragEnd
+      color: @props.dataColor
     )
 
   handleGraphClick: (attributeName) ->
@@ -230,6 +232,7 @@ module.exports = NodeView = React.createClass
         min: @props.data.min
         max: @props.data.max
         data: @props.data.frames
+        color: @props.dataColor
       })
     else
       (SquareImage {

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -178,9 +178,8 @@ module.exports = NodeView = React.createClass
     @setState ignoreDrag: false
 
   renderSliderView: ->
-    enabled = not @props.running or @props.data.canEditValueWhileRunning()
     showHandle = @props.data.canEditInitialValue()
-    value = @props.data.currentValue or @props.data.initialValue
+    value = @props.data.currentValue ? @props.data.initialValue
 
     (SliderView
       orientation: "vertical"
@@ -194,7 +193,6 @@ module.exports = NodeView = React.createClass
       displaySemiQuant: @props.data.valueDefinedSemiQuantitatively
       max: @props.data.max
       min: @props.data.min
-      enabled: enabled
       onSliderDragStart: @handleSliderDragStart
       onSliderDragEnd: @handleSliderDragEnd
       color: @props.dataColor

--- a/src/code/views/value-slider-view.coffee
+++ b/src/code/views/value-slider-view.coffee
@@ -41,6 +41,7 @@ ValueSlider = React.createClass
     displaySemiQuant: false
     enabled: true
     orientation: "horizontal"
+    color: "gray"
     filled: false
     onValueChange: (v) ->
       log.info "new value #{v}"
@@ -282,21 +283,21 @@ ValueSlider = React.createClass
     if filled then inset += 1
     if orientation is 'horizontal'
       (g {},
-        (path {d:"M#{inset} #{center} l #{width - (inset*2)} 0", className:"slider-line", stroke:"blue"})
-        if not filled
+        (path {d:"M#{inset} #{center} l #{@props.width - (inset*2)} 0", className:"slider-line", stroke:"#ccc"})
+        if not @props.filled
           (g {},
-            (circle {cx:circleRadius, cy:center, r:circleRadius, className:"slider-shape", stroke:"blue"})
-            (circle {cx:width - circleRadius, cy:center, r:circleRadius, className:"slider-shape"})
+            (circle {cx:circleRadius, cy:center, r:circleRadius, className:"slider-shape", stroke:"#ccc"})
+            (circle {cx:@props.width - circleRadius, cy:center, r:circleRadius, className:"slider-shape"})
           )
         @renderTicks()
       )
     else
       (g {},
-        (path {d:"M#{center} #{inset} l 0 #{height - (inset*2)}", className:"slider-line", stroke:"blue"})
-        if not filled
+        (path {d:"M#{center} #{inset} l 0 #{@props.height - (inset*2)}", className:"slider-line", stroke:"#ccc"})
+        if not @props.filled
           (g {},
-            (circle {cx:center, cy:circleRadius, r:circleRadius, className:"slider-shape", stroke:"blue"})
-            (circle {cx:center, cy:height - circleRadius, r:circleRadius, className:"slider-shape"})
+            (circle {cx:center, cy:circleRadius, r:circleRadius, className:"slider-shape", stroke:"#ccc"})
+            (circle {cx:center, cy:@props.height - circleRadius, r:circleRadius, className:"slider-shape"})
           )
         @renderTicks()
       )
@@ -305,16 +306,28 @@ ValueSlider = React.createClass
     { orientation, width, height } = @props
     center = @thickness() / 2
     inset = circleRadius + 1
-    if orientation is 'horizontal'
-      (path {d:"M#{inset} #{center} l #{width - (inset*2)} 0", className:"slider-line fill-line"})
+    if @props.horizontal
+      (path
+        d: "M#{inset} #{center} l #{@props.width - (inset*2)} 0"
+        className: "slider-line fill-line"
+        stroke: @props.color
+      )
     else
       totalHeight = height - (inset * 2)
       top = inset + (totalHeight * (1 - @sliderLocation()))
       height = totalHeight-top
       if height > 0
         (g {},
-          (path {d:"M#{center} #{top} l 0 #{height}", className:"slider-line fill-line"}) # flat top
-          (path {d:"M#{center} #{totalHeight} l 0 1", className:"slider-line fill-line cap"})      # rounded bottom
+          (path # flat top
+            d: "M#{center} #{top} l 0 #{height}"
+            className: "slider-line fill-line"
+            stroke: @props.color
+          )
+          (path # rounded bottom
+            d: "M#{center} #{totalHeight} l 0 1"
+            className: "slider-line fill-line cap"
+            stroke: @props.color
+          )
         )
 
   render: ->

--- a/src/code/views/value-slider-view.coffee
+++ b/src/code/views/value-slider-view.coffee
@@ -283,34 +283,34 @@ ValueSlider = React.createClass
     if filled then inset += 1
     if orientation is 'horizontal'
       (g {},
-        (path {d:"M#{inset} #{center} l #{@props.width - (inset*2)} 0", className:"slider-line", stroke:"#ccc"})
-        if not @props.filled
+        (path {d:"M#{inset} #{center} l #{width - (inset*2)} 0", className:"slider-line", stroke:"#ccc"})
+        if not filled
           (g {},
             (circle {cx:circleRadius, cy:center, r:circleRadius, className:"slider-shape", stroke:"#ccc"})
-            (circle {cx:@props.width - circleRadius, cy:center, r:circleRadius, className:"slider-shape"})
+            (circle {cx:width - circleRadius, cy:center, r:circleRadius, className:"slider-shape"})
           )
         @renderTicks()
       )
     else
       (g {},
-        (path {d:"M#{center} #{inset} l 0 #{@props.height - (inset*2)}", className:"slider-line", stroke:"#ccc"})
-        if not @props.filled
+        (path {d:"M#{center} #{inset} l 0 #{height - (inset*2)}", className:"slider-line", stroke:"#ccc"})
+        if not filled
           (g {},
             (circle {cx:center, cy:circleRadius, r:circleRadius, className:"slider-shape", stroke:"#ccc"})
-            (circle {cx:center, cy:@props.height - circleRadius, r:circleRadius, className:"slider-shape"})
+            (circle {cx:center, cy:height - circleRadius, r:circleRadius, className:"slider-shape"})
           )
         @renderTicks()
       )
 
   renderFill: ->
-    { orientation, width, height } = @props
+    { orientation, color, width, height } = @props
     center = @thickness() / 2
     inset = circleRadius + 1
-    if @props.horizontal
+    if orientation is 'horizontal'
       (path
-        d: "M#{inset} #{center} l #{@props.width - (inset*2)} 0"
+        d: "M#{inset} #{center} l #{width - (inset*2)} 0"
         className: "slider-line fill-line"
-        stroke: @props.color
+        stroke: color
       )
     else
       totalHeight = height - (inset * 2)
@@ -321,12 +321,12 @@ ValueSlider = React.createClass
           (path # flat top
             d: "M#{center} #{top} l 0 #{height}"
             className: "slider-line fill-line"
-            stroke: @props.color
+            stroke: color
           )
           (path # rounded bottom
             d: "M#{center} #{totalHeight} l 0 1"
             className: "slider-line fill-line cap"
-            stroke: @props.color
+            stroke: color
           )
         )
 

--- a/src/code/views/value-slider-view.coffee
+++ b/src/code/views/value-slider-view.coffee
@@ -39,7 +39,6 @@ ValueSlider = React.createClass
     minLabel: null
     maxLabel: null
     displaySemiQuant: false
-    enabled: true
     orientation: "horizontal"
     color: "gray"
     filled: false
@@ -331,7 +330,7 @@ ValueSlider = React.createClass
         )
 
   render: ->
-    { orientation, width, height, enabled, filled, showHandle, showLabels } = @props
+    { orientation, width, height, filled, showHandle, showLabels } = @props
     horizontal = orientation is 'horizontal'
     lengendHeight = 9 + 4.5
     style =
@@ -341,7 +340,6 @@ ValueSlider = React.createClass
       height: height + (if horizontal then lengendHeight else 0)
     classNames = "value-slider"
     if not horizontal then classNames += " vertical"
-    if not enabled then classNames += " disabled"
     if filled then classNames += " filled"
     (div {
       className: classNames

--- a/src/stylus/components/value-slider.styl
+++ b/src/stylus/components/value-slider.styl
@@ -73,12 +73,6 @@ orange-fill = #e99373
       display flex
       flex-direction column
 
-  &.disabled
-    .slider-line
-      stroke #CCC
-    .slider-shape
-      fill #CCC
-
     .value-slider-handle
       cursor not-allowed
       background-color #DDD

--- a/src/stylus/components/value-slider.styl
+++ b/src/stylus/components/value-slider.styl
@@ -5,7 +5,6 @@ orange-fill = #e99373
   position relative
   margin 1em
   .slider-line
-    stroke black
     fill none
 
   .slider-shape
@@ -103,13 +102,11 @@ orange-fill = #e99373
       border-bottom 3px solid transparent
 
     .slider-line
-      stroke gray-fill
       fill none
       stroke-width 8
       stroke-linecap round
 
       &.fill-line
-        stroke orange-fill
         stroke-linecap butt
 
         &.cap


### PR DESCRIPTION
This PR lets the data colors for the mini-graph and the sliders be adjusted dynamically.

When the simulation is being recorded, the data is displayed in CODAP orange.

Otherwise is gray.

@sfentress please review when you get a chance.
