### PR TITLE
Clickable checkbox labels; CSS hygiene

### DIFF
--- a/src/code/views/modal-google-save-view.coffee
+++ b/src/code/views/modal-google-save-view.coffee
@@ -41,8 +41,10 @@ module.exports = React.createClass
               })
             )
             (div {className: 'make-public'},
-              (input {type: 'checkbox', value: 'public', checked: @state.isPublic, onChange: @handlePublicChange})
-              (label {}, tr '~GOOGLE_SAVE.MAKE_PUBLIC')
+              (label {}, [
+                input {type: 'checkbox', value: 'public', checked: @state.isPublic, onChange: @handlePublicChange}
+                tr '~GOOGLE_SAVE.MAKE_PUBLIC'
+              ])
             )
             (div {className: 'buttons'},
               (button {name: 'cancel', value: 'Cancel', onClick: @props.onClose}, 'Cancel')

--- a/src/code/views/node-value-inspector-view.coffee
+++ b/src/code/views/node-value-inspector-view.coffee
@@ -125,8 +125,10 @@ module.exports = React.createClass
         )
         (span {className: "checkbox group full"},
           (span {},
-            (input {type: "checkbox", checked: node.isAccumulator, onChange: @updateChecked})
-            (label {}, tr "~NODE-VALUE-EDIT.IS_ACCUMULATOR")
+            (label {}, [
+              input {type: "checkbox", checked: node.isAccumulator, onChange: @updateChecked}
+              tr "~NODE-VALUE-EDIT.IS_ACCUMULATOR"
+            ])
           )
         )
       )

--- a/src/code/views/simulation-inspector-view.coffee
+++ b/src/code/views/simulation-inspector-view.coffee
@@ -36,22 +36,30 @@ module.exports = React.createClass
         (div {className: "title"}, tr "~SIMULATION.SIMULATION_SETTINGS")
 
         (div {className: "row"},
-          (input {type: 'checkbox', value: 'cap-values', checked: @state.capNodeValues, onChange: @setCapNodeValues})
-          (label {}, tr '~SIMULATION.CAP_VALUES')
+          (label {}, [
+            input {type: 'checkbox', value: 'cap-values', checked: @state.capNodeValues, onChange: @setCapNodeValues}
+            tr '~SIMULATION.CAP_VALUES'
+          ])
         )
       )
       (div {className: "title"}, tr "~SIMULATION.DIAGRAM_SETTINGS")
       (div {className: minigraphsCheckboxClass},
-        (input {type: 'checkbox', value: 'show-mini', checked: @state.showingMinigraphs, disabled: @state.diagramOnly, onChange: @setShowingMinigraphs})
-        (label {}, tr '~DOCUMENT.ACTIONS.SHOW_MINI_GRAPHS')
+        (label {}, [
+          input {type: 'checkbox', value: 'show-mini', checked: @state.showingMinigraphs, disabled: @state.diagramOnly, onChange: @setShowingMinigraphs}
+          tr '~DOCUMENT.ACTIONS.SHOW_MINI_GRAPHS'
+        ])
       )
       (div {className: "row"},
-        (input {type: 'checkbox', value: 'diagram-only', checked: @state.diagramOnly, onChange: @setDiagramOnly})
-        (label {}, tr '~SIMULATION.DIAGRAM_ONLY')
+        (label {}, [
+          input {type: 'checkbox', value: 'diagram-only', checked: @state.diagramOnly, onChange: @setDiagramOnly}
+          tr '~SIMULATION.DIAGRAM_ONLY'
+        ])
       )
       (div {className: "row"},
-        (input {type: 'checkbox', value: 'relationship-symbols', checked: @state.relationshipSymbols, onChange: @setRelationshipSymbols})
-        (label {}, tr '~SIMULATION.RELATIONSHIP_SYMBOLS')
+        (label {}, [
+          input {type: 'checkbox', value: 'relationship-symbols', checked: @state.relationshipSymbols, onChange: @setRelationshipSymbols}
+          tr '~SIMULATION.RELATIONSHIP_SYMBOLS'
+        ])
       )
 
     )

--- a/src/stylus/app.styl
+++ b/src/stylus/app.styl
@@ -30,3 +30,6 @@ body
   enable-flex(column)
   .canvas
     top palette-and-actions-height
+
+label > input[type="checkbox"]
+  margin-right 0.5em

--- a/src/stylus/components/simulation-panel.styl
+++ b/src/stylus/components/simulation-panel.styl
@@ -17,7 +17,7 @@ panelWidth = 236px
     margin-top: 0.7em
     margin-bottom: 0.5em
   .row
-    marging 0.1em
+    margin 0.1em
     display flex
     justify-content flex-start
     &.split

--- a/src/stylus/mixins/default.styl
+++ b/src/stylus/mixins/default.styl
@@ -29,14 +29,12 @@ flex-content(flex-grow=1, flex-shrink=0, flex-basis=10px)
   -webkit-flex-grow flex-grow
   -webkit-flex-shrink flex-shrink
 
-absolute(top = 'auto', left = 'auto', right = 'auto', bottom = 'auto', height = 'auto', width = 'auto')
+absolute(top = auto, left = auto, right = auto, bottom = auto)
   position absolute
   top top
   left left
   right right
   bottom bottom
-  height height
-  width width
 
 no-select()
    -webkit-touch-callout none


### PR DESCRIPTION
Make checkbox labels clickable [#144866291]. Fix a couple of CSS hygiene issues:

Fix Stylus `absolute` function
- `'auto'` is an invalid value; use `auto` instead
- eliminate `width` & `height` as they were never used (and aren't involved in absolute positioning)

Fix `marging` -> `margin`

@knowuh There will be a conflict with the `flow-ui-changes` branch so you can let me do the merge.