### PR TITLE
Set the arrows not to link to the bottom [#141351881]

### DIFF
--- a/src/code/utils/js-plumb-diagram-toolkit.coffee
+++ b/src/code/utils/js-plumb-diagram-toolkit.coffee
@@ -12,7 +12,7 @@ module.exports = class DiagramToolkit
     @kit       = jsPlumb.getInstance {Container: @domContext}
     @kit.importDefaults
       Connector:        ["Bezier", {curviness: 80}],
-      Anchor:           "Continuous",
+      Anchor:           ["Continuous", { faces:["top","left","right"] }]
       DragOptions :     {cursor: 'pointer', zIndex:2000},
       ConnectionsDetachable: true,
       DoNotThrowErrors: false


### PR DESCRIPTION
Changes jsplumb connection defaults so it does not use the bottom for a connection point.