### PR TITLE
Double-click on link should now brings up relationship panel [#142637503]

### DIFF
--- a/src/code/stores/inspector-panel-store.coffee
+++ b/src/code/stores/inspector-panel-store.coffee
@@ -1,0 +1,45 @@
+
+InspectorPanelActions = Reflux.createActions(
+  [
+    "openInspectorPanel"
+    "closeInspectorPanel"
+  ]
+)
+
+InspectorPanelStore = Reflux.createStore
+  listenables: [InspectorPanelActions]
+
+  init: ->
+    @settings =
+      nowShowing: null
+      selectedLink: null
+
+  onOpenInspectorPanel: (nowShowing, options) ->
+    @settings.nowShowing = nowShowing
+    @settings.selectedLink = options.link if options?.link?
+    @notifyChange()
+
+  onCloseInspectorPanel: ->
+    @settings.nowShowing = null
+    @notifyChange()
+
+  notifyChange: ->
+    @trigger _.clone @settings
+
+mixin =
+  getInitialState: ->
+    _.clone InspectorPanelStore.settings
+
+  componentDidMount: ->
+    @inspectorPanelUnsubscribe = InspectorPanelStore.listen @onInspectorPanelStoreChange
+
+  componentWillUnmount: ->
+    @inspectorPanelUnsubscribe()
+
+  onInspectorPanelStoreChange: (newData) ->
+    @setState _.clone newData
+
+module.exports =
+  actions: InspectorPanelActions
+  store: InspectorPanelStore
+  mixin: mixin

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -33,7 +33,6 @@ module.exports = React.createClass
       Container:            $container[0]
       handleConnect:        @handleConnect
       handleClick:          @handleLinkClick
-      handleDoubleClick:    @handleLinkEditClick
       handleLabelEdit:      @handleLabelEdit
 
     # force an initial draw of the connections
@@ -182,11 +181,6 @@ module.exports = React.createClass
       multipleSelections = evt.ctrlKey || evt.metaKey || evt.shiftKey
       @forceRedrawLinks = true
       GraphStore.store.clickLink connection.linkModel, multipleSelections
-
-  handleLinkEditClick: (connection, evnt) ->
-    @handleEvent =>
-      @forceRedrawLinks = true
-      GraphStore.store.editLink connection.linkModel
 
   _updateNodeValue: (name, key, value) ->
     changed = 0

--- a/src/code/views/inspector-panel-view.coffee
+++ b/src/code/views/inspector-panel-view.coffee
@@ -6,6 +6,7 @@ LinkRelationInspectorView = React.createFactory require './relation-inspector-vi
 NodeRelationInspectorView = React.createFactory require './relation-inspector-view'
 SimulationInspectorView   = React.createFactory require './simulation-inspector-view'
 
+InspectorPanelStore  = require "../stores/inspector-panel-store"
 
 {div, i, span} = React.DOM
 
@@ -71,17 +72,11 @@ ToolPanel = React.createFactory React.createClass
 
     (div {className: 'tool-panel'}, buttonsView)
 
-
-
 module.exports = React.createClass
 
   displayName: 'InspectorPanelView'
 
-  getInitialState: ->
-    nowShowing: null
-
-  setShowing: (item) ->
-    @setState(nowShowing: item)
+  mixins: [ InspectorPanelStore.mixin ]
 
   renderSimulationInspector: ->
     (SimulationInspectorView {})
@@ -115,8 +110,7 @@ module.exports = React.createClass
   # 2016-03-15 SF: Changed this to a function explicitly called when selection changes
   nodeSelectionChanged: ->
     unless (@props.node or @props.link)
-      @setState
-        nowShowing: null
+      InspectorPanelStore.actions.closeInspectorPanel()
 
   renderInspectorPanel: ->
     view = switch @state.nowShowing
@@ -139,7 +133,7 @@ module.exports = React.createClass
         node: @props.node
         link: @props.link
         nowShowing: @state.nowShowing
-        onNowShowing: @setShowing
+        onNowShowing: InspectorPanelStore.actions.openInspectorPanel
         diagramOnly: @props.diagramOnly
       )
       @renderInspectorPanel()

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -8,6 +8,8 @@ GraphView   = React.createFactory require "./node-svg-graph-view"
 CodapConnect = require '../models/codap-connect'
 DEFAULT_CONTEXT_NAME = 'building-models'
 
