### PR TITLE
Fixed because text not always saving [#143497999]

### DIFF
--- a/src/code/views/link-relation-view.coffee
+++ b/src/code/views/link-relation-view.coffee
@@ -188,7 +188,7 @@ module.exports = LinkRelationView = React.createClass
         (textarea
           defaultValue: @props.link.reasoning
           placeholder: tr "~NODE-RELATION-EDIT.BECAUSE_PLACEHOLDER"
-          onBlur: @updateReasoning
+          onChange: @updateReasoning
           ref: 'reasoning'
           className: 'full'
           rows: 3


### PR DESCRIPTION
Changed from onBlur to onChange handler because when you click on the canvas the textarea is removed before the blur handler can get the value.