### PR TITLE
Complexity levels

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "mathjs": "1.7.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
+    "react-radio-group": "^3.0.2",
     "reflux": "0.2.7",
     "uuid": "2.0.1"
   },

--- a/src/code/data/migrations/20_add_complexity.coffee
+++ b/src/code/data/migrations/20_add_complexity.coffee
@@ -1,0 +1,21 @@
+AppSettingsStore = require('../../stores/app-settings-store').store
+
+migration =
+  version: "1.19.0"
+  description: "Adds complexity setting, based on old diagramOnly. Removes diagramOnly"
+  date: "2017-09-26"
+
+  doUpdate: (data) ->
+    data.settings ?= {}
+    wasDiagramOnly = data.settings.diagramOnly or false
+
+    delete data.settings.diagramOnly
+
+    defaultComplexity = if wasDiagramOnly
+      AppSettingsStore.Complexity.diagramOnly
+    else
+      AppSettingsStore.Complexity.basic
+
+    data.settings.complexity ?= defaultComplexity
+
+module.exports = _.mixin migration, require './migration-mixin'

--- a/src/code/data/migrations/migrations.coffee
+++ b/src/code/data/migrations/migrations.coffee
@@ -20,6 +20,7 @@ migrations = [
   require "./17_remove_simulation_speed"
   require "./18_serialize_experiment_number"
   require "./19_add_relation_type"
+  require "./20_add_complexity"
 ]
 
 module.exports =

--- a/src/code/models/relation-factory.coffee
+++ b/src/code/models/relation-factory.coffee
@@ -207,6 +207,10 @@ module.exports = class RelationFactory
   @iconName: (incdec,amount)->
     "icon-#{incdec.prefixIco}-#{amount.postfixIco}"
 
+  @basicVectors:
+    increase: @increase
+    decrease: @decrease
+
   @vectors:
     increase: @increase
     decrease: @decrease

--- a/src/code/stores/app-settings-store.coffee
+++ b/src/code/stores/app-settings-store.coffee
@@ -3,29 +3,40 @@ ImportActions   = require '../actions/import-actions'
 
 AppSettingsActions = Reflux.createActions(
   [
-    "diagramOnly"
+    "setComplexity"
     "showMinigraphs"
     "relationshipSymbols"
   ]
 )
 
+Complexity = {
+  diagramOnly: "diagram-only",
+  basic: "basic",
+  expanded: "expanded",
+  collectors: "collectors"
+}
+
 AppSettingsStore   = Reflux.createStore
   listenables: [AppSettingsActions, ImportActions]
 
   init: ->
+    complexity = if HashParams.getParam('simplified')
+      Complexity.diagramOnly
+    else
+      Complexity.basic
+
     @settings =
       showingSettingsDialog: false
-      diagramOnly: HashParams.getParam('simplified') or false
+      complexity: complexity
       showingMinigraphs: false
       relationshipSymbols: false
 
-  onDiagramOnly: (diagramOnly) ->
-    @settings.diagramOnly = diagramOnly
-    if diagramOnly then @settings.showingMinigraphs = false
-    @notifyChange()
-
   onShowMinigraphs: (show) ->
     @settings.showingMinigraphs = show
+    @notifyChange()
+
+  onSetComplexity: (val) ->
+    @settings.complexity = val
     @notifyChange()
 
   onRelationshipSymbols: (show) ->
@@ -34,19 +45,17 @@ AppSettingsStore   = Reflux.createStore
 
   notifyChange: ->
     @trigger _.clone @settings
-    if @settings.diagramOnly
-      HashParams.setParam('simplified','true')
-    else
-      HashParams.clearParam('simplified')
 
   onImport: (data) ->
     _.merge @settings, data.settings
     @notifyChange()
 
   serialize: ->
-    diagramOnly: @settings.diagramOnly
+    complexity: @settings.complexity
     showingMinigraphs: @settings.showingMinigraphs
     relationshipSymbols: @settings.relationshipSymbols
+
+AppSettingsStore.Complexity = Complexity
 
 mixin =
   getInitialState: ->

--- a/src/code/stores/app-settings-store.coffee
+++ b/src/code/stores/app-settings-store.coffee
@@ -10,10 +10,10 @@ AppSettingsActions = Reflux.createActions(
 )
 
 Complexity = {
-  diagramOnly: "diagram-only",
-  basic: "basic",
-  expanded: "expanded",
-  collectors: "collectors"
+  diagramOnly: 0,
+  basic: 1,
+  expanded: 2,
+  collectors: 3
 }
 
 AppSettingsStore   = Reflux.createStore

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -14,6 +14,7 @@ GraphActions        = require "../actions/graph-actions"
 CodapActions        = require '../actions/codap-actions'
 InspectorPanelStore = require "../stores/inspector-panel-store"
 CodapConnect        = require '../models/codap-connect'
+RelationFactory     = require "../models/relation-factory"
 DEFAULT_CONTEXT_NAME = 'building-models'
 
 GraphStore  = Reflux.createStore
@@ -515,6 +516,41 @@ GraphStore  = Reflux.createStore
       links: linkDescription
       model: modelDescription
     }
