### PR TITLE
Collector nodes should ignore outbound `accumulator` links

### DIFF
--- a/src/code/models/node.coffee
+++ b/src/code/models/node.coffee
@@ -110,8 +110,8 @@ module.exports = class Node extends GraphPrimitive
     else
       throw new Error "Bad link for Node:#{@.id}"
 
-  outLinks: ->
-    _.filter @links, (link) => link.sourceNode is @
+  outLinks: (relationType = null) ->
+    _.filter @links, (link) => (link.sourceNode is @) and (relationType is null or relationType is link.relation.type)
 
   inLinks: (relationType = null) ->
     _.filter @links, (link) => (link.targetNode is @) and (relationType is null or relationType is link.relation.type)


### PR DESCRIPTION
`Node.outLinks()` accepts `relationType` argument like `Node.inLinks()`
- fixes [#147461367] which was treating outbound `accumulator` links as `transfer` links due to the expectation that the `relationType` argument would be respected.

@dougmartin If you could take a look at #309 as well I'd like to get both of them into a build. Thx