### PR TITLE
Fix bug when editing title after undoing title change [#145244601]

### DIFF
--- a/src/code/mixins/node-title.coffee
+++ b/src/code/mixins/node-title.coffee
@@ -8,7 +8,7 @@ module.exports =
 
   isDefaultTitle: ->
     @props.title is @titlePlaceholder()
-    
+
   displayTitleForInput: (proposedTitle) ->
     # For input fields, use 'placeholder' value @defaultTitle
     # to work, the 'value' attribute of the input should be blank
@@ -17,6 +17,8 @@ module.exports =
   maxTitleLength: ->
     35
 
-  cleanupTitle: (newTitle) ->
-    newTitle = newTitle.substr(0, @maxTitleLength())
-    newTitle = if newTitle.length > 0 then newTitle else @defaultTitle()
+  cleanupTitle: (newTitle, isComplete) ->
+    cleanTitle = if isComplete then _.trim(newTitle) else newTitle
+    cleanTitle = cleanTitle.substr(0, @maxTitleLength())
+    cleanTitle = if isComplete then _.trim(cleanTitle) else cleanTitle
+    cleanTitle = if cleanTitle.length > 0 then cleanTitle else @defaultTitle()

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -81,7 +81,7 @@ NodeTitle = React.createFactory React.createClass
       className: className
       onKeyUp: if canDeleteWhenEmpty then @detectDeleteWhenEmpty else null
       onChange: @updateTitle
-      defaultValue: displayTitle
+      value: displayTitle
       maxLength: @maxTitleLength()
       placeholder: @titlePlaceholder()
       onBlur: =>

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -51,14 +51,14 @@ NodeTitle = React.createFactory React.createClass
     if e.which in [8, 46] and not @titleUpdated
       @props.graphStore.removeNode @props.nodeKey
 
-  updateTitle: (e) ->
+  updateTitle: (isComplete) ->
     @titleUpdated = true
-    newTitle = @cleanupTitle(@inputValue())
+    newTitle = @cleanupTitle(@inputValue(), isComplete)
     @setState isUniqueTitle: @isUniqueTitle newTitle
     @props.onChange(newTitle)
 
   finishEditing: ->
-    @updateTitle()
+    @updateTitle(true)
     @props.onStopEditing()
 
   renderTitle: ->
@@ -80,12 +80,11 @@ NodeTitle = React.createFactory React.createClass
       style: { display: if @props.isEditing then "block" else "none" }
       className: className
       onKeyUp: if canDeleteWhenEmpty then @detectDeleteWhenEmpty else null
-      onChange: @updateTitle
+      onChange: => @updateTitle()
       value: displayTitle
       maxLength: @maxTitleLength()
       placeholder: @titlePlaceholder()
-      onBlur: =>
-        @finishEditing()
+      onBlur: => @finishEditing()
     })
 
   render: ->


### PR DESCRIPTION
Fix bug when editing title after undoing title change [#145244601] 
Trim node titles to eliminate leading/trailing white space [#144377505]

A recent bug-fix made the <input> DOM element persistent. This also made its contents persistent, which allowed the incorrect contents to be retrieved because the <input> element is uncontrolled. But since we have an onChange handler, we simply make the <input> element controlled at this point.