### PR TITLE
Make deleting a node more intuitive when variable name editing is the focus. [#136380649]

### DIFF
--- a/src/code/mixins/app-view.coffee
+++ b/src/code/mixins/app-view.coffee
@@ -23,7 +23,8 @@ module.exports =
     if add
       deleteFunction = @props.graphStore.deleteSelected.bind @props.graphStore
       $(window).on 'keydown', (e) ->
-        if e.which is 8 and not $(e.target).is('input, textarea')
+        # 8 is backspace, 46 is delete
+        if e.which in [8, 46] and not $(e.target).is('input, textarea')
           e.preventDefault()
           deleteFunction()
     else

--- a/src/code/models/node.coffee
+++ b/src/code/models/node.coffee
@@ -33,6 +33,7 @@ module.exports = class Node extends GraphPrimitive
       @valueDefinedSemiQuantitatively=true,
       @paletteItem
       @frames=[]
+      @addedThisSession=false
     } = nodeSpec
 
     # Save internal values of min, max and initialValues. Actual values retreived

--- a/src/code/utils/js-plumb-diagram-toolkit.coffee
+++ b/src/code/utils/js-plumb-diagram-toolkit.coffee
@@ -106,7 +106,7 @@ module.exports = class DiagramToolkit
     outlineColor: "rgb(0,240,10)"
     outlineWidth: "10px"
 
