### PR TITLE
Fix bug that manifests in Firefox in which the link source drag area …

### DIFF
--- a/src/code/utils/js-plumb-diagram-toolkit.coffee
+++ b/src/code/utils/js-plumb-diagram-toolkit.coffee
@@ -55,14 +55,15 @@ module.exports = class DiagramToolkit
     ]
     results
 
-  makeSource: (div) ->
+  makeSource: (div, clientClasses) ->
+    classes = 'node-link-button' + if clientClasses then " #{clientClasses}" else ''
     endpoints = @kit.addEndpoint(div,
       isSource: true
       dropOptions:
         activeClass: "dragActive"
       anchor: "Bottom"
       connectorStyle : { strokeStyle:"#666" }
-      endpoint: @_endpointOptions("Rectangle", 19, 'node-link-button')
+      endpoint: @_endpointOptions("Rectangle", 26, classes)
       connectorOverlays: [["Arrow", {location:1.0, width:10, length:10}]]
       maxConnections: -1
     )

--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -189,6 +189,9 @@ $node-design-height = 94px
   opacity 0.0
   cursor pointer
 
+  &.correct-drag-top
+    margin-top -13px
+
 .node-link-target
   margin-top 7px
   background-color transparent


### PR DESCRIPTION
…is offset from the link source circle element [#142418227]

There is a bug which only manifests in Firefox (but which may well be a jsPlumb bug)
in which the draggable rectangle that corresponds to the link source action circle
is offset from the link source action circle by half the size of the rectangle, i.e.
its top is aligned with the center of the action circle rather than its top. If we
hard-code the correction factor and browser-sniff for Firefox, then the fix becomes
a bug if the underlying bug is fixed by some future version of jsPlumb. Therefore,
we dynamically check for the existence of the bug and apply the `.correct-drag-top`
class only in situations where we've determined the fix applies. We can't easily
apply an arbitrary correction factor because the node in question is absolutely
positioned by jsPlumb. We can apply a class with a constant correction factor that
we know corresponds to the observed Firefox behavior and only apply it if the
detected offset is great enough to make the constant correction an improvement.