+
+  # Returns the minimum complexity that the current graph allows.
+  # Returns
+  #   diagramOnly    if there are no defined relationships
+  #   basic          if all scalars are `about the same`
+  #   expanded       if there are no collectors
+  #   collectors     if there are collectors
+  getMinimumComplexity: ->
+    complexities = {
+      0: AppSettingsStore.store.Complexity.diagramOnly
+      1: AppSettingsStore.store.Complexity.basic
+      2: AppSettingsStore.store.Complexity.expanded
+      3: AppSettingsStore.store.Complexity.collectors
+    }
+
+    minComplexity = 0
+
+    links = @getLinks()
+    _.each links, (link) ->
+      return unless (source = link.sourceNode) and (target = link.targetNode)
+
+      if source.isAccumulator or target.isAccumulator
+        # we know we have to be the highest complexity
+        minComplexity = 3
+      else if link.relation?.formula
+        # we know we'll be at least 1 or 2
+        linkComplexity
+        relation = RelationFactory.selectionsFromRelation(link.relation)
+        if relation.scalar.id is "aboutTheSame"
+          linkComplexity = 1
+        else linkComplexity = 2
+        if linkComplexity > minComplexity
+          minComplexity = linkComplexity
+
+    return complexities[minComplexity]
 
   loadData: (data) ->
     log.info "json success"

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -542,7 +542,6 @@ GraphStore  = Reflux.createStore
         minComplexity = 3
       else if link.relation?.formula
         # we know we'll be at least 1 or 2
-        linkComplexity
         relation = RelationFactory.selectionsFromRelation(link.relation)
         if relation.scalar.id is "aboutTheSame"
           linkComplexity = 1

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -519,18 +519,11 @@ GraphStore  = Reflux.createStore
 
   # Returns the minimum complexity that the current graph allows.
   # Returns
-  #   diagramOnly    if there are no defined relationships
-  #   basic          if all scalars are `about the same`
-  #   expanded       if there are no collectors
-  #   collectors     if there are collectors
+  #   0 (diagramOnly)    if there are no defined relationships
+  #   1 (basic)          if all scalars are `about the same`
+  #   2 (expanded)       if there are no collectors
+  #   3 (collectors)     if there are collectors
   getMinimumComplexity: ->
-    complexities = {
-      0: AppSettingsStore.store.Complexity.diagramOnly
-      1: AppSettingsStore.store.Complexity.basic
-      2: AppSettingsStore.store.Complexity.expanded
-      3: AppSettingsStore.store.Complexity.collectors
-    }
-
     minComplexity = 0
 
     links = @getLinks()
@@ -549,7 +542,7 @@ GraphStore  = Reflux.createStore
         if linkComplexity > minComplexity
           minComplexity = linkComplexity
 
-    return complexities[minComplexity]
+    return minComplexity
 
   loadData: (data) ->
     log.info "json success"

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -1,4 +1,4 @@
-AppSettingsActions = require('./app-settings-store').actions
+AppSettingsStore   = require './app-settings-store'
 ImportActions      = require '../actions/import-actions'
 GraphActions       = require '../actions/graph-actions'
 Simulation         = require "../models/simulation"
@@ -31,7 +31,7 @@ SimulationActions.runSimulation = Reflux.createAction({sync: true})
 
 SimulationStore   = Reflux.createStore
   listenables: [
-    SimulationActions, AppSettingsActions,
+    SimulationActions, AppSettingsStore.actions,
     ImportActions, GraphActions]
 
   init: ->
@@ -64,8 +64,9 @@ SimulationStore   = Reflux.createStore
     @_updateModelIsRunnable()
     @_updateGraphHasCollector()
 
-  onDiagramOnly: ->
-    SimulationActions.collapseSimulationPanel()
+  onSetComplexity: (complexity) ->
+    if complexity is AppSettingsStore.store.Complexity.diagramOnly
+      SimulationActions.collapseSimulationPanel()
 
   onExpandSimulationPanel: ->
     @settings.simulationPanelExpanded = true

--- a/src/code/utils/lang/en-US.coffee
+++ b/src/code/utils/lang/en-US.coffee
@@ -165,10 +165,10 @@ module.exports =
 
   "~SIMULATION.SIMULATION_SETTINGS": "Simulation Settings"
   "~SIMULATION.DIAGRAM_SETTINGS": "Diagram settings"
+  "~SIMULATION.VIEW_SETTINGS": "View settings"
   "~SIMULATION.STEP_UNIT": "Each calculation is 1"
   "~SIMULATION.DURATION": "Calculations per run"
   "~SIMULATION.CAP_VALUES": "Limit values to min/max range"
-  "~SIMULATION.COMPLEXITY": "Complexity:"
   "~SIMULATION.COMPLEXITY.DIAGRAM_ONLY": "Diagram only tools"
   "~SIMULATION.COMPLEXITY.BASIC": "Basic (increases/decreases) relationships"
   "~SIMULATION.COMPLEXITY.EXPANDED": "Expanded set of relationships including custom graphs"

--- a/src/code/utils/lang/en-US.coffee
+++ b/src/code/utils/lang/en-US.coffee
@@ -168,7 +168,11 @@ module.exports =
   "~SIMULATION.STEP_UNIT": "Each calculation is 1"
   "~SIMULATION.DURATION": "Calculations per run"
   "~SIMULATION.CAP_VALUES": "Limit values to min/max range"
-  "~SIMULATION.DIAGRAM_ONLY": "Diagram only tools"
+  "~SIMULATION.COMPLEXITY": "Complexity:"
+  "~SIMULATION.COMPLEXITY.DIAGRAM_ONLY": "Diagram only tools"
+  "~SIMULATION.COMPLEXITY.BASIC": "Basic (increases/decreases) relationships"
+  "~SIMULATION.COMPLEXITY.EXPANDED": "Expanded set of relationships including custom graphs"
+  "~SIMULATION.COMPLEXITY.COLLECTORS": "Include collectors"
   "~SIMULATION.RELATIONSHIP_SYMBOLS": "Show relationship symbols"
 
   "~DROP.ONLY_IMAGES_ALLOWED": "Sorry, only images are allowed."

--- a/src/code/views/app-view.coffee
+++ b/src/code/views/app-view.coffee
@@ -61,7 +61,7 @@ module.exports = React.createClass
           })
           (DocumentActions
             graphStore: @props.graphStore
-            diagramOnly: @state.diagramOnly
+            diagramOnly: @state.complexity is AppSettingsStore.store.Complexity.diagramOnly
             iframed: @state.iframed
           )
         )
