### PR TITLE
Collector shows multiple images of the assigned icon [#144045227]

### DIFF
--- a/src/code/models/node.coffee
+++ b/src/code/models/node.coffee
@@ -49,6 +49,8 @@ module.exports = class Node extends GraphPrimitive
 
     @isInCycle = false      # we always initalize with no links, so we can't be in cycle
 
+    @_collectorImageProps = null
+
   # Scale the value of initialValue such that, if we are in semi-quantitative mode,
   # we always return a value between 0 and 100. Likewise, if we try to set a value while
   # we are in SQ mode, we set the actual internal value to the same proportion between
@@ -165,6 +167,23 @@ module.exports = class Node extends GraphPrimitive
     else
       @max = Math.max @max, @min
     @initialValue = Math.max @min, Math.min @max, @initialValue
+
+    # clear collector images when @isAccumulator -> false
+    if (not @isAccumulator)
+      @_collectorImageProps = null
+
+  collectorImageProps: ->
+    # preserve collector images unless explicitly cleared
+    if not @_collectorImageProps
+      @_collectorImageProps = []
+      for i in [0..8] by 2
+        row = Math.trunc(i/3)
+        col = i - row * 3
+        @_collectorImageProps.push
+          left: Math.random() * 10 + col * 20   # [0, 10) [20, 30) [40, 50)
+          top: Math.random() * 10 + row * 20    # [0, 10) [20, 30) [40, 50)
+          rotation: Math.random() * 60 - 30     # [-30, 30) [-30, 30) [-30, 30)
+    @_collectorImageProps
 
   # Given a value between _min and _max, calculate the SQ proportion
   mapQuantToSemiquant: (val) ->

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -3,6 +3,7 @@ tr = require "../utils/translate"
 
 SimulationActions = require("../stores/simulation-store").actions
 SquareImage = React.createFactory require "./square-image-view"
+StackedImage = React.createFactory require "./stacked-image-view"
 SliderView  = React.createFactory require "./value-slider-view"
 GraphView   = React.createFactory require "./node-svg-graph-view"
 CodapConnect = require '../models/codap-connect'
@@ -267,6 +268,11 @@ module.exports = NodeView = React.createClass
         data: @props.data.frames
         color: @props.dataColor
         image: @props.data.image
+      })
+    else if @props.data.isAccumulator
+      (StackedImage {
+        image: @props.data.image,
+        imageProps: @props.data.collectorImageProps()
       })
     else
       (SquareImage {

--- a/src/code/views/stacked-image-view.coffee
+++ b/src/code/views/stacked-image-view.coffee
@@ -28,6 +28,6 @@ module.exports = React.createClass
       transform: "rotate(#{imgProps.rotation}deg)"
     )
     div { style: { position: "relative", width: "100%", height: "100%" } },
-        @props.imageProps.map((imgProps, index) =>
+        _.map(@props.imageProps, (imgProps, index) =>
           div { style: _.assign({}, @css(index), styles[index]), key: index }
         )

--- a/src/code/views/stacked-image-view.coffee
+++ b/src/code/views/stacked-image-view.coffee
@@ -1,0 +1,33 @@
+{div} = React.DOM
+
+module.exports = React.createClass
+
+  displayName: "StackedImage"
+
+  image: ->
+    if @props.image?.length > 0 and @props.image isnt "#remote"
+      "url(#{@props.image})"
+    else
+      "none"
+
+  css: (index) ->
+    position: "absolute"
+    backgroundImage: @image()
+    backgroundSize: "contain"
+    backgroundPosition: "center"
+    backgroundRepeat: "no-repeat"
+    margin: 0
+    padding: 0
+    height: "50%"
+    width: "50%"
+
+  render: ->
+    styles = @props.imageProps.map((imgProps) ->
+      top: "#{imgProps.top}%"
+      left: "#{imgProps.left}%"
+      transform: "rotate(#{imgProps.rotation}deg)"
+    )
+    div { style: { position: "relative", width: "100%", height: "100%" } },
+        @props.imageProps.map((imgProps, index) =>
+          div { style: _.assign({}, @css(index), styles[index]), key: index }
+        )


### PR DESCRIPTION
- Collectors use a set of five images "randomly" distributed within the node [#144045227]
- in fact the images are in five fixed locations with small random perturbations so that they generally cover the view

Went through several iterations with Dan before settling on this behavior.