### PR TITLE
Send experiment number as categorical to CODAP [#136990473]

### DIFF
--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -96,7 +96,7 @@ module.exports = class CodapConnect
                 pluralCase: 'runs'
               attrs: [
                 name: tr '~CODAP.SIMULATION.EXPERIMENT'
-                type: 'numeric'
+                type: 'categorical'
               ]
             },
             {


### PR DESCRIPTION
This change sends experiment numbers as categorical values instead of numeric values so when experiment numbers are added as a legend in a graph, then the legend is categorical instead of numerical.