@@ -77,7 +77,7 @@ module.exports = React.createClass
           onNodeChanged: @onNodeChanged
           onNodeDelete: @onNodeDelete
           palette: @state.palette
-          diagramOnly: @state.diagramOnly
+          diagramOnly: @state.complexity is AppSettingsStore.store.Complexity.diagramOnly
           toggleImageBrowser: @toggleImageBrowser
           graphStore: @props.graphStore
           ref: "inspectorPanel"

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -452,6 +452,7 @@ module.exports = React.createClass
     dataColor = Color.colors.mediumGray.value
     if @state.isRecording
       dataColor = Color.colors.data.value
+    diagramOnly = @state.complexity is AppSettingsStore.store.Complexity.diagramOnly
 
     (div {className: "graph-view #{if @state.canDrop then 'can-drop' else ''}", ref: 'linkView', onDragOver: @onDragOver, onDrop: @onDrop, onDragLeave: @onDragLeave},
       (div {className: 'container', ref: 'container', onMouseDown: @onMouseDown, onMouseUp: @onMouseUp, onMouseMove: @onMouseMove},
@@ -476,7 +477,7 @@ module.exports = React.createClass
             graphStore: @props.graphStore
             selectionManager: @props.selectionManager
             showMinigraph: @state.showingMinigraphs
-            showGraphButton: @state.codapHasLoaded and not @state.diagramOnly
+            showGraphButton: @state.codapHasLoaded and not diagramOnly
           })
       )
     )

--- a/src/code/views/link-relation-view.coffee
+++ b/src/code/views/link-relation-view.coffee
@@ -1,10 +1,11 @@
 {br, div, h2, label, span, input, p, i, select, option, textarea} = React.DOM
 
-RelationFactory = require "../models/relation-factory"
-SvgGraph        = React.createFactory require "./svg-graph-view"
-tr              = require "../utils/translate"
-autosize        = require "autosize"
-SimulationStore = require '../stores/simulation-store'
+RelationFactory  = require "../models/relation-factory"
+SvgGraph         = React.createFactory require "./svg-graph-view"
+tr               = require "../utils/translate"
+autosize         = require "autosize"
+SimulationStore  = require '../stores/simulation-store'
+AppSettingsStore = require '../stores/app-settings-store'
 
 Graph = React.createFactory React.createClass
   render: ->
@@ -31,7 +32,7 @@ module.exports = LinkRelationView = React.createClass
 
   displayName: 'LinkRelationView'
 
-  mixins: [SimulationStore.mixin]
+  mixins: [ SimulationStore.mixin, AppSettingsStore.mixin ]
 
   getDefaultProps: ->
     link:
@@ -157,13 +158,19 @@ module.exports = LinkRelationView = React.createClass
     newVector
 
   getScalar: ->
-    if @refs.scalar
+    if @state.complexity is AppSettingsStore.store.Complexity.basic
+      RelationFactory.scalars.aboutTheSame
+    else if @refs.scalar
       RelationFactory.scalars[@refs.scalar.value]
     else
       undefined
 
   renderVectorPulldown: (vectorSelection)->
-    options = _.map RelationFactory.vectors, (opt, i) ->
+    vectorOptions = if @state.complexity is AppSettingsStore.store.Complexity.basic
+      RelationFactory.basicVectors
+    else
+      RelationFactory.vectors
+    options = _.map vectorOptions, (opt, i) ->
       (option {value: opt.id, key: i}, opt.uiText)
 
     if not vectorSelection?
@@ -190,8 +197,12 @@ module.exports = LinkRelationView = React.createClass
     else
       currentOption = scalarSelection.id
 
-    # place dropdown but hide it if we haven't selected vector (to keep spacing)
-    visClass = if @state.selectedVector then ' visible' else ' hidden'
+    onlyBasic = @state.complexity is AppSettingsStore.store.Complexity.basic
+    vectorSelected = @state.selectedVector
+    # place dropdown but hide it (to keep spacing) if we haven't selected
+    # the vector or we have only basic complecity settings
+    visible = vectorSelected and not onlyBasic
+    visClass = if visible then ' visible' else ' hidden'
 
     if @state.selectedVector?.isCustomRelationship
       (div {className: "bb-select#{visClass}"},

--- a/src/code/views/simulation-inspector-view.coffee
+++ b/src/code/views/simulation-inspector-view.coffee
@@ -31,25 +31,15 @@ module.exports = React.createClass
   setComplexity: (val) ->
     AppSettingsStore.actions.setComplexity val
 
-  isDisabled: (myComplexity, minComplexity) ->
-    if minComplexity is Complexity.diagramOnly
-      return false
-    if minComplexity is Complexity.basic
-      return myComplexity is Complexity.diagramOnly
-    if minComplexity is Complexity.expanded
-      return myComplexity is Complexity.diagramOnly or
-             myComplexity is Complexity.basic
-    return myComplexity isnt Complexity.collectors
-
   render: ->
     runPanelClasses = "run-panel"
     diagramOnly = @state.complexity is Complexity.diagramOnly
     if diagramOnly then runPanelClasses += " collapsed"
 
     minComplexity = GraphStore.getMinimumComplexity()
-    diagramOnlyDisabled = @isDisabled(Complexity.diagramOnly, minComplexity)
-    basicDisabled = @isDisabled(Complexity.basic, minComplexity)
-    expandedDisabled = @isDisabled(Complexity.expanded, minComplexity)
+    diagramOnlyDisabled = minComplexity > Complexity.diagramOnly
+    basicDisabled = minComplexity > Complexity.basic
+    expandedDisabled = minComplexity > Complexity.expanded
 
     (div {className: "simulation-panel"},
       (div {className: "title"}, tr "~SIMULATION.DIAGRAM_SETTINGS")
@@ -60,19 +50,19 @@ module.exports = React.createClass
         className: "radio-group"
       }, [
         (label {key: 'complexity-diagram-only'},
-          (RadioF {value: "diagram-only", disabled: diagramOnlyDisabled})
+          (RadioF {value: Complexity.diagramOnly, disabled: diagramOnlyDisabled})
           (span {className: if diagramOnlyDisabled then "disabled"}, tr '~SIMULATION.COMPLEXITY.DIAGRAM_ONLY')
         )
         (label {key: 'complexity-basic'},
-          (RadioF {value: "basic", disabled: basicDisabled})
+          (RadioF {value: Complexity.basic, disabled: basicDisabled})
           (span {className: if basicDisabled then "disabled"}, tr '~SIMULATION.COMPLEXITY.BASIC')
         )
         (label {key: 'complexity-expanded'},
-          (RadioF {value: "expanded", disabled: expandedDisabled})
+          (RadioF {value: Complexity.expanded, disabled: expandedDisabled})
           (span {className: if expandedDisabled then "disabled"}, tr '~SIMULATION.COMPLEXITY.EXPANDED')
         )
         (label {key: 'complexity-collectors'},
-          (RadioF {value: "collectors"})
+          (RadioF {value: Complexity.collectors})
           (span {}, tr '~SIMULATION.COMPLEXITY.COLLECTORS')
         )
       ])

