### PR TITLE
Explicit experiment button

### DIFF
--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -30,9 +30,8 @@ module.exports = class CodapConnect
     @sendThrottleMs = 300
 
     # Create a new case in these instances:
-    SimulationStore.actions.resetSimulation.listen         @_openNewCase.bind(@)
-    SimulationStore.actions.recordStream.listen            @_openNewCase.bind(@)
-    SimulationStore.actions.recordPeriod.listen            @_openNewCase.bind(@)
+    SimulationStore.actions.resetSimulation.listen    @_openNewCase.bind(@)
+    SimulationStore.actions.createExperiment.listen   @_openNewCase.bind(@)
 
     SimulationStore.actions.recordingFramesCreated.listen  @_addData.bind(@)
 
@@ -109,7 +108,7 @@ module.exports = class CodapConnect
               },
               attrs: [
                   {
-                    name: tr '~CODAP.SIMULATION.RUN'
+                    name: tr '~CODAP.SIMULATION.EXPERIMENT'
                     formula: 'caseIndex'
                     type: 'nominal'
                   }

--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -109,16 +109,8 @@ module.exports = class CodapConnect
               attrs: [
                   {
                     name: tr '~CODAP.SIMULATION.EXPERIMENT'
-                    formula: 'caseIndex'
-                    type: 'nominal'
+                    type: 'numeric'
                   }
-#                  {
-#                    name: tr '~CODAP.SIMULATION.STEPS'
-#                    type: 'numeric'
-#                    formula: 'count()'
-#                    description: tr '~CODAP.SIMULATION.STEPS.DESCRIPTION'
-#                    precision: 0
-#                  }
                 ]
               },
               {
@@ -136,14 +128,16 @@ module.exports = class CodapConnect
         , @initGameHandler
 
   _openNewCase: ->
+    caseData = {}
+    caseData[tr '~CODAP.SIMULATION.EXPERIMENT'] = SimulationStore.store.settings.experimentNumber
     @currentCaseID = null
-
     @_createCollection()
-
     @codapPhone.call
       action: 'create',
       resource: 'collection[Simulation].case',
-      values: [ {} ]
+      values: {
+        values: caseData
+      }
     , (result) =>
       if result?.success
         @currentCaseID = result.values[0].id

--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -127,6 +127,7 @@ module.exports = class CodapConnect
         , @initGameHandler
 
   _openNewCase: ->
+    @caseOpened = true
     caseData = {}
     caseData[tr '~CODAP.SIMULATION.EXPERIMENT'] = SimulationStore.store.settings.experimentNumber
     @currentCaseID = null
@@ -145,7 +146,6 @@ module.exports = class CodapConnect
         [collectionResponse, caseResponse] = result
 
         if caseResponse.success
-          @caseOpened = true
           @currentCaseID = caseResponse.values[0].id
           @_flushQueue()
           if not @standaloneMode

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -24,7 +24,7 @@ GraphStore  = Reflux.createStore
     @selectionManager   = new SelectionManager()
     PaletteDeleteStore.store.listen @paletteDelete.bind(@)
 
-    SimulationStore.actions.resetSimulation.listen         @resetSimulation.bind(@)
+    SimulationStore.actions.createExperiment.listen        @resetSimulation.bind(@)
     SimulationStore.actions.setDuration.listen             @resetSimulation.bind(@)
     SimulationStore.actions.createExperiment.listen        @resetSimulation.bind(@)
     SimulationStore.actions.simulationFramesCreated.listen @updateSimulationData.bind(@)

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -26,6 +26,7 @@ GraphStore  = Reflux.createStore
 
     SimulationStore.actions.resetSimulation.listen         @resetSimulation.bind(@)
     SimulationStore.actions.setDuration.listen             @resetSimulation.bind(@)
+    SimulationStore.actions.createExperiment.listen        @resetSimulation.bind(@)
     SimulationStore.actions.simulationFramesCreated.listen @updateSimulationData.bind(@)
 
     @codapStandaloneMode = false

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -23,6 +23,7 @@ SimulationActions = Reflux.createActions(
     "stopRecording"
     "recordingDidStart"
     "recordingDidEnd"
+    "createExperiment"
   ]
 )
 SimulationActions.runSimulation = Reflux.createAction({sync: true})
@@ -45,6 +46,7 @@ SimulationStore   = Reflux.createStore
     @settings =
       simulationPanelExpanded: false
       duration: defaultDuration
+      experimentNumber: 1
       stepUnits: defaultUnit
       stepUnitsName: unitName
       timeUnitOptions: timeUnitOptions
