### PR TITLE
Don't divide flow by 100 if target of flow has other inputs [#146168951]

### DIFF
--- a/src/code/models/simulation.coffee
+++ b/src/code/models/simulation.coffee
@@ -4,7 +4,8 @@ isScaledTransferNode = (node) ->
   return false unless node.isTransfer
   return false if node.inLinks('transfer-modifier').length
   sourceNode = node.transferLink?.sourceNode
-  not sourceNode?.inLinks().length
+  targetNode = node.transferLink?.targetNode
+  not sourceNode?.inLinks().length and not (targetNode?.inLinks().length > 1)
 
 isUnscaledTransferNode = (node) ->
   node.isTransfer and not isScaledTransferNode(node)


### PR DESCRIPTION
From: Daniel Damelin <ddamelin@concord.org>
Subject: problematic thing with algorithm
Date: May 26, 2017 at 9:04:42 AM PDT
To: Kirk Swenson <kswenson@concord.org>, Steve Roderick <steveroderick@mac.com>

HI Kirk and Steve,

Take a look at this model:
https://codap.concord.org/releases/latest/static/dg/en/cert/index.html#shared=20882

For the simple flow we divide by 100, but for the one directly added to “b” we don’t so that aspect of the adding overwhelms the value of “b” making the flow from “a” to “b” mostly irrelevant.

Not sure what to do here. I think our current rule is that as long as there is nothing pointing to the source collector “a” we divide the flow value by 100, but we might be able to fix this by also saying we only divide the flow value by 100 if both the source “a” and sink “b” have nothing connected to them.

What do you think?

-Dan