--- a/src/code/views/simulation-inspector-view.coffee
+++ b/src/code/views/simulation-inspector-view.coffee
@@ -4,8 +4,11 @@ RadioF          = React.createFactory Radio
 Dropdown        = React.createFactory require './dropdown-view'
 SimulationStore = require '../stores/simulation-store'
 AppSettingsStore = require '../stores/app-settings-store'
+GraphStore      = require('../stores/graph-store').store
 tr              = require '../utils/translate'
 {div, span, i, input, label}  = React.DOM
+
+Complexity = AppSettingsStore.store.Complexity
 
 module.exports = React.createClass
 
@@ -28,10 +31,25 @@ module.exports = React.createClass
   setComplexity: (val) ->
     AppSettingsStore.actions.setComplexity val
 
+  isDisabled: (myComplexity, minComplexity) ->
+    if minComplexity is Complexity.diagramOnly
+      return false
+    if minComplexity is Complexity.basic
+      return myComplexity is Complexity.diagramOnly
+    if minComplexity is Complexity.expanded
+      return myComplexity is Complexity.diagramOnly or
+             myComplexity is Complexity.basic
+    return myComplexity isnt Complexity.collectors
+
   render: ->
     runPanelClasses = "run-panel"
-    diagramOnly = @state.complexity is AppSettingsStore.store.Complexity.diagramOnly
+    diagramOnly = @state.complexity is Complexity.diagramOnly
     if diagramOnly then runPanelClasses += " collapsed"
+
+    minComplexity = GraphStore.getMinimumComplexity()
+    diagramOnlyDisabled = @isDisabled(Complexity.diagramOnly, minComplexity)
+    basicDisabled = @isDisabled(Complexity.basic, minComplexity)
+    expandedDisabled = @isDisabled(Complexity.expanded, minComplexity)
 
     (div {className: "simulation-panel"},
       (div {className: "title"}, tr "~SIMULATION.DIAGRAM_SETTINGS")
@@ -42,16 +60,16 @@ module.exports = React.createClass
         className: "radio-group"
       }, [
         (label {key: 'complexity-diagram-only'},
-          (RadioF {value: "diagram-only"})
-          (span {}, tr '~SIMULATION.COMPLEXITY.DIAGRAM_ONLY')
+          (RadioF {value: "diagram-only", disabled: diagramOnlyDisabled})
+          (span {className: if diagramOnlyDisabled then "disabled"}, tr '~SIMULATION.COMPLEXITY.DIAGRAM_ONLY')
         )
         (label {key: 'complexity-basic'},
-          (RadioF {value: "basic"})
-          (span {}, tr '~SIMULATION.COMPLEXITY.BASIC')
+          (RadioF {value: "basic", disabled: basicDisabled})
+          (span {className: if basicDisabled then "disabled"}, tr '~SIMULATION.COMPLEXITY.BASIC')
         )
         (label {key: 'complexity-expanded'},
-          (RadioF {value: "expanded"})
-          (span {}, tr '~SIMULATION.COMPLEXITY.EXPANDED')
+          (RadioF {value: "expanded", disabled: expandedDisabled})
+          (span {className: if expandedDisabled then "disabled"}, tr '~SIMULATION.COMPLEXITY.EXPANDED')
         )
         (label {key: 'complexity-collectors'},
           (RadioF {value: "collectors"})

--- a/src/code/views/simulation-inspector-view.coffee
+++ b/src/code/views/simulation-inspector-view.coffee
@@ -1,3 +1,6 @@
+{RadioGroup, Radio}  = require 'react-radio-group'
+RadioGroupF     = React.createFactory RadioGroup
+RadioF          = React.createFactory Radio
 Dropdown        = React.createFactory require './dropdown-view'
 SimulationStore = require '../stores/simulation-store'
 AppSettingsStore = require '../stores/app-settings-store'
@@ -62,17 +65,26 @@ module.exports = React.createClass
           tr '~DOCUMENT.ACTIONS.SHOW_MINI_GRAPHS'
         ])
       )
