### PR TITLE
Tweak z-indexes to render component correctly

### DIFF
--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -242,4 +242,4 @@ $node-design-height = 94px
     color rgba(0,110,200,1)
 
 .jsplumb-connector
-  z-index 4
+  z-index 0

--- a/src/stylus/components/top-node-palette.styl
+++ b/src/stylus/components/top-node-palette.styl
@@ -57,7 +57,7 @@ node-well-tab-height = 30px
   position absolute
   left 0px
   max-width node-well-width
-  z-index 1
+  z-index 3
   transition 0.2s
   .tab-wrapper
     width 100%


### PR DESCRIPTION
Just 2 small changes:
- set line's z-index to 0,
- render palette on the top (z-axis = 3)