### PR TITLE
Synchronize Sage node title/CODAP attribute name changes

### DIFF
--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -211,7 +211,7 @@ module.exports = class CodapConnect
           else if node.codapName isnt attr.name
             node.codapName = attr.name
             if not initialSync and (node.title isnt attr.name)
-              @graphStore._changeNode node, { title: attr.name }
+              @graphStore._changeNode node, { title: attr.name }, false
           if initialSync
             _.remove nodesToSync, (node) -> node.codapID and node.codapName
           else

--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -227,11 +227,13 @@ module.exports = class CodapConnect
         action: 'update'
         resource: "dataContext[Sage Simulation].collection[Samples].attribute[#{codapKey}]"
         values: { name: node.title }
+        meta:
+          dirtyDocument: false
       @codapPhone.call message, (response) =>
         if response.success
           if response?.values?.attrs
             @_syncAttributeProperties response.values.attrs
-        else
+        else if node.codapID and node.codapName
           console.log "Error: CODAP attribute rename failed!"
 
   _timeStamp: ->

--- a/src/code/models/node.coffee
+++ b/src/code/models/node.coffee
@@ -28,6 +28,8 @@ module.exports = class Node extends GraphPrimitive
       @x=0
       @y=0
       @title= tr "~NODE.UNTITLED"
+      @codapID = null
+      @codapName = null
       @image
       @isAccumulator=false
       @valueDefinedSemiQuantitatively=true,
@@ -176,6 +178,8 @@ module.exports = class Node extends GraphPrimitive
   toExport: ->
     data:
       title: @title
+      codapName: @codapName
+      codapID: @codapID
       x: @x
       y: @y
       paletteItem: @paletteItem

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -272,14 +272,14 @@ GraphStore  = Reflux.createStore
             execute: => @_changeNode node, data
             undo: => @_changeNode node, originalData
 
-  _changeNode: (node, data) ->
+  _changeNode: (node, data, notifyCodap = true) ->
     log.info "Change for #{node.title}"
     for key in NodeModel.fields
       if data.hasOwnProperty key
         log.info "Change #{key} for #{node.title}"
         prev = node[key]
         node[key] = data[key]
-        if @usingCODAP and key is 'title'
+        if notifyCodap and @usingCODAP and key is 'title'
           codapConnect = CodapConnect.instance DEFAULT_CONTEXT_NAME
           codapConnect.sendRenameAttribute node.key, prev
     node.normalizeValues(_.keys(data))

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -12,6 +12,8 @@ SimulationStore     = require "../stores/simulation-store"
 GraphActions        = require "../actions/graph-actions"
 CodapActions        = require '../actions/codap-actions'
 InspectorPanelStore = require "../stores/inspector-panel-store"
+CodapConnect        = require '../models/codap-connect'
+DEFAULT_CONTEXT_NAME = 'building-models'
 
 GraphStore  = Reflux.createStore
   init: (context) ->
@@ -167,11 +169,11 @@ GraphStore  = Reflux.createStore
       loop
         newTitle = tr template, {index: index++}
         break if @isUniqueTitle newTitle, node, nodes
-    node.title = newTitle
+    newTitle
 
   addNode: (node) ->
     @endNodeEdit()
-    @ensureUniqueTitle node
+    node.title = @ensureUniqueTitle node
     @undoRedoManager.createAndExecuteCommand 'addNode',
       execute: => @_addNode node
       undo: => @_removeNode node
@@ -275,7 +277,11 @@ GraphStore  = Reflux.createStore
     for key in NodeModel.fields
       if data.hasOwnProperty key
         log.info "Change #{key} for #{node.title}"
+        prev = node[key]
         node[key] = data[key]
+        if @usingCODAP and key is 'title'
+          codapConnect = CodapConnect.instance DEFAULT_CONTEXT_NAME
+          codapConnect.sendRenameAttribute node.key, prev
     node.normalizeValues(_.keys(data))
     @_notifyNodeChanged(node)
 

--- a/src/code/utils/escape-reg-ex.coffee
+++ b/src/code/utils/escape-reg-ex.coffee
@@ -1,0 +1,8 @@
+  # from http://stackoverflow.com/a/6969486
+  exports.escapeRegExpRE = /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g
+
+  exports.escapeRegExp = (str) ->
+    str.replace(exports.escapeRegExpRE, "\\$&")
+
+  exports.createEscapedRegExp = (str, flags) ->
+    new RegExp(exports.escapeRegExp(str), flags)

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -185,11 +185,16 @@ module.exports = NodeView = React.createClass
     @props.graphStore.changeNodeWithKey(@props.nodeKey, {title:newTitle})
 
   startEditing: ->
+    @initialTitle = @props.graphStore.nodeKeys[@props.nodeKey].title
     @props.selectionManager.selectNodeForTitleEditing(@props.data)
 
   stopEditing: ->
     @props.graphStore.endNodeEdit()
     @props.selectionManager.clearTitleEditing()
+    finalTitle = @props.graphStore.nodeKeys[@props.nodeKey].title
+    if finalTitle isnt @initialTitle
+      codapConnect = CodapConnect.instance DEFAULT_CONTEXT_NAME
+      codapConnect.sendRenameAttribute @props.nodeKey, @initialTitle
 
   isEditing: ->
     @props.selectionManager.isSelectedForTitleEditing(@props.data)

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -191,10 +191,6 @@ module.exports = NodeView = React.createClass
   stopEditing: ->
     @props.graphStore.endNodeEdit()
     @props.selectionManager.clearTitleEditing()
-    finalTitle = @props.graphStore.nodeKeys[@props.nodeKey].title
-    if finalTitle isnt @initialTitle
-      codapConnect = CodapConnect.instance DEFAULT_CONTEXT_NAME
-      codapConnect.sendRenameAttribute @props.nodeKey, @initialTitle
 
   isEditing: ->
     @props.selectionManager.isSelectedForTitleEditing(@props.data)


### PR DESCRIPTION
- synchronize nodes/attribute IDs and titles/names at initialization time
- serialize synchronized IDs and names/titles for continued synchronization
- call plugin API updateAttributes when node titles are changed [#134408929]
- respond to plugin API updateAttributes notification by changing node title when appropriate [#137900155]

Requires CODAP PR [#151](https://github.com/concord-consortium/codap/pull/151) to provide the necessary changes to the CODAP plugin API. Requires CODAP PR [#152](https://github.com/concord-consortium/codap/pull/152) to support undo/redo of title changes when synchronizing CODAP attribute names.