### PR TITLE
Fix relationship panel tab navigation bug [#144497757]

### DIFF
--- a/src/code/views/relation-inspector-view.coffee
+++ b/src/code/views/relation-inspector-view.coffee
@@ -25,13 +25,16 @@ module.exports = RelationInspectorView = React.createClass
 
     (Tabber.Tab {label: label, component: relationView, defined: isFullyDefined})
 
+  onTabSelected: (index) ->
+    inspectorPanelStore.actions.openInspectorPanel 'relations', {link: @props.node.inLinks()?[index]}
+
   renderNodeRelationInspector: ->
     selectedTabIndex = 0
     tabs = _.map @props.node.inLinks(), (link, i) =>
       selectedTabIndex = i if (@state.selectedLink is link)
       @renderTabforLink(link)
     (div {className:'relation-inspector'},
-      (TabbedPanel {tabs: tabs, selectedTabIndex: selectedTabIndex})
+      (TabbedPanel {tabs: tabs, selectedTabIndex: selectedTabIndex, onTabSelected: @onTabSelected})
     )
 
   renderLinkRelationInspector: ->

--- a/src/code/views/tabbed-panel-view.coffee
+++ b/src/code/views/tabbed-panel-view.coffee
@@ -34,6 +34,12 @@ module.exports = React.createClass
   selectedTab: (index) ->
     @setState selectedTabIndex: index or 0
 
+  onTabSelected: (index) ->
+    if @props.onTabSelected
+      @props.onTabSelected index
+    else
+      @selectedTab index
+
   renderTab: (tab, index) ->
     (Tab
       label: tab.label
@@ -41,7 +47,7 @@ module.exports = React.createClass
       index: index
       defined: tab.defined
       selected: (index is @state.selectedTabIndex)
-      onSelected: @selectedTab
+      onSelected: @onTabSelected
     )
 
   renderTabs: ->


### PR DESCRIPTION
The `selectedTab` as understood by the TabbedPanelView was getting out of sync with the InspectorPanelStore's notion of the `selectedLink`. The fix implemented here is to configure the TabbedPanelView with an onTabSelected prop which is used to update the `selectedLink`, which eventually propagates back to set the `selectedTab` of the TabbedPanelView.

Note that two recent PRs (#273 & #275) dealt with the TabbedPanelView's setting of its `selectedTab` state. Given that the InspectorPanelStore's `selectedLink` is used to specify the `selectedTab` prop for the TabbedPanelView, it's worth revisiting those fixes to make sure that they're still appropriate in light of these changes.