### PR TITLE
Run simulation synchronously

### DIFF
--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -9,7 +9,6 @@ SimulationActions = Reflux.createActions(
   [
     "expandSimulationPanel"
     "collapseSimulationPanel"
-    "runSimulation"
     "resetSimulation"
     "setDuration"
     "setStepUnits"
@@ -26,6 +25,7 @@ SimulationActions = Reflux.createActions(
     "recordingDidEnd"
   ]
 )
+SimulationActions.runSimulation = Reflux.createAction({sync: true})
 
 SimulationStore   = Reflux.createStore
   listenables: [

--- a/src/code/views/value-slider-view.coffee
+++ b/src/code/views/value-slider-view.coffee
@@ -132,7 +132,8 @@ ValueSlider = React.createClass
     return unless onValueChange?
 
     value = @position(e)
-    onValueChange(value)
+    unless value is @props.value
+      onValueChange(value)
 
   handleJumpAndDrag: (e) ->
     @handleDrag(e)


### PR DESCRIPTION
This eliminates the issue where the simulation runs multiple times with the same value, leading to straight lines in the graphs.

It also seems to have a positive effect on the feeling of "lag" when moving a slider, although I'm still trying to profile the speed accurately.