@@ -171,6 +173,11 @@ SimulationStore   = Reflux.createStore
 
   onResetSimulation: ->
     @experimentFrameIndex = 0
+
+  onCreateExperiment: ->
+    @experimentFrameIndex = 0
+    @settings.experimentNumber++
+    @notifyChange()
 
   onStopRecording: ->
     @_stopRecording()

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -69,6 +69,7 @@ SimulationStore   = Reflux.createStore
   onExpandSimulationPanel: ->
     @settings.simulationPanelExpanded = true
     @settings.modelIsRunning = true
+    @_updateModelIsRunnable()
     @notifyChange()
 
   onCollapseSimulationPanel: ->

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -9,7 +9,7 @@ SimulationActions = Reflux.createActions(
   [
     "expandSimulationPanel"
     "collapseSimulationPanel"
-    "resetSimulation"
+    "runSimulation"
     "setDuration"
     "setStepUnits"
     "simulationStarted"
@@ -69,7 +69,6 @@ SimulationStore   = Reflux.createStore
   onExpandSimulationPanel: ->
     @settings.simulationPanelExpanded = true
     @settings.modelIsRunning = true
-    SimulationActions.resetSimulation.trigger()
     @notifyChange()
 
   onCollapseSimulationPanel: ->
@@ -170,9 +169,6 @@ SimulationStore   = Reflux.createStore
     @settings.isRecordingStream = false
     @settings.isRecordingPeriod = false
     SimulationActions.recordingDidEnd()
-
-  onResetSimulation: ->
-    @experimentFrameIndex = 0
 
   onCreateExperiment: ->
     @experimentFrameIndex = 0

--- a/src/code/utils/lang/us-en.coffee
+++ b/src/code/utils/lang/us-en.coffee
@@ -155,6 +155,7 @@ module.exports =
   "~RELATIONSHIP.NO_RELATION": "No relation defined"
 
   "~CODAP.SIMULATION.RUN": "run"
+  "~CODAP.SIMULATION.EXPERIMENT": "Exp.#"
   "~CODAP.SIMULATION.STEPS": "steps"
   "~CODAP.SIMULATION.STEPS.DESCRIPTION": "Number of steps in the simulation."
 

--- a/src/code/views/experiment-panel-view.coffee
+++ b/src/code/views/experiment-panel-view.coffee
@@ -11,7 +11,8 @@ module.exports = React.createClass
 
 
   increment: ->
-    SimulationStore.actions.createExperiment()
+    unless @props.disabled
+      SimulationStore.actions.createExperiment()
 
   renderLabel: ->
     experimentLabel = "Experiment #"

--- a/src/code/views/experiment-view.coffee
+++ b/src/code/views/experiment-view.coffee
@@ -11,25 +11,23 @@ module.exports = React.createClass
 
 
   increment: ->
-    lastCount = @state.count || 1
-    @setState
-      count: lastCount + 1
+    SimulationStore.actions.createExperiment()
 
   renderLabel: ->
     experimentLabel = "Experiment #"
     (span {className: "experiment-label"}, experimentLabel)
 
   renderCounter: ->
-    count = @state.count || 211
-    (div {className: "experiment-counter"},
+    count = @state.experimentNumber || 211
+    (div {className: "experiment-counter", onClick: @increment },
       (div {className: "count"}, count)
-      (div {className: "increment", onClick: @increment }, "+")
+      (div {className: "increment"}, "+")
     )
 
   render: ->
-    classes = ["experiment-panel","disabled"]
+    classes = ["experiment-panel"]
     if @props.disabled
-      classes.append('disabled')
+      classes.push('disabled')
     (div {className: classes.join(" ") },
       @renderLabel()
       @renderCounter()

--- a/src/code/views/experiment-view.coffee
+++ b/src/code/views/experiment-view.coffee
@@ -1,0 +1,36 @@
+SimulationStore = require '../stores/simulation-store'
+tr              = require '../utils/translate'
+
+{div, span, i, input}  = React.DOM
+
+module.exports = React.createClass
+
+  displayName: 'ExperimentView'
+
+  mixins: [ SimulationStore.mixin ]
+
+
+  increment: ->
+    lastCount = @state.count || 1
+    @setState
+      count: lastCount + 1
+
+  renderLabel: ->
+    experimentLabel = "Experiment #"
+    (span {className: "experiment-label"}, experimentLabel)
+
+  renderCounter: ->
+    count = @state.count || 211
+    (div {className: "experiment-counter"},
+      (div {className: "count"}, count)
+      (div {className: "increment", onClick: @increment }, "+")
+    )
+
+  render: ->
+    classes = ["experiment-panel","disabled"]
+    if @props.disabled
+      classes.append('disabled')
+    (div {className: classes.join(" ") },
+      @renderLabel()
+      @renderCounter()
+    )

--- a/src/code/views/simulation-run-panel-view.coffee
+++ b/src/code/views/simulation-run-panel-view.coffee
@@ -35,7 +35,7 @@ module.exports = React.createClass
     disabled = (@state.isRecording && !@state.isRecordingOne) || !@state.modelIsRunnable
     (div {className: wrapperClasses},
       (div {className: "vertical" },
-        (ExperimentPanel {})
+        (ExperimentPanel {disabled: disabled})
         if @state.graphHasCollector
           @renderRecordForCollectors()
         else

--- a/src/code/views/simulation-run-panel-view.coffee
+++ b/src/code/views/simulation-run-panel-view.coffee
@@ -2,6 +2,7 @@ SimulationStore = require '../stores/simulation-store'
 tr              = require '../utils/translate'
 RecordButton    = React.createFactory require './record-button-view'
 Dropdown        = React.createFactory require './dropdown-view'
+ExperimentPanel = React.createFactory require './experiment-view'
 
 {div, span, i, input}  = React.DOM
 
@@ -32,26 +33,30 @@ module.exports = React.createClass
     wrapperClasses = "buttons flow"
     if !@state.simulationPanelExpanded then wrapperClasses += " closed"
     disabled = (@state.isRecording && !@state.isRecordingOne) || !@state.modelIsRunnable
-    if @state.graphHasCollector
-      (div {className: wrapperClasses},
-        @renderRecordForCollectors()
-      )
-    else
-      (div {className: wrapperClasses},
-        (RecordButton
-          onClick: SimulationStore.actions.recordOne
-          disabled: disabled
-          ,
+    (div {className: wrapperClasses},
+      (div {className: "vertical" },
+        (ExperimentPanel {})
+        if @state.graphHasCollector
+          @renderRecordForCollectors()
+        else
           (div {className: "horizontal"},
-            (span {}, tr "~DOCUMENT.ACTIONS.DATA.RECORD-1")
-            (i className: "icon-codap-camera")
+            (RecordButton
+              onClick: SimulationStore.actions.recordOne
+              disabled: disabled
+              ,
+              (div {className: "horizontal"},
+                (span {}, tr "~DOCUMENT.ACTIONS.DATA.RECORD-1")
+                (i className: "icon-codap-camera")
+              )
+              (div {className: "horizontal"},
+                (span {}, tr "~DOCUMENT.ACTIONS.DATA.POINT")
+              )
+            )
+            @renderRecordStreamButton()
           )
-          (div {className: "horizontal"},
-            (span {}, tr "~DOCUMENT.ACTIONS.DATA.POINT")
-          )
-        )
-        @renderRecordStreamButton()
       )
+    )
+
 
   renderRecordForCollectors: ->
     recordAction = SimulationStore.actions.recordPeriod

--- a/src/code/views/simulation-run-panel-view.coffee
+++ b/src/code/views/simulation-run-panel-view.coffee
@@ -2,7 +2,7 @@ SimulationStore = require '../stores/simulation-store'
 tr              = require '../utils/translate'
 RecordButton    = React.createFactory require './record-button-view'
 Dropdown        = React.createFactory require './dropdown-view'
-ExperimentPanel = React.createFactory require './experiment-view'
+ExperimentPanel = React.createFactory require './experiment-panel-view'
 
 {div, span, i, input}  = React.DOM
 
@@ -33,9 +33,10 @@ module.exports = React.createClass
     wrapperClasses = "buttons flow"
     if !@state.simulationPanelExpanded then wrapperClasses += " closed"
     disabled = (@state.isRecording && !@state.isRecordingOne) || !@state.modelIsRunnable
+    experimentDisabled = !@state.modelIsRunnable || @state.isRecordingPeriod
     (div {className: wrapperClasses},
       (div {className: "vertical" },
-        (ExperimentPanel {disabled: disabled})
+        (ExperimentPanel {disabled: experimentDisabled})
         if @state.graphHasCollector
           @renderRecordForCollectors()
         else

--- a/src/stylus/components/document-actions-view.styl
+++ b/src/stylus/components/document-actions-view.styl
@@ -1,5 +1,5 @@
 .document-actions
-  enable-flex(justify:flex-end)
+  enable-flex(justify: flex-end, alignItems: center)
   width 100%
   .misc-actions
     padding-left 22px

--- a/src/stylus/components/experiment-panel-view.styl
+++ b/src/stylus/components/experiment-panel-view.styl
@@ -1,0 +1,45 @@
+.experiment-panel
+  min-width 160px
+  margin 0px
+  padding 0px
+  line-height 1em
+  font-size 10pt
+  color #222
+  align-self center
+  &.disabled
+    color button-disabled
+    .count
+      border 1px solid button-disabled
+    .increment
+      border 1px solid button-disabled
+      cursor default
+      &:hover
+        background white
+
+  div, span
+    display inline-block
+
+  span
+    margin-right 0.5em
+
+  .count 
+    padding 2px
+    border 1px solid #aaa
+    width 2em
+    text-align right
+    background white
+    border-radius 2px 0px 0px 2px
+    font-weight normal
+
+  .increment 
+    padding 2px
+    border 1px solid #aaa
+    border-left none
+    font-weight bold
+    width 1.5em
+    text-align center
+    cursor pointer
+    background white
+    border-radius 0px 2px 2px 0px
+    &:hover
+          background #ddd

--- a/src/stylus/components/experiment-panel-view.styl
+++ b/src/stylus/components/experiment-panel-view.styl
@@ -4,17 +4,21 @@
   padding 0px
   line-height 1em
   font-size 10pt
-  color #222
+  color #444
   align-self center
+  user-select none
   &.disabled
     color button-disabled
+    .experiment-counter
+      cursor default
+      &:hover
+        background white
+
     .count
       border 1px solid button-disabled
     .increment
       border 1px solid button-disabled
-      cursor default
-      &:hover
-        background white
+
 
   div, span
     display inline-block
@@ -22,12 +26,20 @@
   span
     margin-right 0.5em
 
+  .experiment-counter
+    cursor pointer
+    div
+      background #fafafa
+    &:hover
+      div
+        background white
+        border-color #666
+
   .count 
     padding 2px
     border 1px solid #aaa
     width 2em
     text-align right
-    background white
     border-radius 2px 0px 0px 2px
     font-weight normal
 
@@ -38,8 +50,4 @@
     font-weight bold
     width 1.5em
     text-align center
-    cursor pointer
-    background white
     border-radius 0px 2px 2px 0px
-    &:hover
-          background #ddd

--- a/src/stylus/components/experiment-panel-view.styl
+++ b/src/stylus/components/experiment-panel-view.styl
@@ -12,7 +12,9 @@
     .experiment-counter
       cursor default
       &:hover
-        background white
+        div
+          background #fafafa
+          border-color inherit
 
     .count
       border 1px solid button-disabled

--- a/src/stylus/components/simulation-run-panel.styl
+++ b/src/stylus/components/simulation-run-panel.styl
@@ -14,11 +14,12 @@
 .simulation-run-panel, .simulation-run-panel>.flow
   display flex
   justify-content flex-end
+  align-items center
   input[type="number"]
     margin-left 0.5em
   .toggle-title
     position: relative
-    left: 34px
+    left: 24px
     label-font()
     -webkit-transform rotate(-90deg)
     transform rotate(-90deg)

--- a/test/simulation-test.coffee
+++ b/test/simulation-test.coffee
@@ -289,6 +289,7 @@ describe "The SimulationStore, with a network in the GraphStore", ->
       asyncListenTest done, SimulationActions.recordingDidStart, (nodeNames) ->
         nodeNames.should.eql ["A", "B"]
 
+      SimulationActions.createExperiment()
       SimulationActions.recordPeriod()
 
     it "should call simulationFramesCreated with all the step values", (done) ->
@@ -305,7 +306,7 @@ describe "The SimulationStore, with a network in the GraphStore", ->
           frame9.time.should.equal 10
           frame9.nodes.should.eql [ { title: 'A', value: 10 }, { title: 'B', value: 1 } ]
 
-      SimulationActions.resetSimulation()
+      SimulationActions.createExperiment()
       SimulationActions.recordPeriod()
 
   describe "for a slow simulation for 3 iterations", ->


### PR DESCRIPTION
Adds a button and counter at the top of the simulation panel that lets a student specify the start of a new experiment.

[PT story for expiriments](https://www.pivotaltracker.com/story/show/134408545)

[PT story for not creating cases until record pushed](https://www.pivotaltracker.com/story/show/135145637)


@sfentress I think this is ready for a review if you get a chance.