### PR TITLE
Enable `numberToggle` on graphs [#143266621]

### DIFF
--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -263,10 +263,11 @@ module.exports = class CodapConnect
       resource: 'component',
       values:
         type: 'graph'
-        xAttributeName: timeUnit,
-        yAttributeName: yAttributeName,
-        size: { width: 242, height: 221 },
+        xAttributeName: timeUnit
+        yAttributeName: yAttributeName
+        size: { width: 242, height: 221 }
         position: 'bottom'
+        enableNumberToggle: true
 
   createTable: ->
     unless @tableCreated


### PR DESCRIPTION
Enable the `numberToggle` UI on graphs created by Sage.

Requires CODAP PR [Enable graph numberToggle via plugin API](https://github.com/concord-consortium/codap/pull/148).