### PR TITLE
Improve Sage URL query parameter handling

### DIFF
--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -44,18 +44,18 @@
   <script type="text/javascript" charset="utf-8">
     if(self == top) {
       // redirect to CFM wrapper if we have none
-      if (~window.location.href.indexOf("index")) {
-        window.location = window.location.toString().replace("index","sage");
-      } else {
-        window.location = window.location.href + "sage.html";
-      }
+      path = window.location.pathname.indexOf('index') >= 0
+              ? window.location.pathname.replace('index', 'sage')
+              : window.location.pathname + 'sage.html';
+      window.location = window.location.protocol + "//" + window.location.host +
+                          path + window.location.search + window.location.hash;
     }
     else {
       Sage.initApp(false);
 
       var cfm, client;
       try {
-        cfm = parent && parent.SageCloundFileManager ? parent.SageCloundFileManager : null;
+        cfm = parent && parent.SageCloudFileManager ? parent.SageCloudFileManager : null;
       }
       catch(e) {
         console.log("Error connecting to CFM: " + e);

--- a/src/assets/sage.html
+++ b/src/assets/sage.html
@@ -12,10 +12,13 @@
     <div id="wrapper">
     </div>
     <script>
-    if(self != top) {
-      // redirect to non CFM wrapped version if we are in an iframe.
-      window.location = window.location.pathname.replace("sage","index");
-    }
+      if(self != top) {
+        // redirect to non CFM wrapped version if we are in an iframe.
+        path = window.location.pathname.replace('sage', 'index');
+        window.location = window.location.protocol + "//" + window.location.host +
+                            path + window.location.search + window.location.hash;
+      }
+
       var buildInfo = "__BUILD_INFO__".split(" ");
       var buildDate = buildInfo[0];
       var tags      = buildInfo[1];
@@ -24,7 +27,7 @@
 
 
       var options = {
-        app: "index.html",
+        app: "index.html" + window.location.search,
         autoSaveInterval: 5,
         mimeType: "application/json",
         appName: "Sage",
@@ -55,7 +58,7 @@
       }
       CloudFileManager.createFrame(options, "wrapper");
       // A poor excuse for namespacing...
-      SageCloundFileManager = CloudFileManager;
+      SageCloudFileManager = CloudFileManager;
     </script>
   </body>
 </html>


### PR DESCRIPTION
- fix bug in which a URL like "http://sage.concord.org/?lang=zh" will reload the page infinitely adding "sage.html" to the URL each time
- preserve query parameters when redirecting
- pass query parameters through CFM to embedded app
- fix typo "SageCloundFileManager" -> "SageCloudFileManager"

@knowuh I'm assigning this one to you for review since you seem to have written some of the code being modified here (and I've been hitting up Doug pretty hard lately).