### PR TITLE
Synchronize use of duration throughout system

### DIFF
--- a/src/code/models/simulation.coffee
+++ b/src/code/models/simulation.coffee
@@ -240,7 +240,7 @@ module.exports = class Simulation
       @generateFrame(time++)
 
     # simulate each step
-    while time <= @duration
+    while time < @duration
       step()
 
     @onFrames(@framesBundle)    # send all at once

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -44,7 +44,6 @@ GraphStore  = Reflux.createStore
     @updateListeners()
 
   _trimSimulation: ->
-    #settings = SimulationStore.store.serialize()
     for node in @getNodes()
       # leaving some excess data reduces flicker during rapid changes
       excessFrames = node.frames.length - 2 * SimulationStore.store.simulationDuration()

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -122,18 +122,23 @@ SimulationStore   = Reflux.createStore
     else
       @defaultUnit
 
+  simulationDuration: ->
+    @settings.duration + (if @settings.graphHasCollector then 1 else 0)
+
+  simulationStepCount: ->
+    return @settings.duration + 1 if @settings.graphHasCollector
+    return @settings.duration if @settings.isRecordingPeriod
+    1
+
   _runSimulation: ->
     if @settings.modelIsRunnable
       # graph-store listens and will reset the simulation when
       # it is run to clear pre-saved data after first load
       @settings.modelIsRunning = true
-      duration = 1
-      if @settings.graphHasCollector || @settings.isRecordingPeriod
-        duration = @settings.duration
       @notifyChange()
       @currentSimulation = new Simulation
         nodes: @nodes
-        duration: duration
+        duration: @simulationStepCount()
         capNodeValues: @settings.capNodeValues
 
         # Simulation events get triggered as Actions here, and are

--- a/src/code/views/node-svg-graph-view.coffee
+++ b/src/code/views/node-svg-graph-view.coffee
@@ -1,7 +1,6 @@
 {svg, path, line, text, div, tspan, image} = React.DOM
 
 SimulationStore = require '../stores/simulation-store'
-SquareImage = React.createFactory require "./square-image-view"
 
 module.exports = NodeSvgGraphView = React.createClass
   displayName: 'NodeSvgGraphView'
@@ -36,7 +35,7 @@ module.exports = NodeSvgGraphView = React.createClass
     min  = @props.min
     data = @props.data
 
-    rangex = @state.duration - 1
+    rangex = SimulationStore.store.simulationDuration()
     data = _.takeRight(data, rangex).reverse()
 
     for point in data

--- a/test/simulation-test.coffee
+++ b/test/simulation-test.coffee
@@ -128,6 +128,7 @@ describe "Simulation", ->
         # 3: basic collector (A->[B])
         {A:5, B:"50+", AB: "1 * in",
         results: [
+          [5, 50]
           [5, 55]
           [5, 60]
         ]}
@@ -135,9 +136,9 @@ describe "Simulation", ->
         # 4: basic collector with feedback (A<->[B])
         {A:10, B:"50+", AB: "1 * in", BA: "1 * in",
         results: [
+          [50, 50]
           [100, 100]
           [200, 200]
-          [400, 400]
         ]}
 
         # 5: three-node graph (>-) with averaging
@@ -157,6 +158,7 @@ describe "Simulation", ->
         # 7: three-node graph with collector (>-[C])
         {A: 10, B: 20, C: "0+", AC: "1 * in", BC: "0.1 * in",
         results: [
+          [10, 20, 0]
           [10, 20, 12]
           [10, 20, 24]
         ]}
@@ -164,14 +166,15 @@ describe "Simulation", ->
         # 8: three-node graph with collector (>-[C]) and negative relationship
         {A: 10, B: 1, C: "0+", AC: "1 * in", BC: "-1 * in",
         results: [
+          [10, 1, 0]
           [10, 1, 9]
           [10, 1, 18]
-          [10, 1, 27]
         ]}
 
         # 9: four-node graph with collector (>-[D]) and scaled product combination
         {A: 50, B: 50, C: 0, D: "0+", AC: "1 * in", BC: "1 * in", CD: "1 * in"
         results: [
+          [50, 50, 25, 0]
           [50, 50, 25, 25]
           [50, 50, 25, 50]
         ]}
