### PR TITLE
Set collector initial value

### DIFF
--- a/src/code/models/relation-factory.coffee
+++ b/src/code/models/relation-factory.coffee
@@ -137,6 +137,20 @@ module.exports = class RelationFactory
       return -scope.in
     forDualAccumulator: false
 
+  @setInitialValue:
+    type: "initial-value"
+    id: "setInitialValue"
+    text: tr "~NODE-RELATION-EDIT.SETS_INITIAL"
+    postfixIco: "initial-value"
+    formula: "initial-value"          # used only for matching
+    magnitude: 0
+    gradual: 0
+    func: (scope) ->
+      return
+    forDualAccumulator: false
+    forSoloAccumulatorOnly: true      # not allowed for dual accumulator
+    hideAdditionalText: true          # may eventually need each relation to set entire text...
+
   @transferred:
     type: "transfer"
     id: "transferred"
@@ -226,6 +240,7 @@ module.exports = class RelationFactory
   @accumulators:
     added: @added
     subtracted: @subtracted
+    setInitialValue: @setInitialValue
     transferred: @transferred
 
   @transferModifiers:

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -321,7 +321,8 @@ GraphStore  = Reflux.createStore
             changedLinks = [].concat(node.inLinks())
                             # along with outbound transfer links
                               .concat(_.filter(node.outLinks(), (link) ->
-                                link.relation.type is 'transfer'))
+                                link.relation.type is 'transfer' or
+                                link.relation.type is 'initial-value'))
             originalRelations = {}
             for link in changedLinks
               originalRelations[link.key] = link.relation

--- a/src/code/utils/lang/en-US-master.json
+++ b/src/code/utils/lang/en-US-master.json
@@ -64,6 +64,7 @@
     "~NODE-RELATION-EDIT.IS": "is",
     "~NODE-RELATION-EDIT.ADDED_TO": "added to",
     "~NODE-RELATION-EDIT.SUBTRACTED_FROM": "subtracted from",
+    "~NODE-RELATION-EDIT.SETS_INITIAL": "sets the initial value of",
     "~NODE-RELATION-EDIT.TRANSFERRED_TO": "transferred to",
     "~NODE-RELATION-EDIT.EACH": "each",
     "~NODE-RELATION-EDIT.ALL": "All",
@@ -92,7 +93,7 @@
     "~PALETTE-INSPECTOR.DELETE": "Delete Image",
     "~PALETTE-INSPECTOR.REPLACE": "Replace Image",
 
-    // views/palette-delete-view.coffee    
+    // views/palette-delete-view.coffee
     "~PALETTE-DIALOG.TITLE": "Delete image?",
     "~PALETTE-DIALOG.DELETE": "Delete",
     "~PALETTE-DIALOG.REPLACE": "and replace with",

--- a/src/code/utils/lang/en-US.json
+++ b/src/code/utils/lang/en-US.json
@@ -25,7 +25,7 @@
     "~NODE-EDIT.ADD_REMOTE": "Add remote",
     "~NODE-EDIT.DELETE": "Delete",
 
-                                             
+
     "~NODE-VALUE-EDIT.INITIAL-VALUE": "Initial Value",
     "~NODE-VALUE-EDIT.DEFINING_WITH_NUMBERS": "You are defining values with numbers.",
     "~NODE-VALUE-EDIT.DEFINING_WITH_WORDS": "You are defining values with words.",
@@ -40,7 +40,7 @@
     "~NODE-VALUE-EDIT.HIGH": "High",
     "~NODE-VALUE-EDIT.DEPENDENT_VARIABLE": "This node is a dependent variable",
 
-                                           
+
     "~NODE-RELATION-EDIT.COMBINATION_METHOD": "Combine variables using:",
     "~NODE-RELATION-EDIT.ARITHMETIC_MEAN": "average",
     "~NODE-RELATION-EDIT.SCALED_PRODUCT": "limiting factor",
@@ -64,6 +64,7 @@
     "~NODE-RELATION-EDIT.IS": "is",
     "~NODE-RELATION-EDIT.ADDED_TO": "added to",
     "~NODE-RELATION-EDIT.SUBTRACTED_FROM": "subtracted from",
+    "~NODE-RELATION-EDIT.SETS_INITIAL": "sets the initial value of",
     "~NODE-RELATION-EDIT.TRANSFERRED_TO": "transferred to",
     "~NODE-RELATION-EDIT.EACH": "each",
     "~NODE-RELATION-EDIT.ALL": "All",
@@ -85,26 +86,26 @@
     "~ADD-NEW-IMAGE.MY-COMPUTER-TAB": "My Computer",
     "~ADD-NEW-IMAGE.LINK-TAB": "Link",
 
-                                          
+
     "~PALETTE-INSPECTOR.ADD_IMAGE": "New Image",
     "~PALETTE-INSPECTOR.ADD_IMAGE_SHORT": "New",
     "~PALETTE-INSPECTOR.ABOUT_IMAGE": "About This Image",
     "~PALETTE-INSPECTOR.DELETE": "Delete Image",
     "~PALETTE-INSPECTOR.REPLACE": "Replace Image",
 
-                                           
+
     "~PALETTE-DIALOG.TITLE": "Delete image?",
     "~PALETTE-DIALOG.DELETE": "Delete",
     "~PALETTE-DIALOG.REPLACE": "and replace with",
     "~PALETTE-DIALOG.OK": "ok",
     "~PALETTE-DIALOG.CANCEL": "✖ cancel",
 
-                                       
+
     "~METADATA.TITLE": "Title",
     "~METADATA.LINK": "Link",
     "~METADATA.CREDIT": "Credit",
 
