### PR TITLE
Use diffing to decide when to draw jsPlumb, run simulation. Speed up model.

### DIFF
--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -386,17 +386,22 @@ GraphStore  = Reflux.createStore
   toJsonString: (palette) ->
     JSON.stringify @serialize palette
 
+  getGraphState: ->
+    nodes = @getNodes()
+    links = @getLinks()
+
+    {
+      nodes
+      links
+    }
+
   updateListeners: ->
-    data =
-      nodes: @getNodes()
-      links: @getLinks()
-    GraphActions.graphChanged.trigger(data)
+    GraphActions.graphChanged.trigger(@getGraphState())
 
 
 mixin =
   getInitialState: ->
-    nodes: GraphStore.getNodes()
-    links: GraphStore.getLinks()
+    GraphStore.getGraphState()
 
   componentDidMount: ->
     @unsubscribe = GraphActions.graphChanged.listen @onGraphChanged
@@ -404,10 +409,9 @@ mixin =
   componentWillUnmount: ->
     @unsubscribe()
 
-  onGraphChanged: (status) ->
-    @setState
-      nodes: status.nodes
-      links: status.links
+  onGraphChanged: (state) ->
+    @setState state
+
     # TODO: not this:
     @diagramToolkit?.repaint()
 

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -30,6 +30,8 @@ GraphStore  = Reflux.createStore
 
     @codapStandaloneMode = false
 
+    @lastRunModel = ""   # string description of the model last time we ran simulation
+
   resetSimulation: ->
     for node in @getNodes()
       node.frames = []
@@ -119,7 +121,6 @@ GraphStore  = Reflux.createStore
     @undoRedoManager.createAndExecuteCommand 'addLink',
       execute: => @_addLink link
       undo: => @_removeLink link
-    SimulationStore.actions.runSimulation()
 
   _addLink: (link) ->
     unless link.sourceNode is link.targetNode or @hasLink link
@@ -135,7 +136,6 @@ GraphStore  = Reflux.createStore
     @undoRedoManager.createAndExecuteCommand 'removeLink',
       execute: => @_removeLink link
       undo: => @_addLink link
-    SimulationStore.actions.runSimulation()
 
   _removeLink: (link) ->
     delete @linkKeys[link.terminalKey()]
@@ -239,9 +239,6 @@ GraphStore  = Reflux.createStore
           execute: => @_changeNode node, data
           undo: => @_changeNode node, originalData
 
-      if data.isAccumulator? and nodeChanged
-        SimulationStore.actions.runSimulation()
-
   _changeNode: (node, data) ->
     log.info "Change for #{node.title}"
     for key in NodeModel.fields
@@ -288,7 +285,6 @@ GraphStore  = Reflux.createStore
       @undoRedoManager.createAndExecuteCommand 'changeLink',
         execute: => @_changeLink link,  changes
         undo: => @_changeLink link, originalData
-    SimulationStore.actions.runSimulation()
 
   _maybeChangeSelectedItem: (item) ->
     # TODO: This is kind of hacky:
@@ -355,20 +351,30 @@ GraphStore  = Reflux.createStore
   #
   # links: link terminal locations, and link formula (for stroke style), plus number of nodes
   #         e.g. "10,20;1 * in;50,60|" for each link
+  # model: description of each link relationship and the values of its terminal nodes
+  #         e.g. "node-0:50;1 * in;node-1:50|" for each link
   #
   # We pass nodes and links so as not to calculate @getNodes and @getLinks redundantly.
   getDescription: (nodes, links) ->
     linkDescription = ""
+    modelDescription = ""
+
     _.each links, (link) ->
       return unless (source = link.sourceNode) and (target = link.targetNode)
       linkDescription += "#{source.x},#{source.y};"
       linkDescription += link.relation.formula + ";"
       linkDescription += "#{target.x},#{target.y}|"
 
+      if link.relation.isDefined
+        modelDescription += "#{source.key}:#{source.initialValue};"
+        modelDescription += link.relation.formula + ";"
+        modelDescription += "#{target.key}#{if target.isAccumulator then ':'+(target.value ? target.initialValue) else ''}|"
+
     linkDescription += nodes.length     # we need to redraw targets when new node is added
 
     return {
       links: linkDescription
+      model: modelDescription
     }
 
   loadData: (data) ->
@@ -420,7 +426,12 @@ GraphStore  = Reflux.createStore
     }
 
   updateListeners: ->
