### PR TITLE
Fix undo/redo of node title changes without enter key [#106772348]

### DIFF
--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -62,10 +62,12 @@ NodeTitle = React.createFactory React.createClass
     @props.onStopEditing()
 
   renderTitle: ->
-    className = "node-title"
-    if @isDefaultTitle()
-      className = "node-title untitled"
-    (div {className: className, onClick: @props.onStartEditing }, @props.title)
+    (div {
+      className: "node-title#{if @isDefaultTitle then ' untitled' else ''}"
+      key: "display"
+      style: { display: if @props.isEditing then "none" else "block" }
+      onClick: @props.onStartEditing
+    }, @props.title)
 
   renderTitleInput: ->
     displayTitle = @displayTitleForInput(@props.title)
@@ -74,6 +76,8 @@ NodeTitle = React.createFactory React.createClass
     (input {
       type: "text"
       ref: "input"
+      key: "edit"
+      style: { display: if @props.isEditing then "block" else "none" }
       className: className
       onKeyUp: if canDeleteWhenEmpty then @detectDeleteWhenEmpty else null
       onChange: @updateTitle
@@ -85,12 +89,10 @@ NodeTitle = React.createFactory React.createClass
     })
 
   render: ->
-    (div {className: 'node-title-box'},
-      if @props.isEditing
-        @renderTitleInput()
-      else
-        @renderTitle()
-    )
+    (div {className: 'node-title-box'}, [
+      @renderTitle()
+      @renderTitleInput()
+    ])
 
 module.exports = NodeView = React.createClass
 


### PR DESCRIPTION
If the edit were completed with a click outside the edit field rather than the enter/return key, the undo/redo mechanism would not be invoked. The bug occurs when the `onBlur` event is not handled because the `input` element is destroyed too early. The fix here is to always render the `input` element but control its visibility with `display: none`, so the underlying DOM element doesn't get destroyed and the `onBlur` event gets handled correctly.