-      (div {className: "row"},
-        (label {key: 'diagram-label'}, [
-          input {
-            key: 'diagram-checkbox'
-            type: 'checkbox'
-            value: 'diagram-only'
-            checked: @state.diagramOnly
-            onChange: @setDiagramOnly
-          }
-          tr '~SIMULATION.DIAGRAM_ONLY'
-        ])
+      (div {},
+        (div {className: "radio-title"}, tr "~SIMULATION.COMPLEXITY")
+        (RadioGroupF {name: "complexity", className: "radio-group"},
+          (label {key: 'complexity-diagram-only'},
+            (RadioF {value: "diagram-only"})
+            (span {}, tr '~SIMULATION.COMPLEXITY.DIAGRAM_ONLY')
+          )
+          (label {key: 'complexity-basic'},
+            (RadioF {value: "basic"})
+            (span {}, tr '~SIMULATION.COMPLEXITY.BASIC')
+          )
+          (label {key: 'complexity-expanded'},
+            (RadioF {value: "expanded"})
+            (span {}, tr '~SIMULATION.COMPLEXITY.EXPANDED')
+          )
+          (label {key: 'complexity-collectors'},
+            (RadioF {value: "collectors"})
+            (span {}, tr '~SIMULATION.COMPLEXITY.COLLECTORS')
+          )
+        )
       )
       (div {className: "row"},
         (label {key: 'symbols-label'}, [

--- a/src/code/views/simulation-inspector-view.coffee
+++ b/src/code/views/simulation-inspector-view.coffee
@@ -19,25 +19,28 @@ module.exports = React.createClass
   setCapNodeValues: (e) ->
     SimulationStore.actions.capNodeValues e.target.checked
 
-  setDiagramOnly: (e) ->
-    AppSettingsStore.actions.diagramOnly e.target.checked
-
   setShowingMinigraphs: (e) ->
     AppSettingsStore.actions.showMinigraphs e.target.checked
 
   setRelationshipSymbols: (e) ->
     AppSettingsStore.actions.relationshipSymbols e.target.checked
 
+  setComplexity: (val) ->
+    AppSettingsStore.actions.setComplexity val
+
   render: ->
     runPanelClasses = "run-panel"
-    if not @state.diagramOnly then runPanelClasses += " expanded"
+    diagramOnly = @state.complexity is AppSettingsStore.store.Complexity.diagramOnly
+    if not diagramOnly then runPanelClasses += " expanded"
     minigraphsCheckboxClass = "row"
-    if @state.diagramOnly then minigraphsCheckboxClass += " disabled"
+    if diagramOnly then minigraphsCheckboxClass += " disabled"
 
     (div {className: "simulation-panel"},
       (div {className: "title"}, tr "~SIMULATION.DIAGRAM_SETTINGS")
       (RadioGroupF {
         name: "complexity"
+        selectedValue: @state.complexity
+        onChange: @setComplexity
         className: "radio-group"
       }, [
         (label {key: 'complexity-diagram-only'},

--- a/src/code/views/simulation-inspector-view.coffee
+++ b/src/code/views/simulation-inspector-view.coffee
@@ -35,6 +35,54 @@ module.exports = React.createClass
     if @state.diagramOnly then minigraphsCheckboxClass += " disabled"
 
     (div {className: "simulation-panel"},
+      (div {className: "title"}, tr "~SIMULATION.DIAGRAM_SETTINGS")
+      (RadioGroupF {
+        name: "complexity"
+        className: "radio-group"
+      }, [
+        (label {key: 'complexity-diagram-only'},
+          (RadioF {value: "diagram-only"})
+          (span {}, tr '~SIMULATION.COMPLEXITY.DIAGRAM_ONLY')
+        )
+        (label {key: 'complexity-basic'},
+          (RadioF {value: "basic"})
+          (span {}, tr '~SIMULATION.COMPLEXITY.BASIC')
+        )
+        (label {key: 'complexity-expanded'},
+          (RadioF {value: "expanded"})
+          (span {}, tr '~SIMULATION.COMPLEXITY.EXPANDED')
+        )
+        (label {key: 'complexity-collectors'},
+          (RadioF {value: "collectors"})
+          (span {}, tr '~SIMULATION.COMPLEXITY.COLLECTORS')
+        )
+      ])
+      (div {className: "title"}, tr "~SIMULATION.VIEW_SETTINGS")
+      (div {className: minigraphsCheckboxClass},
+        (label {key: 'minigraphs-label'}, [
+          input {
+            key: 'minigraphs-checkbox'
+            type: 'checkbox'
+            value: 'show-mini'
+            checked: @state.showingMinigraphs
+            disabled: @state.diagramOnly
+            onChange: @setShowingMinigraphs
+          }
+          tr '~DOCUMENT.ACTIONS.SHOW_MINI_GRAPHS'
+        ])
+      )
+      (div {className: "row"},
+        (label {key: 'symbols-label'}, [
+          input {
+            key: 'symbols-checkbox'
+            type: 'checkbox'
+            value: 'relationship-symbols'
+            checked: @state.relationshipSymbols
+            onChange: @setRelationshipSymbols
+          }
+          tr '~SIMULATION.RELATIONSHIP_SYMBOLS'
+        ])
+      )
       (div {className: runPanelClasses},
         (div {className: "title"}, tr "~SIMULATION.SIMULATION_SETTINGS")
 
@@ -50,53 +98,6 @@ module.exports = React.createClass
             tr '~SIMULATION.CAP_VALUES'
           ])
         )
-      )
-      (div {className: "title"}, tr "~SIMULATION.DIAGRAM_SETTINGS")
-      (div {className: minigraphsCheckboxClass},
-        (label {key: 'minigraphs-label'}, [
-          input {
-            key: 'minigraphs-checkbox'
-            type: 'checkbox'
-            value: 'show-mini'
-            checked: @state.showingMinigraphs
-            disabled: @state.diagramOnly
-            onChange: @setShowingMinigraphs
-          }
-          tr '~DOCUMENT.ACTIONS.SHOW_MINI_GRAPHS'
-        ])
-      )
-      (div {},
-        (div {className: "radio-title"}, tr "~SIMULATION.COMPLEXITY")
-        (RadioGroupF {name: "complexity", className: "radio-group"},
-          (label {key: 'complexity-diagram-only'},
-            (RadioF {value: "diagram-only"})
-            (span {}, tr '~SIMULATION.COMPLEXITY.DIAGRAM_ONLY')
-          )
-          (label {key: 'complexity-basic'},
-            (RadioF {value: "basic"})
-            (span {}, tr '~SIMULATION.COMPLEXITY.BASIC')
-          )
-          (label {key: 'complexity-expanded'},
-            (RadioF {value: "expanded"})
-            (span {}, tr '~SIMULATION.COMPLEXITY.EXPANDED')
-          )
-          (label {key: 'complexity-collectors'},
-            (RadioF {value: "collectors"})
-            (span {}, tr '~SIMULATION.COMPLEXITY.COLLECTORS')
-          )
-        )
-      )
-      (div {className: "row"},
-        (label {key: 'symbols-label'}, [
-          input {
-            key: 'symbols-checkbox'
-            type: 'checkbox'
-            value: 'relationship-symbols'
-            checked: @state.relationshipSymbols
-            onChange: @setRelationshipSymbols
-          }
-          tr '~SIMULATION.RELATIONSHIP_SYMBOLS'
-        ])
       )
 
     )

--- a/src/code/views/simulation-inspector-view.coffee
+++ b/src/code/views/simulation-inspector-view.coffee
@@ -31,9 +31,7 @@ module.exports = React.createClass
   render: ->
     runPanelClasses = "run-panel"
     diagramOnly = @state.complexity is AppSettingsStore.store.Complexity.diagramOnly
-    if not diagramOnly then runPanelClasses += " expanded"
-    minigraphsCheckboxClass = "row"
-    if diagramOnly then minigraphsCheckboxClass += " disabled"
+    if diagramOnly then runPanelClasses += " collapsed"
 
     (div {className: "simulation-panel"},
       (div {className: "title"}, tr "~SIMULATION.DIAGRAM_SETTINGS")
@@ -60,31 +58,32 @@ module.exports = React.createClass
           (span {}, tr '~SIMULATION.COMPLEXITY.COLLECTORS')
         )
       ])
-      (div {className: "title"}, tr "~SIMULATION.VIEW_SETTINGS")
-      (div {className: minigraphsCheckboxClass},
-        (label {key: 'minigraphs-label'}, [
-          input {
-            key: 'minigraphs-checkbox'
-            type: 'checkbox'
-            value: 'show-mini'
-            checked: @state.showingMinigraphs
-            disabled: @state.diagramOnly
-            onChange: @setShowingMinigraphs
-          }
-          tr '~DOCUMENT.ACTIONS.SHOW_MINI_GRAPHS'
-        ])
-      )
-      (div {className: "row"},
-        (label {key: 'symbols-label'}, [
-          input {
-            key: 'symbols-checkbox'
-            type: 'checkbox'
-            value: 'relationship-symbols'
-            checked: @state.relationshipSymbols
-            onChange: @setRelationshipSymbols
-          }
-          tr '~SIMULATION.RELATIONSHIP_SYMBOLS'
-        ])
+      (div {className: runPanelClasses},
+        (div {className: "title"}, tr "~SIMULATION.VIEW_SETTINGS")
+        (div {className: "row"},
+          (label {key: 'minigraphs-label'}, [
+            input {
+              key: 'minigraphs-checkbox'
+              type: 'checkbox'
+              value: 'show-mini'
+              checked: @state.showingMinigraphs
+              onChange: @setShowingMinigraphs
+            }
+            tr '~DOCUMENT.ACTIONS.SHOW_MINI_GRAPHS'
+          ])
+        )
+        (div {className: "row"},
+          (label {key: 'symbols-label'}, [
+            input {
+              key: 'symbols-checkbox'
+              type: 'checkbox'
+              value: 'relationship-symbols'
+              checked: @state.relationshipSymbols
+              onChange: @setRelationshipSymbols
+            }
+            tr '~SIMULATION.RELATIONSHIP_SYMBOLS'
+          ])
+        )
       )
       (div {className: runPanelClasses},
         (div {className: "title"}, tr "~SIMULATION.SIMULATION_SETTINGS")

--- a/src/stylus/components/simulation-panel.styl
+++ b/src/stylus/components/simulation-panel.styl
@@ -93,15 +93,13 @@ panelWidth = 236px
     width 100%
     margin 0 7px 0 8px
 
-  .radio-title
-    margin-left 7px
   .radio-group
     display flex
     flex-direction column
-    margin 5px 0 5px 17px
+    margin 5px
     label
       display flex
-      padding-bottom 3px
+      padding-bottom 7px
       input[type="radio"]
         flex none
         margin-right 7px

--- a/src/stylus/components/simulation-panel.styl
+++ b/src/stylus/components/simulation-panel.styl
@@ -92,3 +92,17 @@ panelWidth = 236px
   .wide
     width 100%
     margin 0 7px 0 8px
+
+  .radio-title
+    margin-left 7px
+  .radio-group
+    display flex
+    flex-direction column
+    margin 5px 0 5px 17px
+    label
+      display flex
+      padding-bottom 3px
+      input[type="radio"]
+        flex none
+        margin-right 7px
+

--- a/src/stylus/components/simulation-panel.styl
+++ b/src/stylus/components/simulation-panel.styl
@@ -82,11 +82,13 @@ panelWidth = 236px
         color #AAA
   .run-panel
     overflow: hidden
-    height: 0px
-    webkit-transition: height 0.7s
-    transition: height 0.7s
-    &.expanded
-      height: 60px
+    max-height: 1000px
+    webkit-transition: max-height 2.7s
+    transition: max-height 2.7s
+    &.collapsed
+      max-height: 0px
+      webkit-transition: max-height 0.7s
+      transition: max-height 0.7s
   .full
     width 100%
   .wide

--- a/src/stylus/components/simulation-panel.styl
+++ b/src/stylus/components/simulation-panel.styl
@@ -106,3 +106,5 @@ panelWidth = 236px
         flex none
         margin-right 7px
 
+  span.disabled
+    color #AAA

--- a/test/complexity-test.coffee
+++ b/test/complexity-test.coffee
@@ -25,7 +25,8 @@ CodapConnect    = requireModel 'codap-connect'
 
 requireStore = (name) -> require "#{__dirname}/../src/code/stores/#{name}"
 
-GraphStore      = requireStore('graph-store').store
+GraphStore       = requireStore('graph-store').store
+AppSettingsStore = requireStore('app-settings-store').store
 
 
 LinkNodes = (sourceNode, targetNode, relation) ->
@@ -59,7 +60,7 @@ describe "The minimum complexity", ->
       @graphStore.addLink link
 
     it "should be diagram-only", ->
-      @graphStore.getMinimumComplexity().should.equal "diagram-only"
+      @graphStore.getMinimumComplexity().should.equal AppSettingsStore.Complexity.diagramOnly
 
   describe "for a graph with only an `about the same` relation", ->
     beforeEach ->
@@ -75,7 +76,7 @@ describe "The minimum complexity", ->
       @graphStore.addLink link
 
     it "should be basic", ->
-      @graphStore.getMinimumComplexity().should.equal "basic"
+      @graphStore.getMinimumComplexity().should.equal AppSettingsStore.Complexity.basic
 
   describe "for a graph with an `a lot` relation", ->
     beforeEach ->
@@ -91,7 +92,7 @@ describe "The minimum complexity", ->
       @graphStore.addLink link
 
     it "should be expanded", ->
-      @graphStore.getMinimumComplexity().should.equal "expanded"
+      @graphStore.getMinimumComplexity().should.equal AppSettingsStore.Complexity.expanded
 
   describe "for a graph with a collector", ->
     beforeEach ->
@@ -104,4 +105,4 @@ describe "The minimum complexity", ->
       @graphStore.addLink link
 
     it "should be collectors", ->
-      @graphStore.getMinimumComplexity().should.equal "collectors"
+      @graphStore.getMinimumComplexity().should.equal AppSettingsStore.Complexity.collectors

--- a/test/complexity-test.coffee
+++ b/test/complexity-test.coffee
@@ -1,0 +1,107 @@
+global._      = require 'lodash'
+global.log    = require 'loglevel'
+global.Reflux = require 'reflux'
+global.window = { location: '' }
+global.window.performance = {
+  now: ->
+    Date.now()
+}
+global.requestAnimationFrame = (callback) ->
+  setTimeout callback, 1
+
+chai = require('chai')
+chai.config.includeStack = true
+
+expect         = chai.expect
+should         = chai.should()
+Sinon          = require('sinon')
+
+requireModel = (name) -> require "#{__dirname}/../src/code/models/#{name}"
+
+Link            = requireModel 'link'
+Node            = requireModel 'node'
+RelationFactory = requireModel 'relation-factory'
+CodapConnect    = requireModel 'codap-connect'
+
+requireStore = (name) -> require "#{__dirname}/../src/code/stores/#{name}"
+
+GraphStore      = requireStore('graph-store').store
+
+
+LinkNodes = (sourceNode, targetNode, relation) ->
+  link = new Link
+    title: "function"
+    sourceNode: sourceNode
+    targetNode: targetNode
+    relation: relation
+  link
+
+describe "The minimum complexity", ->
+  beforeEach ->
+    @sandbox = Sinon.sandbox.create()
+    @sandbox.stub CodapConnect, "instance", ->
+      sendUndoableActionPerformed: -> return ''
+
+    @graphStore = GraphStore
+    @graphStore.init()
+
+  afterEach ->
+    CodapConnect.instance.restore()
+
+  describe "for a graph without relations", ->
+    beforeEach ->
+      nodeA    = new Node()
+      nodeB    = new Node()
+      link     = LinkNodes(nodeA, nodeB)
+
+      @graphStore.addNode nodeA
+      @graphStore.addNode nodeB
+      @graphStore.addLink link
+
+    it "should be diagram-only", ->
+      @graphStore.getMinimumComplexity().should.equal "diagram-only"
+
+  describe "for a graph with only an `about the same` relation", ->
+    beforeEach ->
+      nodeA    = new Node()
+      nodeB    = new Node()
+      vector   = RelationFactory.decrease
+      scalar   = RelationFactory.aboutTheSame
+      relation = RelationFactory.fromSelections vector, scalar
+      link     = LinkNodes(nodeA, nodeB, relation)
+
+      @graphStore.addNode nodeA
+      @graphStore.addNode nodeB
+      @graphStore.addLink link
+
+    it "should be basic", ->
+      @graphStore.getMinimumComplexity().should.equal "basic"
+
+  describe "for a graph with an `a lot` relation", ->
+    beforeEach ->
+      nodeA    = new Node()
+      nodeB    = new Node()
+      vector   = RelationFactory.increase
+      scalar   = RelationFactory.aLot
+      relation = RelationFactory.fromSelections vector, scalar
+      link     = LinkNodes(nodeA, nodeB, relation)
+
+      @graphStore.addNode nodeA
+      @graphStore.addNode nodeB
+      @graphStore.addLink link
+
+    it "should be expanded", ->
+      @graphStore.getMinimumComplexity().should.equal "expanded"
+
+  describe "for a graph with a collector", ->
+    beforeEach ->
+      nodeA    = new Node()
+      nodeB    = new Node({isAccumulator: true})
+      link     = LinkNodes(nodeA, nodeB)
+
+      @graphStore.addNode nodeA
+      @graphStore.addNode nodeB
+      @graphStore.addLink link
+
+    it "should be collectors", ->
+      @graphStore.getMinimumComplexity().should.equal "collectors"

--- a/test/loading-serialization-test.coffee
+++ b/test/loading-serialization-test.coffee
@@ -100,7 +100,7 @@ describe "Serialization and Loading", ->
         model.nodes.should.exist
         model.links.should.exist
 
-        model.version.should.equal "1.18.0"
+        model.version.should.equal "1.19.0"
         model.nodes.length.should.equal 2
         model.links.length.should.equal 2
 
@@ -149,11 +149,11 @@ describe "Serialization and Loading", ->
         palette[1].uuid.should.equal "uuid-bee"
 
       it "should be able to serialize the settings", ->
-        AppSettingsStore.store.settings.diagramOnly = true
+        AppSettingsStore.store.settings.complexity = "expanded"
         AppSettingsStore.store.settings.showingMinigraphs = true
         jsonString = @graphStore.toJsonString(@fakePalette)
         model = JSON.parse jsonString
-        model.settings.diagramOnly.should.equal true
+        model.settings.complexity.should.equal "expanded"
         model.settings.showingMinigraphs.should.equal true
 
       it "should be able to serialize the simulation settings", ->
@@ -185,9 +185,9 @@ describe "Serialization and Loading", ->
 
     it "should read the settings without error", ->
       data = JSON.parse(@serializedForm)
-      data.settings = {diagramOnly: true, showMinigraphs: true}
+      data.settings = {complexity: "expanded", showMinigraphs: true}
       @graphStore.loadData(data)
-      AppSettingsStore.store.settings.diagramOnly.should.equal true
+      AppSettingsStore.store.settings.complexity.should.equal "expanded"
       AppSettingsStore.store.settings.showMinigraphs.should.equal true
 
     it "nodes should have paletteItem properties after loading", ->

--- a/test/migrations-test.coffee
+++ b/test/migrations-test.coffee
@@ -138,4 +138,4 @@ describe "Migrations",  ->
 
     describe "v-1.19.0 changes", ->
       it "should have complexity setting", ->
-        @result.settings.complexity.should.equal "basic"
+        @result.settings.complexity.should.equal 1

--- a/test/migrations-test.coffee
+++ b/test/migrations-test.coffee
@@ -13,8 +13,8 @@ describe "Migrations",  ->
       @result = Migrations.update(originalData)
 
     describe "the final version number", ->
-      it "should be 1.18.0", ->
-        @result.version.should.equal "1.18.0"
+      it "should be 1.19.0", ->
+        @result.version.should.equal "1.19.0"
 
     describe "the nodes", ->
       it "should have two nodes", ->
@@ -77,9 +77,10 @@ describe "Migrations",  ->
         for paletteItem in @result.palette
           paletteItem.uuid.should.not.be.null
 
-    describe "v-1.6 changes", ->
-      it "should have diagramOnly setting", ->
-        @result.settings.diagramOnly.should.equal false
+    # Removed in 1.19
+    # describe "v-1.6 changes", ->
+    #   it "should have diagramOnly setting", ->
+    #     @result.settings.diagramOnly.should.equal false
 
     describe "v-1.7 changes", ->
       it "should have settings for the simulation", ->
@@ -134,3 +135,7 @@ describe "Migrations",  ->
       it "should have link relation type", ->
         for link in @result.links
           link.relation.type.should.exist
+
+    describe "v-1.19.0 changes", ->
+      it "should have complexity setting", ->
+        @result.settings.complexity.should.equal "basic"

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,6 +877,18 @@ fbjs@^0.8.1, fbjs@^0.8.4:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 filename-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.0.tgz#996e3e80479b98b9897f15a8a58b3d084e926775"
@@ -1485,6 +1497,10 @@ js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
 
+js-tokens@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+
 json-stable-stringify@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz#611c23e814db375527df851193db59dd2af27f45"
@@ -1771,6 +1787,12 @@ loose-envify@^1.0.0, loose-envify@^1.1.0:
   dependencies:
     js-tokens "^2.0.0"
 
+loose-envify@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  dependencies:
+    js-tokens "^3.0.0"
+
 lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
@@ -1955,6 +1977,10 @@ object-assign@^3.0.0:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
+
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
 object-is@^1.0.1:
   version "1.0.1"
@@ -2143,6 +2169,14 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.8:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 public-encrypt@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.0.tgz#39f699f3a46560dd5ebacbca693caf7c65c18cc6"
@@ -2194,6 +2228,12 @@ react-dom@^15.4.2:
     fbjs "^0.8.1"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+
+react-radio-group@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-radio-group/-/react-radio-group-3.0.2.tgz#b1f1c67f8ef95a988287cdb3c687ec41a9ced8c6"
+  dependencies:
+    prop-types "^15.5.8"
 
 react@^15.4.2:
   version "15.4.2"


### PR DESCRIPTION
Hi @knowuh, this is a bigger PR. If you could look at it any time in the next few days that would be great.

This adds more settings for the "complexity" of a diagram, beyond the original "diagram-only tools" checkbox that existed before.

You can now set the complexity to four levels, "diagram-only", "basic relations", "expanded relations" and "collectors." By default a model starts at "basic", unless (1) it loads data that had the old `diagramOnly: true` setting, or (2) you launch with the hash param `#simplified=true` (matching the old feature).

Lower complexity levels prevent the user from accessing certain tools, like the "varies" relationship, all the scalar relationships, and turning nodes into collectors.

The graph is scanned to note the minimum complexity it supports, and prevents the user from lowering the complexity of a diagram if there are features present of a higher complexity. (If the user removes those features, they can subsequently lower the complexity.)

See PT story: https://www.pivotaltracker.com/story/show/151201919

Built branch: http://sage.concord.org/branch/complexity-levels/sage.html