-                                      
+
     "~IMAGE-BROWSER.PREVIEW": "Preview Your Image",
     "~IMAGE-BROWSER.ADD_IMAGE": "Add Image",
     "~IMAGE-BROWSER.SEARCH_HEADER": "Search for images",
@@ -138,7 +139,7 @@
     "~COLOR.MEDIUM_GRAY": "Gray",
     "~COLOR.DATA": "Codap Orange",
 
-                            
+
     "~FILE.CHECKING_AUTH": "Checking authorization...",
     "~FILE.CONFIRM": "Are you sure?",
     "~FILE.DOWNLOADING": "Downloading...",

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -249,7 +249,9 @@ module.exports = React.createClass
     isEditing = link is @state.editingLink
     isDashed = !link.relation.isDefined && @state.simulationPanelExpanded
     relationDetails = RelationFactory.selectionsFromRelation(link.relation)
-    if relationDetails.vector? and relationDetails.vector.isCustomRelationship and link.relation.customData?
+    if relationDetails.vector?.isCustomRelationship and link.relation.customData?
+      link.color = LinkColors.customRelationship
+    else if relationDetails.accumulator?.id is "setInitialValue"
       link.color = LinkColors.customRelationship
     else if link.relation.isTransferModifier
       link.color = LinkColors.transferModifier

--- a/src/code/views/link-relation-view.coffee
+++ b/src/code/views/link-relation-view.coffee
@@ -219,7 +219,8 @@ module.exports = LinkRelationView = React.createClass
   renderAccumulator: (source, target) ->
     options = []
     _.each RelationFactory.accumulators, (opt, i) =>
-      if not opt.forDualAccumulator or @state.isDualAccumulator
+      if (not opt.forDualAccumulator or @state.isDualAccumulator) and
+          (not opt.forSoloAccumulatorOnly or not @state.isDualAccumulator)
         options.push (option {value: opt.id, key: opt.id}, opt.text)
 
     if not @state.selectedAccumulator
@@ -229,17 +230,19 @@ module.exports = LinkRelationView = React.createClass
     else
       currentOption = @state.selectedAccumulator.id
 
+    textClass = if @state.selectedAccumulator?.hideAdditionalText then "hidden" else ""
+
     (div {className: 'top'},
       (span {className: "source"}, source)
-      (span {}, " #{tr "~NODE-RELATION-EDIT.IS"} ")
+      (span {className: textClass}, " #{tr "~NODE-RELATION-EDIT.IS"} ")
       (div {},
         (select {value: currentOption, ref: "accumulator", onChange: @updateRelation},
           options
         )
       )
       (span {className: "target"}, target)
-      (span {}, " #{tr "~NODE-RELATION-EDIT.EACH"} ")
-      (span {}, @state.stepUnits.toLowerCase())
+      (span {className: textClass}, " #{tr "~NODE-RELATION-EDIT.EACH"} ")
+      (span {className: textClass}, @state.stepUnits.toLowerCase())
     )
 
   renderTransfer: (source, target) ->

--- a/src/stylus/components/relation-inspector.styl
+++ b/src/stylus/components/relation-inspector.styl
@@ -44,6 +44,9 @@ colored-span(color)
       color darken(codap-orange, 10)
       font-weight bold
 
+    .hidden
+      display none
+
   .bb-select
     margin-left 0px
     margin-top 0.25em

--- a/test/simulation-test.coffee
+++ b/test/simulation-test.coffee
@@ -208,6 +208,29 @@ describe "Simulation", ->
         results: [
           [100, 100]
         ]}
+
+        # *** Collector initial-value tests ***
+
+        # 13: (A-init->B+)
+        {A:10, B:"50+", AB: "initial-value",
+        results: [
+          [10, 10]
+          [10, 10]
+        ]}
+
+        # 14: A and B averageing initial values >- (A-init->C+, B-init->C+)
+        {A:10, B:20, C:"50+", AC: "initial-value", BC: "initial-value",
+        results: [
+          [10, 20, 15]
+          [10, 20, 15]
+        ]}
+
+        # 15: Setting initial values, and accumulating >- (A-init->C+, B->C+)
+        {A:10, B:20, C:"50+", AC: "initial-value", BC: "1 * in",
+        results: [
+          [10, 20, 10]
+          [10, 20, 30]
+        ]}
       ]
 
       _.each scenarios, (scenario, i) ->
@@ -220,8 +243,13 @@ describe "Simulation", ->
             else if key.length == 2
               node1 = nodes[key[0]]
               node2 = nodes[key[1]]
-              type = if node2.isAccumulator then 'accumulator' else 'range'
-              LinkNodes(node1, node2, { type, formula: value })
+              func = null
+              if node2.isAccumulator
+                type = if value is 'initial-value' then value else 'accumulator'
+                if type is 'initial-value' then func = () => {}
+              else
+                type = 'range'
+              LinkNodes(node1, node2, { type, formula: value, func })
           for result, j in scenario.results
             nodeArray = (node for key, node of nodes)
             simulation = new Simulation


### PR DESCRIPTION
@kswenson since you were most recently working in the simulation code, I wonder if you could take a look at this.

This implements this story: https://www.pivotaltracker.com/story/show/151201810

Non-collector variables can link to collectors with a new relationship type, "set initial value." The model should run exactly the same as if the collector's own initial value had been set by hand.

The simulation changes ended up being pretty simple once I realized I should just set the initial values before running through the steps.

The model can be run here: http://sage.concord.org/branch/set-collector-init-value/sage.html
In CODAP: http://codap.concord.org/releases/latest/static/dg/en/cert/index.html?di=http://sage.concord.org/branch/set-collector-init-value/sage.html

(en-US-master.json updated, en-US.json updated so that the branch deploy would have strings, and will be overwritten before merging by POEditor push/pull.)