### PR TITLE
Improve locations of connections to flow nodes

### DIFF
--- a/src/code/utils/js-plumb-diagram-toolkit.coffee
+++ b/src/code/utils/js-plumb-diagram-toolkit.coffee
@@ -18,6 +18,19 @@ module.exports = class DiagramToolkit
       DoNotThrowErrors: false
     @registerListeners()
 
+    # transfer-modifier links attach to fixed locations on the left or right of the flow node
+    @flowNodeModifierAnchors = [[0, 0.4, -1, 0, 8, 0], [1, 0.7, 1, 0, -8, 0]]
+    # flow links attach to fixed locations on the left or right of the flow node
+    @flowNodeFlowAnchors = [[0, 0.6, -1, 0, 16, 0], [1, 0.6, 1, 0, -16, 0]]
+    # other links attach to three fixed locations on the top or bottom of the flow node or
+    # two fixed locations on the left or right of the flow node chosen to not overlap the others
+    @flowNodeLinkAnchors = [[0.3, 0, 0, -1, 0, 12], [0.5, 0, 0, -1, 0, 12], [0.7, 0, 0, -1, 0, 12],
+                            [0, 0.25, -1, 0, 8, 0], [0, 0.75, -1, 0, 8, 0],
+                            [0.3, 1, 0, 1, 0, -10], [0.5, 1, 0, 1, 0, -10], [0.7, 1, 0, 1, 0, -10],
+                            [1, 0.25, 1, 0, -8, 0], [1, 0.4, 1, 0, -8, 0], [1, 0.8, 1, 0, -8, 0]]
+    # links to non-flow nodes link to locations assigned by jsPlumb on the left, top, or right faces
+    @standardAnchors = ["Continuous", { faces:["top","left","right"] }]
+
   registerListeners: ->
     @kit.bind 'connection', @handleConnect.bind @
     @kit.bind 'beforeDrag', (source) =>
@@ -239,28 +252,16 @@ module.exports = class DiagramToolkit
     linkTarget = opts.linkModel?.targetNode
     linkRelation = opts.linkModel?.relation
 
-    # transfer-modifier links attach to fixed locations on the left or right of the flow node
-    flowNodeModifierAnchors = [[0, 0.4, -1, 0, 8, 0], [1, 0.4, 1, 0, -8, 0]]
-    # flow links attach to fixed locations on the left or right of the flow node
-    flowNodeFlowAnchors = [[0, 0.6, -1, 0, 16, 0], [1, 0.6, 1, 0, -16, 0]]
-    # other links attach to three fixed locations on the top or bottom of the flow node or
-    # two fixed locations on the left or right of the flow node chosen to not overlap the others
-    flowNodeLinkAnchors = [[0.3, 0, 0, -1, 0, 12], [0.5, 0, 0, -1, 0, 12], [0.7, 0, 0, -1, 0, 12],
-                           [0, 0.25, -1, 0, 8, 0], [0, 0.75, -1, 0, 8, 0],
-                           [0.3, 1, 0, 1, 0, -10], [0.5, 1, 0, 1, 0, -10], [0.7, 1, 0, 1, 0, -10],
-                           [1, 0.25, 1, 0, -8, 0], [1, 0.75, 1, 0, -8, 0]]
-    # links to non-flow nodes link to locations assigned by jsPlumb on the left, top, or right faces
-    standardAnchors = ["Continuous", { faces:["top","left","right"] }]
     isLinkToFlowNode = linkTarget?.isTransfer
     isModifierToFlowNode = linkRelation?.isTransferModifier or
                             # transfer-modifier link isn't identified as such until it's defined
                             linkTarget?.isTransfer and linkTarget.transferLink?.sourceNode is linkSource
     isTransferToFlowNode = opts.isTransfer and opts.fromSource
     isTransferFromFlowNode = opts.isTransfer and not opts.fromSource
-    sourceAnchors = if isTransferFromFlowNode then flowNodeFlowAnchors else standardAnchors
-    targetAnchors = if isTransferToFlowNode then flowNodeFlowAnchors else \
-                      if isModifierToFlowNode then flowNodeModifierAnchors else \
-                        if isLinkToFlowNode then flowNodeLinkAnchors else standardAnchors
+    sourceAnchors = if isTransferFromFlowNode then @flowNodeFlowAnchors else @standardAnchors
+    targetAnchors = if isTransferToFlowNode then @flowNodeFlowAnchors else \
+                      if isModifierToFlowNode then @flowNodeModifierAnchors else \
+                        if isLinkToFlowNode then @flowNodeLinkAnchors else @standardAnchors
 
     connection = @kit.connect
       source: opts.source

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -26,7 +26,7 @@ module.exports = React.createClass
   getDefaultProps: ->
     linkTarget: '.link-top'
     connectionTarget: '.link-target'
-    transferTarget: '.transfer-target'
+    transferTarget: '.link-target'
 
   componentDidMount: ->
     $container = $(@refs.container)
@@ -293,13 +293,14 @@ module.exports = React.createClass
     target = $(ReactDOM.findDOMNode this.refs[targetNode.key]).find(targetConnectionClass)
     if source and target
       opts = {
-        source: source,
-        target: target,
-        label: "",
+        fromSource: fromSource
+        source: source
+        target: target
+        label: ""
         color: if fromSource then LinkColors.decrease else LinkColors.increase
         thickness: 10
         showIndicators: false
-        isEditing: false,
+        isEditing: false
         linkModel: link
         isTransfer: true
         hideArrow: fromSource


### PR DESCRIPTION
- flow links attach to the flow node at the locations of the "pipes" in the image
- transfer-modifier links attach to the flow node above the flow links
- range links attach to the flow node on the top and bottom or on the sides away from the flow and transfer-modifier links
- all links are adjusted to touch the node rather than stopping ~10-15 pixels away at the node surround

To accomplish these things we abandon jsPlumb's "Continuous" anchors, for which jsPlumb assigns the connection points and adjusts them on the basis of how many connections there are, etc., in favor of a "Dynamic" (in jsPlumb lingo) set of "Static" (also jsPlumb lingo) anchor points chosen not to interfere with each other.

@dstrawberrygirl I know you're away at a conference at the moment, but you've done some work in this area so if you have some time and wanted to save Doug from having to review yet another of my pull requests you could take a look at this jsPlumb-related PR. Otherwise, @dougmartin , it could fall to you again. I'm off of Building Models after today, though, so we're nearing the end. 😉 