### PR TITLE
Nodes must have unique names [#134798657]

### DIFF
--- a/src/code/models/node.coffee
+++ b/src/code/models/node.coffee
@@ -27,7 +27,7 @@ module.exports = class Node extends GraphPrimitive
     {
       @x=0
       @y=0
-      @title="untitled"
+      @title= tr "~NODE.UNTITLED"
       @image
       @isAccumulator=false
       @valueDefinedSemiQuantitatively=true,

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -154,8 +154,7 @@ GraphStore  = Reflux.createStore
 
   ensureUniqueTitle: (node, newTitle=node.title) ->
     nodes = @getNodes()
-    defaultTitle = tr "~NODE.UNTITLED"
-    if newTitle is defaultTitle or not @isUniqueTitle newTitle, node, nodes
+    if not @isUniqueTitle newTitle, node, nodes
       index = 2
       endsWithNumber = / (\d+)$/
       matches = newTitle.match(endsWithNumber)

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -146,9 +146,31 @@ GraphStore  = Reflux.createStore
     @_graphUpdated()
     @updateListeners()
 
+  isUniqueTitle: (title, skipNode, nodes=@getNodes()) ->
+    nonUniqueNode = (otherNode) ->
+      sameTitle = otherNode.title is title
+      if skipNode then sameTitle and otherNode isnt skipNode else sameTitle
+    not _.find nodes, nonUniqueNode
+
+  ensureUniqueTitle: (node, newTitle=node.title) ->
+    nodes = @getNodes()
+    defaultTitle = tr "~NODE.UNTITLED"
+    if newTitle is defaultTitle or not @isUniqueTitle newTitle, node, nodes
+      index = 2
+      endsWithNumber = / (\d+)$/
+      matches = newTitle.match(endsWithNumber)
+      if matches
+        index = parseInt(matches[1], 10) + 1
+        newTitle = newTitle.replace(endsWithNumber, '')
+      template = "#{newTitle} %{index}"
+      loop
+        newTitle = tr template, {index: index++}
+        break if @isUniqueTitle newTitle, node, nodes
+    node.title = newTitle
 
   addNode: (node) ->
     @endNodeEdit()
+    @ensureUniqueTitle node
     @undoRedoManager.createAndExecuteCommand 'addNode',
       execute: => @_addNode node
       undo: => @_removeNode node

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -14,6 +14,12 @@ NodeTitle = React.createFactory React.createClass
   displayName: "NodeTitle"
   mixins: [require '../mixins/node-title']
 
+  getInitialState: ->
+    isUniqueTitle: @isUniqueTitle @props.node.title
+
+  isUniqueTitle: (title) ->
+    @props.graphStore.isUniqueTitle title, @props.node
+
   componentWillUnmount: ->
     if @props.isEditing
       @inputElm().off()
@@ -47,6 +53,7 @@ NodeTitle = React.createFactory React.createClass
   updateTitle: (e) ->
     @titleUpdated = true
     newTitle = @cleanupTitle(@inputValue())
+    @setState isUniqueTitle: @isUniqueTitle newTitle
     @props.onChange(newTitle)
 
   finishEditing: ->
@@ -62,10 +69,11 @@ NodeTitle = React.createFactory React.createClass
   renderTitleInput: ->
     displayTitle = @displayTitleForInput(@props.title)
     canDeleteWhenEmpty = @props.node.addedThisSession and not @titleUpdated
+    className = "node-title#{if not @state.isUniqueTitle then ' non-unique-title' else ''}"
     (input {
       type: "text"
       ref: "input"
-      className: "node-title"
+      className: className
       onKeyUp: if canDeleteWhenEmpty then @detectDeleteWhenEmpty else null
       onChange: @updateTitle
       defaultValue: displayTitle
@@ -171,6 +179,7 @@ module.exports = NodeView = React.createClass
     @props.graphStore.changeNodeWithKey(@props.nodeKey, {initialValue:newValue})
 
   changeTitle: (newTitle) ->
+    newTitle = @props.graphStore.ensureUniqueTitle @props.data, newTitle
     @props.graphStore.startNodeEdit()
     log.info "Title is changing to #{newTitle}"
     @props.graphStore.changeNodeWithKey(@props.nodeKey, {title:newTitle})

--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -146,6 +146,8 @@ $node-design-height = 94px
     margin-top 4px
     margin-bottom 8px
     padding 0px
+  input[type=text].non-unique-title
+    color: #f00
   .untitled
     italic-font(size:10px)
 


### PR DESCRIPTION
Adds a check when either a file is loaded or when a title is edited to require both a unique node name and the non-default node name ("Untitled"). If the name is not unique a number is appended to it starting at either 2 if the existing node name does not end with an integer or the ending integer + 1.

For visual feedback during title editing the input turns red when the name is not unique.