### PR TITLE
Fix offset when dropping node onto canvas [#144136581]

### DIFF
--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -1,4 +1,5 @@
-Node             = React.createFactory require './node-view'
+NodeView         = require './node-view'
+Node             = React.createFactory NodeView
 NodeModel        = require '../models/node'
 Importer         = require '../utils/importer'
 Color            = require '../utils/colors'
@@ -92,10 +93,11 @@ module.exports = React.createClass
   addPaletteNode: (ui, paletteItem) ->
     # Default new nodes are untitled
     title = tr "~NODE.UNTITLED"
-    offset = $(@refs.linkView).offset()
+    linkOffset = $(@refs.linkView).offset()
+    imageOffset = NodeView.nodeImageOffset()
     newNode = new NodeModel
-      x: ui.offset.left - offset.left
-      y: ui.offset.top - offset.top
+      x: ui.offset.left - linkOffset.left - imageOffset.left
+      y: ui.offset.top - linkOffset.top - imageOffset.top
       title: title
       paletteItem: paletteItem.uuid
       image: paletteItem.image

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -322,6 +322,12 @@ module.exports = NodeView = React.createClass
       )
     )
 
+# synchronized with corresponding CSS values
+NodeView.nodeImageOffset = ->
+  linkTargetTopMargin = 6   # .link-target
+  elementTopMargin = 6      # .elm .top
+  { left: 0, top: linkTargetTopMargin + elementTopMargin }
+
 myView = React.createFactory NodeView
 
 groupView = React.createFactory React.createClass


### PR DESCRIPTION
When dropping a node in the canvas, the node image ends up offset (by 12 pixels) relative to the location of the image when dropped. This is particularly annoying when trying to align nodes.
