### PR TITLE
Update relation graph drawing behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.2.0
 
 node_js:
-  - "0.10"
+  - "node"
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "gulp-stylus": "^2.0.1",
     "mocha": "^2.1.0",
     "react-addons-test-utils": "^15.4.2",
-    "require-dir": "^0.1.0",
+    "require-dir": "^0.3",
     "semver": "^5.1.0",
     "sinon": "^1.12.2",
     "sync-exec": "~0.6.x",

--- a/src/code/views/svg-graph-view.coffee
+++ b/src/code/views/svg-graph-view.coffee
@@ -185,6 +185,7 @@ module.exports = SvgGraphView = React.createClass
     # can only draw on custom relationships
     if @state.canDraw
       document.addEventListener 'mousemove', @drawCurve
+      document.addEventListener 'mouseup', @endDrawCurve
       @drawing = true
       if @state.newCustomData
         scaledCoords = @pointToScaledCoords(evt)
@@ -211,6 +212,7 @@ module.exports = SvgGraphView = React.createClass
   endDrawCurve: (evt) ->
     if @drawing
       document.removeEventListener 'mousemove', @drawCurve
+      document.removeEventListener 'mouseup', @endDrawCurve
       @drawing = false
       #update relation with custom data
       @updateRelationCustomData(@state.currentData)
@@ -241,7 +243,6 @@ module.exports = SvgGraphView = React.createClass
       (div
         className: drawClass
         onMouseDown: @startDrawCurve
-        onMouseUp: @endDrawCurve
         ref: "graphBody"
         ,
         if @state.newCustomData

--- a/src/code/views/svg-graph-view.coffee
+++ b/src/code/views/svg-graph-view.coffee
@@ -184,6 +184,7 @@ module.exports = SvgGraphView = React.createClass
   startDrawCurve: (evt) ->
     # can only draw on custom relationships
     if @state.canDraw
+      document.addEventListener 'mousemove', @drawCurve
       @drawing = true
       if @state.newCustomData
         scaledCoords = @pointToScaledCoords(evt)
@@ -209,12 +210,13 @@ module.exports = SvgGraphView = React.createClass
 
   endDrawCurve: (evt) ->
     if @drawing
+      document.removeEventListener 'mousemove', @drawCurve
       @drawing = false
       #update relation with custom data
       @updateRelationCustomData(@state.currentData)
 
   pointToScaledCoords: (evt) ->
-    rect = evt.target.getBoundingClientRect()
+    rect = this.refs.graphBody?.getBoundingClientRect()
     coords = {x: rect.width - (rect.right-evt.clientX), y: rect.bottom - evt.clientY}
     scaledCoords = {x: Math.round(coords.x / rect.width * 100), y: Math.round(coords.y / rect.height * 100)}
     scaledCoords
@@ -238,9 +240,8 @@ module.exports = SvgGraphView = React.createClass
       (div
         className: drawClass
         onMouseDown: @startDrawCurve
-        onMouseMove: @drawCurve
         onMouseUp: @endDrawCurve
-        onMouseOut: @endDrawCurve
+        ref: "graphBody"
         ,
         if @state.newCustomData
           (div {className: 'graph-hint'},

--- a/src/code/views/svg-graph-view.coffee
+++ b/src/code/views/svg-graph-view.coffee
@@ -218,6 +218,7 @@ module.exports = SvgGraphView = React.createClass
   pointToScaledCoords: (evt) ->
     rect = this.refs.graphBody?.getBoundingClientRect()
     coords = {x: rect.width - (rect.right-evt.clientX), y: rect.bottom - evt.clientY}
+    coords.y = Math.max(0, Math.min(coords.y, rect.height))
     scaledCoords = {x: Math.round(coords.x / rect.width * 100), y: Math.round(coords.y / rect.height * 100)}
     scaledCoords
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2294,9 +2294,9 @@ replacestream@^4.0.0:
     object-assign "^4.0.1"
     readable-stream "^2.0.2"
 
-require-dir@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/require-dir/-/require-dir-0.1.0.tgz#81e01e299faf5b74c34b6594f8e5add5985ddec5"
+require-dir@^0.3:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/require-dir/-/require-dir-0.3.2.tgz#c1d5c75e9fbffde9f2e6b33e383db4f594b5a6a9"
 
 resolve-dir@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
@knowuh Could you take a look?

Previously, when drawing the "Varies" relationship graph, when your mouse left the graph area you'd lose connection, and you'd have to re-click the graph to continue drawing.

Now you should be able to leave the graph and return to it and continue drawing. Further, if you move above or below the graph, it should continue drawing at the very top or bottom. It should not edit points if the mouse is to the left or right of the graph.

It can be tested here: https://sage.concord.org/branch/relation-graph-mouse-handler/sage.html