-  _overlays: (label, selected, editingLabel=true, thickness, finalColor, variableWidth, arrowFoldback, changeIndicator) ->
+  _overlays: (label, selected, editingLabel=true, thickness, finalColor, variableWidth, arrowFoldback, changeIndicator, link) ->
     results = [["Arrow", {
       location: 1.0
       length: 10
@@ -128,7 +128,7 @@ module.exports = class DiagramToolkit
       }]
     if editingLabel
       results.push  ["Custom", {
-        create: @_createEditLabel(label)
+        create: @_createEditLabel(link, label)
         location: 0.5
         id:"customOverlay"
       }]
@@ -145,7 +145,7 @@ module.exports = class DiagramToolkit
     result = stops: [[0.0,startColor], [1.0,endColor]]
     result
 
-  _createEditLabel: (label) ->
+  _createEditLabel: (link, label) ->
     width =
       if label.length < 13 then 90
       else if label.length < 19 then 130
@@ -157,7 +157,7 @@ module.exports = class DiagramToolkit
       .show ->
         $(@).focus()
       .change ->
-        _self.options.handleLabelEdit? this.value
+        _self.options.handleLabelEdit? link, this.value
 
 
   _clean_borked_endpoints: ->
@@ -230,7 +230,7 @@ module.exports = class DiagramToolkit
       source: opts.source
       target: opts.target
       paintStyle: paintStyle
-      overlays: @_overlays opts.label, opts.isSelected, opts.isEditing, thickness, fixedColor, variableWidthMagnitude, arrowFoldback, changeIndicator
+      overlays: @_overlays opts.label, opts.isSelected, opts.isEditing, thickness, fixedColor, variableWidthMagnitude, arrowFoldback, changeIndicator, opts.linkModel
       endpoint: @_endpointOptions("Rectangle", thickness, 'node-link-endpoint')
 
     connection.bind 'click', @handleClick.bind @

--- a/src/code/utils/lang/us-en.coffee
+++ b/src/code/utils/lang/us-en.coffee
@@ -91,8 +91,8 @@ module.exports =
   "~IMAGE-BROWSER.TRY_ANOTHER_SEARCH": "Try another search, or browse images below."
   "~IMAGE-BROWSER.SEARCHING": "Searching for %{scope}\"%{query}\""
   "~IMAGE-BROWSER.NO_EXTERNAL_FOUND": "No openclipart.org results found for \"%{query}.\""
-  "~IMAGE-BROWSER.SHOWING_N_OF_M": "Showing %{numResults} of %{numTotalResults} matches for \"%{query}.\" "
-  "~IMAGE-BROWSER.SHOW_ALL": "Show all matches."
+  "~IMAGE-BROWSER.SHOWING_N_OF_M": "Note: Only showing %{numResults} of %{numTotalResults} matches. "
+  "~IMAGE-BROWSER.SHOW_ALL": "Click here to show all matches."
   "~IMAGE-BROWSER.ALREADY-IN-PALETTE": "Already in palette"
 
   "~IMAGE-BROWSER.PLEASE_DROP_IMAGE": "Please drop an image or enter an image url"
@@ -103,6 +103,7 @@ module.exports =
   "~IMAGE-BROWSER.PLEASE_DROP_FILE": "Please select or drop a file"
   "~IMAGE-BROWSER.DROP_IMAGE_FROM_DESKTOP": "Drop image from desktop here"
   "~IMAGE-BROWSER.CHOOSE_FILE": "Or choose a file from your desktop:"
+  "~IMAGE-BROWSER.PROVIDER_MESSAGE": "Image search courtesy of openclipart.org"
 
   "~COLOR.YELLOW": "Yellow"
   "~COLOR.DARK_BLUE": "Dark Blue"

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -120,6 +120,7 @@ module.exports = React.createClass
     if (prevState.description.links != @state.description.links) or
         (prevState.simulationPanelExpanded != @state.simulationPanelExpanded) or
         (prevState.selectedLink != @state.selectedLink) or
+        (prevState.relationshipSymbols != @state.relationshipSymbols) or
         @forceRedrawLinks
       @diagramToolkit?.clear?()
       @_updateToolkit()

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -36,6 +36,9 @@ module.exports = React.createClass
       handleDoubleClick:    @handleLinkEditClick
       handleLabelEdit:      @handleLabelEdit
 
+    # force an initial draw of the connections
+    @_updateToolkit()
+
     @props.selectionManager.addSelectionListener (manager) =>
       [..., lastLinkSelection] = @state.selectedLink
       selectedNodes     = manager.getNodeInspection() or []

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -100,6 +100,7 @@ module.exports = React.createClass
       title: title
       paletteItem: paletteItem.uuid
       image: paletteItem.image
+      addedThisSession: true
 
     @props.graphStore.addNode newNode
     @props.graphStore.editNode newNode.key

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -380,8 +380,8 @@ module.exports = React.createClass
     result = (a and b and c and d)
     result
 
-  handleLabelEdit: (title) ->
-    @props.graphStore.changeLink @state.editingLink, {title: title}
+  handleLabelEdit: (link, title) ->
+    @props.graphStore.changeLink link, {title: title}
     @props.selectionManager.clearSelection()
 
   render: ->

--- a/src/code/views/node-svg-graph-view.coffee
+++ b/src/code/views/node-svg-graph-view.coffee
@@ -1,6 +1,7 @@
-{svg, path, line, text, div, tspan} = React.DOM
+{svg, path, line, text, div, tspan, image} = React.DOM
 
 SimulationStore = require '../stores/simulation-store'
+SquareImage = React.createFactory require "./square-image-view"
 
 module.exports = NodeSvgGraphView = React.createClass
   displayName: 'NodeSvgGraphView'
@@ -49,13 +50,34 @@ module.exports = NodeSvgGraphView = React.createClass
       {x: x, y: y}
     data
 
-  renderLineData: ->
-    data = @pointsToPath(@getPathPoints())
-    (path {d: data, strokeWidth: @props.strokeWidth, stroke: @props.color, fill: "none"})
+  renderImage: ->
+    imageOffset = 2
+    imageStyle =
+      position: "absolute"
+      top: imageOffset
+      left: imageOffset
+      opacity: 0.25
+      width: @props.width + imageOffset
+      height: @props.height + imageOffset
+
+    (div {style: imageStyle},
+      (SquareImage {
+        image: @props.image
+      })
+    )
+
+  renderSVG: ->
+    svgOffset = 3
+    svgStyle =
+      position: "absolute"
+      top: svgOffset
+      left: svgOffset
+    (svg {style: svgStyle, width: @props.width, height: @props.height},
+      (path {d: @pointsToPath(@getPathPoints()), strokeWidth: @props.strokeWidth, stroke: @props.color, fill: "none"})
+    )
 
   render: ->
     (div {},
-      (svg {width: @props.width, height: @props.height},
-        @renderLineData()
-      )
+      @renderImage()
+      @renderSVG()
     )

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -235,13 +235,12 @@ module.exports = NodeView = React.createClass
         max: @props.data.max
         data: @props.data.frames
         color: @props.dataColor
+        image: @props.data.image
       })
     else
       (SquareImage {
         image: @props.data.image,
-        ref: "thumbnail"
       })
-
 
   render: ->
     style =

--- a/src/stylus/components/image-browser.styl
+++ b/src/stylus/components/image-browser.styl
@@ -16,12 +16,13 @@
 
   .image-search-dialog-results
     position absolute
-    margin 24px 0px 24px
+    margin 26px 0px 24px 0px
     bottom 0px
     top 0px
     overflow auto
 
     &.show-all
+      margin-top: 0
       overflow auto
     img
       max-width 50px
@@ -33,9 +34,9 @@
     .in-palette
       opacity 0.25
       cursor not-allowed
-  .image-search-dialog-results-text
+  .image-search-dialog-provider-message
     position absolute
-    bottom 10px
+    bottom 0
   .image-search-main-results
     height 330px
     .image-search-section
@@ -43,8 +44,10 @@
       .header
         position absolute
         top 0
-        margin 0    
-      
+        margin 0
+        font-size: 12px
+        font-style: italic
+
 .preview-image
   margin-bottom 20px
   display inline-block


### PR DESCRIPTION
With this change the code now tracks if a node is added during the session (as opposed to loaded from a save) and then deletes the node if during the initial edit the first key pressed is either backspace or delete.

This also fixes the global key handler to also listen for delete (46) along with the existing backspace (8) listener.