### PR TITLE
Limit mini-graph vertical scaling [#145735235]

### DIFF
--- a/src/code/views/node-svg-graph-view.coffee
+++ b/src/code/views/node-svg-graph-view.coffee
@@ -3,6 +3,9 @@
 SimulationStore = require '../stores/simulation-store'
 SquareImage = React.createFactory require "./square-image-view"
 
+limitMin = 0
+limitMax = 120
+
 module.exports = NodeSvgGraphView = React.createClass
   displayName: 'NodeSvgGraphView'
   mixins: [ SimulationStore.mixin ]
@@ -40,8 +43,8 @@ module.exports = NodeSvgGraphView = React.createClass
     data = _.takeRight(data, rangex).reverse()
 
     for point in data
-      if point > max then max = point
-      if point < min then min = point
+      if point > max and max < limitMax then max = Math.min(point, limitMax)
+      if point < min and min > limitMin then min = Math.max(point, limitMin)
     rangey = max - min
 
     data = _.map data, (d, i) ->


### PR DESCRIPTION
The only way to guarantee that the beginning of the mini-graph always aligns with the initial value slider is to limit the mini-graph to [0, 100] like the slider. I suspect this would not be ideal, however, because the shape of the curve as it breaks out of that range is often informative. The approach taken here is to allow the mini-graph vertical axis to scale to a fixed maximum value, in this case [0, 120]. This results in the beginning of the mini-graph generally being close to where the initial slider location, while giving a little visibility into the range beyond 100. There's obviously a tradeoff here. Increasing the value shows more of the curve while moving the mini-graph further away from its initial value slider, while decreasing it back toward 100 does the reverse. Also, I'm currently limiting the lower value to 0 but in theory one could tweak that as well. @ddamelin You should play with it to see what you think. @knowuh Since I assigned the last mini-graph PR to you I'll give you this easier one as well. Let me merge, however, pending Dan's feedback on whether he likes the behavior and/or wants to tweak the parameter(s).