### PR TITLE
Fix gulp.watch configuration so new/deleted files trigger rebuild

### DIFF
--- a/gulp/tasks/default.js
+++ b/gulp/tasks/default.js
@@ -1,13 +1,31 @@
 var gulp = require('gulp');
 var config = require('../config');
 
+// Note that it would be simpler to just remove the './' from the definitions
+// of `src` and `dest` in config.js, but that broke other tasks. Rather than
+// figure out how to fix those other tasks, we simply make the change locally.
+function gulpWatch(watchConfig, tasks) {
+  // eliminate leading './' in paths in favor of cwd option
+  function replaceDotSlash(glob) {
+    return glob.replace(/^\.\//, '');
+  }
+  // watchConfig can be glob string or array of glob strings
+  function processWatchConfig(watchConfig) {
+    return Array.isArray(watchConfig)
+            ? watchConfig.map(function(glob) { return replaceDotSlash(glob); })
+            : replaceDotSlash(watchConfig);
+  }
+  // cwd is required for new/deleted files to be detected (http://stackoverflow.com/a/34346524)
+  gulp.watch(processWatchConfig(watchConfig), { cwd: './' }, tasks);
+}
+
 gulp.task('watch', function() {
-    gulp.watch(config.css.watch,                  ['css']);
-    gulp.watch(config.coffeelint.watch,           ['coffeelint']);
-    gulp.watch(config.browserify.app.watch,       ['browserify-app']);
-    gulp.watch(config.browserify.globals.watch,   ['browserify-globals']);
-    gulp.watch(config.assets.watch,               ['assets']);
-    gulp.watch(config.vendor.watch,               ['vendor']);
+  gulpWatch(config.css.watch,                 ['css']);
+  gulpWatch(config.coffeelint.watch,          ['coffeelint']);
+  gulpWatch(config.browserify.app.watch,      ['browserify-app']);
+  gulpWatch(config.browserify.globals.watch,  ['browserify-globals']);
+  gulpWatch(config.assets.watch,              ['assets']);
+  gulpWatch(config.vendor.watch,              ['vendor']);
 });
 
 gulp.task('lint', ['coffeelint']);


### PR DESCRIPTION
Inspired by [GeniBlocks PR #97](https://github.com/concord-consortium/geniblocks/pull/97).

Gulp.watch has a known bug in which relative paths that begin with `./` cause added/deleted files to be ignored. The solution is to remove the leading `./` from relative paths and then pass `{ cwd: './' }` in the options to gulp.watch(). In the GeniBlocks PR this was as simple as removing the `./` from paths in `config.js`. Unfortunately, the same approach here led to build errors -- apparently other parts of the build process require the leading `./` -- and so the solution here is to programmatically remove the `./` from paths before passing them to gulp.watch().