-    GraphActions.graphChanged.trigger(@getGraphState())
+    graphState = @getGraphState()
+    GraphActions.graphChanged.trigger(graphState)
+
+    if @lastRunModel != graphState.description.model
+      SimulationStore.actions.runSimulation()
+      @lastRunModel = graphState.description.model
 
 
 mixin =

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -111,9 +111,12 @@ module.exports = React.createClass
     canDrop: false
 
   componentDidUpdate: (prevProps, prevState) ->
-    if (prevState.description.links != @state.description.links) or (prevState.simulationPanelExpanded != @state.simulationPanelExpanded)
+    if (prevState.description.links != @state.description.links) or
+        (prevState.simulationPanelExpanded != @state.simulationPanelExpanded) or
+        @forceRedrawLinks
       @diagramToolkit?.clear?()
       @_updateToolkit()
+      @forceRedrawLinks = false
 
   handleEvent: (handler) ->
     if @ignoringEvents
@@ -136,7 +139,8 @@ module.exports = React.createClass
       GraphStore.store.removeNode node_event.nodeKey
 
   handleConnect: (info, evnt) ->
-    @handleEvent ->
+    @handleEvent =>
+      @forceRedrawLinks = true
       GraphStore.store.newLinkFromEvent info, evnt
 
   handleLinkClick: (connection, evnt) ->

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -110,10 +110,8 @@ module.exports = React.createClass
     editingLink: null
     canDrop: false
 
-  componentWillUpdate: ->
-    @diagramToolkit?.clear?()
-
   componentDidUpdate: ->
+    @diagramToolkit?.clear?()
     @_updateToolkit()
 
   handleEvent: (handler) ->

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -110,9 +110,10 @@ module.exports = React.createClass
     editingLink: null
     canDrop: false
 
-  componentDidUpdate: ->
-    @diagramToolkit?.clear?()
-    @_updateToolkit()
+  componentDidUpdate: (prevProps, prevState) ->
+    if (prevState.description.links != @state.description.links) or (prevState.simulationPanelExpanded != @state.simulationPanelExpanded)
+      @diagramToolkit?.clear?()
+      @_updateToolkit()
 
   handleEvent: (handler) ->
     if @ignoringEvents

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -145,7 +145,6 @@ module.exports = NodeView = React.createClass
 
   changeValue: (newValue) ->
     @props.graphStore.changeNodeWithKey(@props.nodeKey, {initialValue:newValue})
-    SimulationActions.runSimulation()
 
   changeTitle: (newTitle) ->
     @props.graphStore.startNodeEdit()

--- a/test/node-list-test.coffee
+++ b/test/node-list-test.coffee
@@ -371,10 +371,10 @@ describe "Graph Descriptions", ->
     )
 
     # A -> B+ -> C -x-> D
-    nodeA    = new Node({x: 10, y: 15})
-    nodeB    = new Node({x: 20, y: 25, isAccumulator: true})
-    nodeC    = new Node({x: 30, y: 35})
-    nodeD    = new Node({x: 40, y: 45})
+    nodeA    = new Node({x: 10, y: 15, initialValue: 10})
+    nodeB    = new Node({x: 20, y: 25, initialValue: 20, isAccumulator: true})
+    nodeC    = new Node({x: 30, y: 35, initialValue: 30})
+    nodeD    = new Node({x: 40, y: 45, initialValue: 40})
     formula  = "1 * in"
     linkA = makeLink(nodeA, nodeB, formula)
     linkB = makeLink(nodeB, nodeC, formula)
@@ -397,3 +397,8 @@ describe "Graph Descriptions", ->
     graphStore = GraphStore.store
     desc = graphStore.getDescription(graphStore.getNodes(), graphStore.getLinks())
     desc.links.should.equal "10,15;1 * in;20,25|20,25;1 * in;30,35|30,35;undefined;40,45|4"
+
+  it "should describe the model graph correctly", ->
+    graphStore = GraphStore.store
+    desc = graphStore.getDescription(graphStore.getNodes(), graphStore.getLinks())
+    desc.model.should.equal "Node-71:10;1 * in;Node-72:20|Node-72:20;1 * in;Node-73|"


### PR DESCRIPTION
This adds "model descriptions," which are easily-comparable reductions of the model state to help decide when to redraw jsPlumb, or rerun the model.

By not redrawing jsPlumb everytime we run a simulation step, we improve our running speed significantly.

https://www.pivotaltracker.com/story/show/134467689