### PR TITLE
Fixed missing initial link drawing when loading a saved file [#142963961]

### DIFF
--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -36,6 +36,9 @@ module.exports = React.createClass
       handleDoubleClick:    @handleLinkEditClick
       handleLabelEdit:      @handleLabelEdit
 
+    # force an initial draw of the connections
+    @_updateToolkit()
+
     @props.selectionManager.addSelectionListener (manager) =>
       [..., lastLinkSelection] = @state.selectedLink
       selectedNodes     = manager.getNodeInspection() or []


### PR DESCRIPTION
When using sage.html outside of CODAP the links where not being drawn at startup if a file was loaded via the command line like this: sage.html#file=localStorage:node%20test

This change forces the graph to draw when it is mounted.