### PR TITLE
Steps start at 1 for models without collectors [#146744415]

### DIFF
--- a/src/code/models/simulation.coffee
+++ b/src/code/models/simulation.coffee
@@ -215,12 +215,12 @@ module.exports = class Simulation
     # from the source node of a transfer link to the transfer node of the transfer link.
 
     nodeValues = {}
+    collectorNodes = _.filter @nodes, (node) -> node.isAccumulator
 
     step = =>
 
       # update the accumulator/collector values on all but the first step
       if time isnt 0
-        collectorNodes = _.filter @nodes, (node) -> node.isAccumulator
         _.each collectorNodes, (node) -> node.setAccumulatorValue nodeValues
 
       # push values down chain

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -148,6 +148,8 @@ SimulationStore   = Reflux.createStore
           if @settings.isRecording
             framesNoTime = _.map frames, (frame) =>
               frame.time = @settings.experimentFrame++
+              # without collectors, start steps at 1
+              ++frame.time unless @settings.graphHasCollector
               return frame
             SimulationActions.recordingFramesCreated(framesNoTime)
 

--- a/test/simulation-test.coffee
+++ b/test/simulation-test.coffee
@@ -369,11 +369,11 @@ describe "The SimulationStore, with a network in the GraphStore", ->
           data.length.should.equal 10
 
           frame0 = data[0]
-          frame0.time.should.equal 0
+          frame0.time.should.equal 1
           frame0.nodes.should.eql [ { title: 'A', value: 10 }, { title: 'B', value: 1 } ]
 
           frame9 = data[9]
-          frame9.time.should.equal 9
+          frame9.time.should.equal 10
           frame9.nodes.should.eql [ { title: 'A', value: 10 }, { title: 'B', value: 1 } ]
 
       SimulationActions.createExperiment()


### PR DESCRIPTION
From discussion on https://www.pivotaltracker.com/story/show/145575739 and Slack:

Evangeline Ireland
[2:46 PM] 
So based on this story: https://www.pivotaltracker.com/story/show/145575739
Only runs that have collectors should have steps that start at 0. Models with no collectors should still start at 1? Current production all models start at 0.

Dan Damelin [4:07 PM] 
Yeah. I think it should start with 1 for non collectors.