### PR TITLE
Fixed undo/redo buttons so they work in standalone mode [#133193161]

### DIFF
--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -46,6 +46,8 @@ module.exports = class CodapConnect
         frame   = ret[0]
         context = ret[1]
 
+        @graphStore.setUsingCODAP true
+
         if frame?.values.externalUndoAvailable
           CodapActions.hideUndoRedo()
         else if frame?.values.standaloneUndoModeAvailable
@@ -209,7 +211,7 @@ module.exports = class CodapConnect
       action: 'notify',
       resource: 'undoChangeNotice'
       values: {
-        operation: 'undoAction'
+        operation: if @standaloneMode then 'undoButtonPress' else 'undoAction'
       }
 
   _sendRedoToCODAP: ->
@@ -217,7 +219,7 @@ module.exports = class CodapConnect
       action: 'notify',
       resource: 'undoChangeNotice'
       values: {
-        operation: 'redoAction'
+        operation: if @standaloneMode then 'redoButtonPress' else 'redoAction'
       }
 
   sendUndoableActionPerformed: (logMessage) ->

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -30,6 +30,7 @@ GraphStore  = Reflux.createStore
     SimulationStore.actions.createExperiment.listen        @resetSimulation.bind(@)
     SimulationStore.actions.simulationFramesCreated.listen @updateSimulationData.bind(@)
 
+    @usingCODAP = false
     @codapStandaloneMode = false
 
     @lastRunModel = ""   # string description of the model last time we ran simulation
@@ -56,20 +57,19 @@ GraphStore  = Reflux.createStore
   # modes. It can be called from the 1) button press, 2) keyboard, and 3) CODAP action.
   # We can be in CODAP standalone mode or not.
   #
-  # We want to immediately execute the action if EITHER we are not in standalone mode
-  # (for all sources), or if we are in standalone mode and the source is CODAP
-  # (forced == true).
+  # The undoRedoManager should handle the undo/redo when EITHER we are not running
+  # in CODAP or the undo/redo has been initiated from CODAP
   #
-  # If we are in standalone mode and the source was not CODAP, we want to send the
-  # event to CODAP.
-  undo: (forced) ->
-    if forced or not @codapStandaloneMode
+  # CODAP should handle the undo/redo when we are running from CODAP in either
+  # standalone or non-standalone mode and CODAP did not initiate the request
+  undo: (fromCODAP) ->
+    if fromCODAP or not @usingCODAP
       @undoRedoManager.undo()
     else
       CodapActions.sendUndoToCODAP()
 
-  redo: (forced) ->
-    if forced or not @codapStandaloneMode
+  redo: (fromCODAP) ->
+    if fromCODAP or not @usingCODAP
       @undoRedoManager.redo()
     else
       CodapActions.sendRedoToCODAP()
@@ -82,6 +82,8 @@ GraphStore  = Reflux.createStore
 
   revertToLastSave: ->
     @undoRedoManager.revertToLastSave()
+
+  setUsingCODAP: (@usingCODAP) ->
 
   setCodapStandaloneMode: (@codapStandaloneMode) ->
 

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -187,8 +187,9 @@ GraphStore  = Reflux.createStore
   moveNodeCompleted: (nodeKey, leftDiff, topDiff) ->
     @endNodeEdit()
     @undoRedoManager.createAndExecuteCommand 'moveNode',
-      execute: => @moveNode nodeKey, 0,0 # FIXME leftDiff, topDiff
+      execute: => @moveNode nodeKey, 0, 0
       undo: => @moveNode nodeKey, -leftDiff, -topDiff
+      redo: => @moveNode nodeKey, leftDiff, topDiff
 
   moveNode: (nodeKey, leftDiff, topDiff) ->
     node = @nodeKeys[nodeKey]

--- a/src/code/stores/undo-redo-ui-store.coffee
+++ b/src/code/stores/undo-redo-ui-store.coffee
@@ -1,0 +1,48 @@
+
+undoRedoUIActions = Reflux.createActions(
+  [
+    "setCanUndoRedo"
+  ]
+)
+
+undoRedoUIStore = Reflux.createStore
+  listenables: [undoRedoUIActions]
+
+  init: (context) ->
+    @canUndo = false
+    @canRedo = false
+
+  onSetCanUndoRedo: (canUndo, canRedo) ->
+    @canUndo = canUndo
+    @canRedo = canRedo
+    @notifyChange()
+
+  notifyChange: ->
+    data =
+      canUndo: @canUndo
+      canRedo: @canRedo
+    @trigger(data)
+
+undoRedoUIMixin =
+  getInitialState: ->
+    canUndo: undoRedoUIStore.canUndo
+    canRedo: undoRedoUIStore.canRedo
+
+  componentDidMount: ->
+    @unsubscribe = undoRedoUIStore.listen @onUndoRedoUIStateChange
+    # can't add listener in init due to order-of-initialization issues
+    GraphStore = require './graph-store'
+    GraphStore?.store?.undoRedoManager?.addChangeListener @onUndoRedoUIStateChange
+
+  componentWillUnmount: ->
+    @unsubscribe()
+
+  onUndoRedoUIStateChange: (state) ->
+    @setState
+      canUndo: state.canUndo
+      canRedo: state.canRedo
+
+module.exports =
+  actions: undoRedoUIActions
+  store: undoRedoUIStore
+  mixin: undoRedoUIMixin

--- a/src/code/utils/undo-redo.coffee
+++ b/src/code/utils/undo-redo.coffee
@@ -160,7 +160,8 @@ class Command
 
   execute: (debug) -> @_call 'execute', debug
   undo: (debug) -> @_call 'undo', debug
-  redo: (debug) -> @_call 'execute', debug, 'redo'
+  redo: (debug) -> if @methods.hasOwnProperty 'redo' then @_call 'redo', debug \
+                                                     else @_call 'execute', debug, 'redo'
 
 class CommandBatch
   constructor: (@name) ->

--- a/src/code/views/document-actions-view.coffee
+++ b/src/code/views/document-actions-view.coffee
@@ -2,27 +2,16 @@
 AboutView        = React.createFactory require './about-view'
 AppSettingsStore = require '../stores/app-settings-store'
 CodapStore       = require '../stores/codap-store'
+UndoRedoUIStore  = require '../stores/undo-redo-ui-store'
 tr               = require '../utils/translate'
 
 SimulationRunPanel = React.createFactory require './simulation-run-panel-view'
 
 module.exports = React.createClass
 
-  mixins: [ CodapStore.mixin, AppSettingsStore.mixin ]
+  mixins: [ CodapStore.mixin, UndoRedoUIStore.mixin, AppSettingsStore.mixin ]
 
   displayName: 'DocumentActions'
-
-  getInitialState: ->
-    canRedo: false
-    canUndo: false
-
-  componentDidMount: ->
-    @props.graphStore.addChangeListener @modelChanged
-
-  modelChanged: (status) ->
-    @setState
-      canRedo: status.canRedo
-      canUndo: status.canUndo
 
   undoClicked: ->
     @props.graphStore.undo()

--- a/src/code/views/global-nav-view.coffee
+++ b/src/code/views/global-nav-view.coffee
@@ -6,17 +6,17 @@ OpenInCodap        = React.createFactory require './open-in-codap-view'
 ModalGoogleSave    = React.createFactory require './modal-google-save-view'
 BuildInfoView      = React.createFactory require './build-info-view'
 GoogleFileStore    = require '../stores/google-file-store'
+UndoRedoUIStore    = require '../stores/undo-redo-ui-store'
 AppSettingsActions = require('../stores/app-settings-store').actions
 
 module.exports = React.createClass
 
   displayName: 'GlobalNav'
 
-  mixins: [ GoogleFileStore.mixin ]
+  mixins: [ GoogleFileStore.mixin, UndoRedoUIStore.mixin ]
 
   getInitialState: ->
     dirty: false
-    canUndo: false
     saved: false
 
   componentDidMount: ->


### PR DESCRIPTION
This change disables sending any events to CODAP about undo/redo when we are in standalone mode and instead relies on the Sage undo/redo manager to handle the requsests.

Before this change when standalone mode was detected the Sage undo/redo actions would be skipped and instead CODAP would be informed of the need for undo/redo. However this effectivly disabled the undo/redo buttons showing in Sage.

A new graph-store variable that tracks if we are running in CODAP (set via codap-connect) is now used to flag when undo/redo events should be sent to CODAP.

NOTE: there needs to be work done in CODAP in the DI API so that CODAP can notify the DI the state of the undo/redo stack.