### PR TITLE
Fix bug in which no tab would be selected when switching node relation inspectors

### DIFF
--- a/src/code/views/tabbed-panel-view.coffee
+++ b/src/code/views/tabbed-panel-view.coffee
@@ -25,7 +25,7 @@ module.exports = React.createClass
     selectedTabIndex: @props.selectedTabIndex || 0
 
   componentWillReceiveProps: (nextProps) ->
-    if @props.selectedTabIndex isnt nextProps.selectedTabIndex
+    if @state.selectedTabIndex isnt nextProps.selectedTabIndex
       @selectedTab nextProps.selectedTabIndex
 
   statics:


### PR DESCRIPTION
Fix bug in which no tab would be selected when switching node relation inspectors [#131890381]
- the TabbedPanelView was not always updating the state to the correct selected tab
