### PR TITLE
Fix several codap related issues

### DIFF
--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -179,7 +179,6 @@ module.exports = class CodapConnect
 
 
   _sendSimulationData: ->
-
     # drain the queue synchronously. Re-add pending data in case of error.
     sampleData = @queue
     @queue = []
@@ -242,7 +241,7 @@ module.exports = class CodapConnect
     if @_shouldSend()
       @_sendSimulationData()
     else
-      setTimeout(@_sendSimulationData, @sendThrottleMs)
+      setTimeout(@_sendSimulationData.bind(@), @sendThrottleMs)
 
   createGraph: (yAttributeName)->
     @_createMissingDataAttributes()

--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -142,7 +142,7 @@ module.exports = class CodapConnect
     currentAttributes = _.sortBy(@_getSampleAttributes(), 'name')
     attributesKey = _.pluck(currentAttributes,'name').join("|")
     if @attributesKey == attributesKey
-      callback()
+      callback() if callback
     else
       doResolve = (listAttributeResponse) =>
         if listAttributeResponse.success
@@ -155,7 +155,7 @@ module.exports = class CodapConnect
           @codapPhone.call message, (response) =>
             if response.success
               @attributesKey = attributesKey
-              callback()
+              callback() if callback
             else
               log.info "Unable to update Attributes"
         else

--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -71,7 +71,9 @@ module.exports = class CodapConnect
       action: 'get',
       resource: 'dataContext[Sage Simulation]'
     , (ret) =>
-      if ret?.success
+      # ret==null is indication of timeout, not an indication that the data set
+      # doesn't exist.
+      if !ret or ret.success
         @initGameHandler ret
       else
         @_createDataContext()

--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -55,7 +55,7 @@ module.exports = class CodapConnect
         # We check for game state in either the frame (CODAP API 2.0) or the dataContext
         # (API 1.0). We ignore the dataContext if we find game state in the interactiveFrame
         state = frame?.values.savedState or
-                context?.values.contextStorage?.gameState
+                context?.values?.contextStorage?.gameState
 
         if state?
           @graphStore.deleteAll()

--- a/src/code/utils/colors.coffee
+++ b/src/code/utils/colors.coffee
@@ -13,6 +13,9 @@ colors =
   lightGray:
     name: tr("~COLOR.LIGHT_GRAY")
     value: "#aaa"
+  mediumGray:
+    name: tr("~COLOR.MED_GRAY")
+    value: "#787878"
   darkGray:
     name: tr("~COLOR.DARK_GRAY")
     value: "#444"

--- a/src/code/utils/importer.coffee
+++ b/src/code/utils/importer.coffee
@@ -9,6 +9,9 @@ module.exports = class MySystemImporter
 
   importData: (data) ->
     Migrations.update(data)
+    # increment last saved experiment number so that each session will
+    # create its own experiments, and not append a prior session's
+    data.settings?.simulation?.experimentNumber++
     # Synchronous invocation of actions / w trigger
     ImportActions.import.trigger(data)
     @importNodes data.nodes

--- a/src/code/utils/lang/us-en.coffee
+++ b/src/code/utils/lang/us-en.coffee
@@ -110,6 +110,7 @@ module.exports =
   "~COLOR.MED_BLUE": "Blue"
   "~COLOR.DARK_GRAY": "Dark Gray"
   "~COLOR.LIGHT_GRAY": "Light Gray"
+  "~COLOR.MEDIUM_GRAY": "Gray"
   "~COLOR.DATA": "Codap Orange"
 
   # google-file-interface

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -385,7 +385,7 @@ module.exports = React.createClass
     @props.selectionManager.clearSelection()
 
   render: ->
-    dataColor = Color.colors.lightGray.value
+    dataColor = Color.colors.mediumGray.value
     if @state.isRecording
       dataColor = Color.colors.data.value
 


### PR DESCRIPTION
This PR aggregates a number of small bug fixes that mainly relate to CODAP interface:

* [#141349005] Fix bug: Step numbers do not reset between experiments
* [#141349005] Fix bug: Graph button does not open a graph in CODAP
* [##137553679] Increment experiment counter each time Sage loads
* [#135860017] Change color of mini-graphs (when not sending data) and filled part of bars to a darker gray
* (No PT Story) Fix missing 'this' binding in a setTimeout managing the CODAP request queue. (There were occasional console log errors due to this issue, mainly during the period that CODAP constructs a new case table component. Believe that data loss could occur from the exception thrown.)
* [#142411089] Fixed bug: Sage sometimes creates two "Sage Simulation" data sets on startup

