### PR TITLE
Changed default recording unit to be days [#135136847]

### DIFF
--- a/src/code/utils/time-units.coffee
+++ b/src/code/utils/time-units.coffee
@@ -19,6 +19,8 @@ module.exports =
 
   defaultUnit: "STEP"
 
+  defaultCollectorUnit: "DAY"
+
   toString: (unit, plural) ->
     number = if plural then ".PLURAL" else ""
     tr "~TIME.#{unit}#{number}"

--- a/src/code/views/node-value-inspector-view.coffee
+++ b/src/code/views/node-value-inspector-view.coffee
@@ -43,6 +43,7 @@ module.exports = React.createClass
   updateChecked:  (evt) ->
     value = evt.target.checked
     @props.graphStore.changeNode(isAccumulator:value)
+    SimulationStore.actions.toggledCollectorTo value
 
   updateDefiningType: ->
     @props.graphStore.changeNode(valueDefinedSemiQuantitatively: not @props.node.valueDefinedSemiQuantitatively)


### PR DESCRIPTION
NOTE: The default quantity is still set at 50.  There was no mention in the story if that was to be changed so I left it alone.

To update the default quantity change this line: https://github.com/concord-consortium/building-models/blob/481f0579c63331c089dd08bda53dd56d19a1be6e/src/code/stores/simulation-store.coffee#L39