@@ -183,6 +186,7 @@ describe "Simulation", ->
         {A:30, B:"20+", AB: "1 * in",
         cap: true
         results: [
+          [30, 20]
           [30, 50]
           [30, 80]
           [30, 100]
@@ -192,6 +196,7 @@ describe "Simulation", ->
         {A:40, B:"90+", AB: "-1 * in",
         cap: true
         results: [
+          [40, 90]
           [40, 50]
           [40, 10]
           [40, 0]
@@ -283,7 +288,7 @@ describe "Simulation", ->
         @transferNode = @transferLink.transferNode
         @arguments =
           nodes: [@nodeA, @nodeB, @transferNode]
-          duration: 1
+          duration: 2
 
         @simulation = new Simulation(@arguments)
 
@@ -315,7 +320,7 @@ describe "Simulation", ->
         it "should transfer the appropriate percentage of the source node with a transfer-modifer", ->
           @nodeA.initialValue = 20
           @transferModifier = LinkNodes(@nodeA, @transferNode, RelationFactory.half)
-          @simulation.duration = 1
+          @simulation.duration = 2
           @simulation.run()
           expect(@nodeA.currentValue, "Node: #{@nodeA.title}").to.be.closeTo 10, 0.000001
           expect(@nodeB.currentValue, "Node: #{@nodeB.title}").to.be.closeTo 60, 0.000001
@@ -361,7 +366,7 @@ describe "The SimulationStore, with a network in the GraphStore", ->
 
       asyncListenTest done, SimulationActions.recordingFramesCreated, (data) ->
 
-          data.length.should.equal 11
+          data.length.should.equal 10
 
           frame0 = data[0]
           frame0.time.should.equal 0
@@ -382,7 +387,7 @@ describe "The SimulationStore, with a network in the GraphStore", ->
     it "should call simulationFramesCreated with 3 frames", (done) ->
       testFunction = (data) ->
         size = data.length
-        size.should.eql(4)
+        size.should.eql(3)
 
       asyncListenTest done, SimulationActions.recordingFramesCreated, testFunction
       SimulationActions.recordPeriod()


### PR DESCRIPTION
- fix one-step recording bug (should only record one data point)
- fix mini-graphs bug in which the first point(s) weren't plotted [#146030015]
- fix bug in which cached mini-graph data could grow unbounded [#146183765]
- adjust simulation unit tests to test initial values

One of the changes I made to the simulation loop while making the recent set of improvements to support flow nodes and collectors better was to add one step to the simulation loop to account for the initial conditions, i.e. if the user asks for ten steps, eleven data points should be generated -- the initial conditions plus the results of the first ten steps. This made sense in that context, but had some less-than-desirable results in other contexts, notably that one-step recording would now record two steps and mini-graphs were not displaying those initial conditions.

The approach taken here is to eliminate the additional step from the `Simulation` model -- when you ask for a specific duration, that's the number of steps you get -- and put the responsibility on the client to determine when to ask for the additional step. This puts the nexus of responsibility in the `SimulationStore` to determine the appropriate duration. Clients like the mini-graphs can use methods like `SimulationStore.simulationDuration()` to determine the total length of the simulation, which allows the mini-graphs to plot all of the data without missing the first couple points.

While investigating the mini-graph issues described above I discovered the fact that while dragging sliders to see the effect on the mini-graphs, the amount of data cached for use by the mini-graphs continued to grow until nodes were caching thousands of points, which would then be serialized with the document. Curious, I looked back through the git history where I discovered that originally, running the simulation triggered the clearing of mini-graph caches. When the one-step recording feature was added, this automatic clearing of the mini-graph caches was removed because in that case each additional point should be added to the mini-graph cumulatively. But no alternate mechanism for clearing the mini-graph caches was ever put in place. The solution I'm using here is to trim the size of the cache on each simulation run, rather than clearing it entirely.

Finally, moving the specification of the additional step out of the `Simulation` model required changes to the unit tests, which actually make the tests more clear because the initial conditions can now be tested whereas they could get hidden by the implicit additional step.

@knowuh I'm tapping you for review since you were part of the mini-graph and one-step recording work.