+InspectorPanelStore = require "../stores/inspector-panel-store"
+
 NodeTitle = React.createFactory React.createClass
   displayName: "NodeTitle"
   mixins: [require '../mixins/node-title']
@@ -104,11 +106,18 @@ module.exports = NodeView = React.createClass
     ignoreDrag: false
 
   handleSelected: (actually_select, evt) ->
-    # console.log 'selected ' + actually_select, evt.ctrlKey, @props.selectionManager.selections
-    if @props.selectionManager
-      selectionKey = if actually_select then @props.nodeKey else "dont-select-anything"
-      multipleSelections = evt.ctrlKey || evt.metaKey || evt.shiftKey
-      @props.selectionManager.selectNodeForInspection(@props.data, multipleSelections)
+    return if not @props.selectionManager
+
+    selectionKey = if actually_select then @props.nodeKey else "dont-select-anything"
+    multipleSelections = evt.ctrlKey || evt.metaKey || evt.shiftKey
+    @props.selectionManager.selectNodeForInspection(@props.data, multipleSelections)
+
+    # open the relationship panel on double click if the node has incombing links
+    if @props.data.inLinks().length > 0
+      now = (new Date()).getTime()
+      if now - (@lastClickLinkTime || 0) <= 250
+        InspectorPanelStore.actions.openInspectorPanel 'relations'
+      @lastClickLinkTime = now
 
   propTypes:
     onDelete: React.PropTypes.func

--- a/src/code/views/relation-inspector-view.coffee
+++ b/src/code/views/relation-inspector-view.coffee
@@ -4,7 +4,7 @@ TabbedPanel = React.createFactory require './tabbed-panel-view'
 Tabber = require './tabbed-panel-view'
 tr = require "../utils/translate"
 
-graphStore        = require '../stores/graph-store'
+inspectorPanelStore = require '../stores/inspector-panel-store'
 
 {div, h2, label, span, input, p, i, select, option} = React.DOM
 
@@ -12,7 +12,7 @@ module.exports = RelationInspectorView = React.createClass
 
   displayName: 'RelationInspectorView'
 
-  mixins: [ graphStore.mixin ]
+  mixins: [ inspectorPanelStore.mixin ]
 
   renderTabforLink: (link) ->
     relationView = (LinkRelationView {link: link, graphStore: @props.graphStore})
@@ -23,9 +23,12 @@ module.exports = RelationInspectorView = React.createClass
     (Tabber.Tab {label: label, component: relationView, defined: isFullyDefined})
 
   renderNodeRelationInspector: ->
-    tabs = _.map @props.node.inLinks(), (link) => @renderTabforLink(link)
+    selectedTabIndex = 0
+    tabs = _.map @props.node.inLinks(), (link, i) =>
+      selectedTabIndex = i if (@state.selectedLink is link)
+      @renderTabforLink(link)
     (div {className:'relation-inspector'},
-      (TabbedPanel {tabs: tabs})
+      (TabbedPanel {tabs: tabs, selectedTabIndex: selectedTabIndex})
     )
 
   renderLinkRelationInspector: ->

--- a/src/code/views/tabbed-panel-view.coffee
+++ b/src/code/views/tabbed-panel-view.coffee
@@ -22,7 +22,11 @@ module.exports = React.createClass
   displayName: 'TabbedPanelView'
 
   getInitialState: ->
-    selectedTabIndex: 0
+    selectedTabIndex: @props.selectedTabIndex || 0
+
+  componentWillReceiveProps: (nextProps) ->
+    if @props.selectedTabIndex isnt nextProps.selectedTabIndex
+      @selectedTab nextProps.selectedTabIndex
 
   statics:
     Tab: (settings) -> new TabInfo settings


### PR DESCRIPTION
This removes the existing double click handler which was not being called anything this the link had a click handler.  Double clicking is detected with a simple test for two clicks within 250ms.

To enable the inspector panel to be commanded to open a panel its state was moved into a new store.