### PR TITLE
Fix relationship symbols no longer come up [#136989689]

### DIFF
--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -120,6 +120,7 @@ module.exports = React.createClass
     if (prevState.description.links != @state.description.links) or
         (prevState.simulationPanelExpanded != @state.simulationPanelExpanded) or
         (prevState.selectedLink != @state.selectedLink) or
+        (prevState.relationshipSymbols != @state.relationshipSymbols) or
         @forceRedrawLinks
       @diagramToolkit?.clear?()
       @_updateToolkit()


### PR DESCRIPTION
Simple change: the graph store just needed to listen for the relationshipSymbols setting in the state to change.  That setting is changed in `app-settings-store`.