### PR TITLE
Changes to flow-modifying links.

### DIFF
--- a/src/code/models/relation-factory.coffee
+++ b/src/code/models/relation-factory.coffee
@@ -207,6 +207,28 @@ module.exports = class RelationFactory
     func: (scope) ->
       return scope.in * 0.25
 
+  @proportionalSourceMore:
+    type: "transfer-modifier"
+    id: "proportionalSourceMore"
+    text: tr "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_MORE"
+    postfixIco: "more"
+    formula: "in * 0.10"
+    magnitude: 0
+    gradual: 0
+    func: (scope) ->
+      return scope.in * 0.10
+
+  @proportionalSourceLess:
+    type: "transfer-modifier"
+    id: "proportionalSourceLess"
+    text: tr "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_LESS"
+    postfixIco: "less"
+    formula: "(maxIn - in) * 0.10 + 0.001"
+    magnitude: 0
+    gradual: 0
+    func: (scope) ->
+      return scope.in * 0.10
+
   @aLittleBit:
     type: "transfer-modifier"
     id: "aLittleBit"
@@ -244,11 +266,8 @@ module.exports = class RelationFactory
     transferred: @transferred
 
   @transferModifiers:
-    all: @all
-    most: @most
-    half: @half
-    some: @some
-    aLittleBit: @aLittleBit
+    proportionalSourceMore: @proportionalSourceMore
+    proportionalSourceLess: @proportionalSourceLess
 
   @CreateRelation: (options) ->
     new Relationship(options)

--- a/src/code/models/relation-factory.coffee
+++ b/src/code/models/relation-factory.coffee
@@ -163,50 +163,6 @@ module.exports = class RelationFactory
       return scope.in
     forDualAccumulator: true
 
-  @all:
-    type: "transfer-modifier"
-    id: "all"
-    text: tr "~NODE-RELATION-EDIT.ALL"
-    postfixIco: "all"
-    formula: "in"
-    magnitude: 0
-    gradual: 0
-    func: (scope) ->
-      return scope.in
-
-  @most:
-    type: "transfer-modifier"
-    id: "most"
-    text: tr "~NODE-RELATION-EDIT.MOST"
-    postfixIco: "most"
-    formula: "in * 0.75"
-    magnitude: 0
-    gradual: 0
-    func: (scope) ->
-      return scope.in * 0.75
-
-  @half:
-    type: "transfer-modifier"
-    id: "half"
-    text: tr "~NODE-RELATION-EDIT.HALF"
-    postfixIco: "half"
-    formula: "in * 0.5"
-    magnitude: 0
-    gradual: 0
-    func: (scope) ->
-      return scope.in * 0.5
-
-  @some:
-    type: "transfer-modifier"
-    id: "some"
-    text: tr "~NODE-RELATION-EDIT.SOME"
-    postfixIco: "some"
-    formula: "in * 0.25"
-    magnitude: 0
-    gradual: 0
-    func: (scope) ->
-      return scope.in * 0.25
-
   @proportionalSourceMore:
     type: "transfer-modifier"
     id: "proportionalSourceMore"
@@ -228,17 +184,6 @@ module.exports = class RelationFactory
     gradual: 0
     func: (scope) ->
       return (scope.maxIn - scope.in) * 0.10 + 0.001
-
-  @aLittleBit:
-    type: "transfer-modifier"
-    id: "aLittleBit"
-    text: tr "~NODE-RELATION-EDIT.A_LITTLE_BIT"
-    postfixIco: "a-little-bit"
-    formula: "in * 0.03"
-    magnitude: 0
-    gradual: 0
-    func: (scope) ->
-      return scope.in * 0.03
 
   @iconName: (incdec,amount)->
     "icon-#{incdec.prefixIco}-#{amount.postfixIco}"
@@ -311,11 +256,8 @@ module.exports = class RelationFactory
   @thicknessFromRelation: (relation) ->
     dt = 1
     switch relation.formula
-      when @all.formula then 1 + 4 * dt
-      when @most.formula then 1 + 3 * dt
-      when @half.formula then 1 + 2 * dt
-      when @some.formula then 1 + 1 * dt
-      when @aLittleBit.formula then 1
+      when @proportionalSourceMore.formula then 1 + 1 * dt
+      when @proportionalSourceLess.formula then 1 + 1 * dt
       else 1
 
   # @isCustomRelationship: (vector) ->

--- a/src/code/models/relation-factory.coffee
+++ b/src/code/models/relation-factory.coffee
@@ -227,7 +227,7 @@ module.exports = class RelationFactory
     magnitude: 0
     gradual: 0
     func: (scope) ->
-      return scope.in * 0.10
+      return (scope.maxIn - scope.in) * 0.10 + 0.001
 
   @aLittleBit:
     type: "transfer-modifier"

--- a/src/code/models/relation-factory.coffee
+++ b/src/code/models/relation-factory.coffee
@@ -179,11 +179,11 @@ module.exports = class RelationFactory
     id: "proportionalSourceLess"
     text: tr "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_LESS"
     postfixIco: "less"
-    formula: "(maxIn - in) * 0.10 + 0.001"
+    formula: "(maxIn - in) * 0.10 + 0.02"
     magnitude: 0
     gradual: 0
     func: (scope) ->
-      return (scope.maxIn - scope.in) * 0.10 + 0.001
+      return (scope.maxIn - scope.in) * 0.10 + 0.02
 
   @iconName: (incdec,amount)->
     "icon-#{incdec.prefixIco}-#{amount.postfixIco}"

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -5,6 +5,7 @@ Simulation         = require "../models/simulation"
 TimeUnits          = require '../utils/time-units'
 tr                 = require '../utils/translate'
 
+DEFAULT_SIMULATION_STEPS = 20
 SimulationActions = Reflux.createActions(
   [
     "expandSimulationPanel"
@@ -39,7 +40,6 @@ SimulationStore   = Reflux.createStore
     @defaultUnit = TimeUnits.defaultUnit
     @unitName    = TimeUnits.toString(@defaultUnit,true)
     @defaultCollectorUnit = TimeUnits.defaultCollectorUnit
-    defaultDuration = 10
     timeUnitOptions = ({name: TimeUnits.toString(unit, true), unit: unit} for unit in TimeUnits.units)
 
     @nodes = []
@@ -47,7 +47,7 @@ SimulationStore   = Reflux.createStore
 
     @settings =
       simulationPanelExpanded: false
-      duration: defaultDuration
+      duration: DEFAULT_SIMULATION_STEPS
       experimentNumber: 1
       experimentFrame: 0
       stepUnits: @defaultUnit

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -39,7 +39,7 @@ SimulationStore   = Reflux.createStore
     @defaultUnit = TimeUnits.defaultUnit
     @unitName    = TimeUnits.toString(@defaultUnit,true)
     @defaultCollectorUnit = TimeUnits.defaultCollectorUnit
-    defaultDuration = 50
+    defaultDuration = 10
     timeUnitOptions = ({name: TimeUnits.toString(unit, true), unit: unit} for unit in TimeUnits.units)
 
     @nodes = []

--- a/src/code/utils/lang/en-US-master.json
+++ b/src/code/utils/lang/en-US-master.json
@@ -75,6 +75,11 @@
     "~NODE-RELATION-EDIT.OF": "of",
     "~NODE-RELATION-EDIT.WILL_FLOW_TO": "will flow to",
 
+    "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_A": "More %{sourceTitle} means",
+    "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_MORE": "more",
+    "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_LESS": "fewer/less",
+    "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_B": " will be transferred to %{targetTitle} each ",
+
     "~TRANSFER_NODE.TITLE": "flow from %{sourceTitle} to %{targetTitle}",
 
     "~LINK-EDIT.DELETE": "✖ Delete Link",

--- a/src/code/utils/lang/en-US-master.json
+++ b/src/code/utils/lang/en-US-master.json
@@ -75,10 +75,14 @@
     "~NODE-RELATION-EDIT.OF": "of",
     "~NODE-RELATION-EDIT.WILL_FLOW_TO": "will flow to",
 
-    "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_A": "More %{sourceTitle} means",
     "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_MORE": "more",
     "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_LESS": "fewer/less",
+
+    "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_A": "More %{sourceTitle} means",
     "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_B": " will be transferred to %{targetTitle} each ",
+
+    "~NODE-RELATION-EDIT.VARIABLE_FLOW_TARGET_A": "More %{targetTitle} means",
+    "~NODE-RELATION-EDIT.VARIABLE_FLOW_TARGET_B": " %{sourceTitle} will be transferred each ",
 
     "~TRANSFER_NODE.TITLE": "flow from %{sourceTitle} to %{targetTitle}",
 

--- a/src/code/utils/lang/en-US.json
+++ b/src/code/utils/lang/en-US.json
@@ -75,6 +75,11 @@
     "~NODE-RELATION-EDIT.OF": "of",
     "~NODE-RELATION-EDIT.WILL_FLOW_TO": "will flow to",
 
+    "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_A": "More %{sourceTitle} means",
+    "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_MORE": "more",
+    "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_LESS": "fewer/less",
+    "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_B": " will be transferred to %{targetTitle} each ",
+
     "~TRANSFER_NODE.TITLE": "flow from %{sourceTitle} to %{targetTitle}",
 
     "~LINK-EDIT.DELETE": "✖ Delete Link",

--- a/src/code/utils/lang/en-US.json
+++ b/src/code/utils/lang/en-US.json
@@ -75,10 +75,14 @@
     "~NODE-RELATION-EDIT.OF": "of",
     "~NODE-RELATION-EDIT.WILL_FLOW_TO": "will flow to",
 
-    "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_A": "More %{sourceTitle} means",
     "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_MORE": "more",
     "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_LESS": "fewer/less",
+
+    "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_A": "More %{sourceTitle} means",
     "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_B": " will be transferred to %{targetTitle} each ",
+
+    "~NODE-RELATION-EDIT.VARIABLE_FLOW_TARGET_A": "More %{targetTitle} means",
+    "~NODE-RELATION-EDIT.VARIABLE_FLOW_TARGET_B": " %{sourceTitle} will be transferred each ",
 
     "~TRANSFER_NODE.TITLE": "flow from %{sourceTitle} to %{targetTitle}",
 

--- a/src/code/utils/link-colors.coffee
+++ b/src/code/utils/link-colors.coffee
@@ -18,11 +18,6 @@ linkColors = module.exports =
     switch link.relation.formula
       when RelationFactory.added.formula then linkColors.increase
       when RelationFactory.subtracted.formula then linkColors.decrease
-      when RelationFactory.all.formula then linkColors.increase
-      when RelationFactory.most.formula then linkColors.increase
-      when RelationFactory.half.formula then linkColors.increase
-      when RelationFactory.some.formula then linkColors.increase
-      when RelationFactory.aLittleBit.formula then linkColors.increase
       when RelationFactory.proportionalSourceLess.formula then linkColors.decrease
       when RelationFactory.proportionalSourceMore.formula then linkColors.increase
       else linkColors.default

--- a/src/code/utils/link-colors.coffee
+++ b/src/code/utils/link-colors.coffee
@@ -23,4 +23,6 @@ linkColors = module.exports =
       when RelationFactory.half.formula then linkColors.increase
       when RelationFactory.some.formula then linkColors.increase
       when RelationFactory.aLittleBit.formula then linkColors.increase
+      when RelationFactory.proportionalSourceLess.formula then linkColors.decrease
+      when RelationFactory.proportionalSourceMore.formula then linkColors.increase
       else linkColors.default

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -254,7 +254,7 @@ module.exports = React.createClass
     else if relationDetails.accumulator?.id is "setInitialValue"
       link.color = LinkColors.customRelationship
     else if link.relation.isTransferModifier
-      link.color = LinkColors.transferModifier
+      link.color = LinkColors.fromLink link
     else
       link.color = LinkColors.fromLink link
     magnitude = relationDetails.magnitude

--- a/src/code/views/link-relation-view.coffee
+++ b/src/code/views/link-relation-view.coffee
@@ -81,7 +81,9 @@ module.exports = LinkRelationView = React.createClass
     status =
       isAccumulator: targetNode.isAccumulator
       isDualAccumulator: sourceNode.isAccumulator and targetNode.isAccumulator
-      isTransferModifier: targetNode.isTransfer and targetNode.transferLink?.sourceNode is sourceNode
+      isTransferModifier: targetNode.isTransfer and
+        (targetNode.transferLink?.sourceNode is sourceNode) or
+        (targetNode.transferLink?.targetNode is sourceNode)
 
   updateState: (props) ->
     status = @checkStatus(props.link)
@@ -248,6 +250,16 @@ module.exports = LinkRelationView = React.createClass
   renderTransfer: (source, target) ->
     options = _.map RelationFactory.transferModifiers, (opt, i) ->
       (option {value: opt.id, key: opt.id}, opt.text)
+    sourceTitle = @props.link.sourceNode?.title || "NONE"
+    targetTitle = @props.link.targetNode?.transferLink?.targetNode?.title || "NONE"
+    line_a = tr "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_A",
+      { sourceTitle: sourceTitle }
+    line_b = tr "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_B",
+      { targetTitle: targetTitle }
+
+    console.log @props
+    console.log @state
+    console.log @state.selectedTransferModifier
 
     if not @state.selectedTransferModifier
       options.unshift (option {key: "placeholder", value: "unselected", disabled: "disabled"},
@@ -255,20 +267,18 @@ module.exports = LinkRelationView = React.createClass
       currentOption = "unselected"
     else
       currentOption = @state.selectedTransferModifier.id
-
     (div {className: 'top'},
-      (select {value: currentOption, ref: "transfer", onChange: @updateRelation},
-        options
-      )
+
+
       # note that localization will be a problem here due to the hard-coded order
       # of the elements and because we can't use the string-replacement capabilities
       # of the translate module since there is special formatting of node titles, etc.
-      (span {}, " #{tr "~NODE-RELATION-EDIT.OF"} ")
-      (span {className: "source"}, source)
-      (span {}, " #{tr "~NODE-RELATION-EDIT.WILL_FLOW_TO"} ")
-      (span {className: "target"}, target)
-      (span {}, " #{tr "~NODE-RELATION-EDIT.EACH"} ")
-      (span {}, @state.stepUnits.toLowerCase())
+      (span {className: "source"}, line_a)
+      (select {value: currentOption, ref: "transfer", onChange: @updateRelation},
+        options
+      )
+      (span {}, line_b)
+      (span {}, "#{@state.stepUnits.toLowerCase()}.")
     )
 
   renderNonAccumulator: (source, target) ->

--- a/src/code/views/link-relation-view.coffee
+++ b/src/code/views/link-relation-view.coffee
@@ -247,19 +247,24 @@ module.exports = LinkRelationView = React.createClass
       (span {className: textClass}, @state.stepUnits.toLowerCase())
     )
 
-  renderTransfer: (source, target) ->
+  renderTransfer: (source, target, isTargetProportional) ->
     options = _.map RelationFactory.transferModifiers, (opt, i) ->
       (option {value: opt.id, key: opt.id}, opt.text)
     sourceTitle = @props.link.sourceNode?.title || "NONE"
     targetTitle = @props.link.targetNode?.transferLink?.targetNode?.title || "NONE"
-    line_a = tr "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_A",
-      { sourceTitle: sourceTitle }
-    line_b = tr "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_B",
-      { targetTitle: targetTitle }
 
-    console.log @props
-    console.log @state
-    console.log @state.selectedTransferModifier
+    if (isTargetProportional)
+      sourceTitle = @props.link.targetNode?.transferLink?.sourceNode?.title || "NONE"
+      line_a = tr "~NODE-RELATION-EDIT.VARIABLE_FLOW_TARGET_A",
+        { targetTitle: targetTitle }
+      line_b = tr "~NODE-RELATION-EDIT.VARIABLE_FLOW_TARGET_B",
+        { sourceTitle: sourceTitle }
+
+    else
+      line_a = tr "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_A",
+        { sourceTitle: sourceTitle }
+      line_b = tr "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_B",
+        { targetTitle: targetTitle }
 
     if not @state.selectedTransferModifier
       options.unshift (option {key: "placeholder", value: "unselected", disabled: "disabled"},
@@ -313,7 +318,8 @@ module.exports = LinkRelationView = React.createClass
         @renderAccumulator(source, target)
       else if @state.isTransferModifier
         target = @props.link.targetNode?.transferLink?.targetNode?.title
-        @renderTransfer(source, target)
+        isTargetProportional = @props.link.sourceNode == @props.link.targetNode?.transferLink?.targetNode
+        @renderTransfer(source, target, isTargetProportional)
       else
         @renderNonAccumulator(source, target)
       (div {className: 'bottom'},

--- a/src/code/views/link-relation-view.coffee
+++ b/src/code/views/link-relation-view.coffee
@@ -248,6 +248,7 @@ module.exports = LinkRelationView = React.createClass
     )
 
   renderTransfer: (source, target, isTargetProportional) ->
+    spanWrap = (string,className) -> "<span class='#{className}'>#{string}</span>"
     options = _.map RelationFactory.transferModifiers, (opt, i) ->
       (option {value: opt.id, key: opt.id}, opt.text)
     sourceTitle = @props.link.sourceNode?.title || "NONE"
@@ -256,15 +257,15 @@ module.exports = LinkRelationView = React.createClass
     if (isTargetProportional)
       sourceTitle = @props.link.targetNode?.transferLink?.sourceNode?.title || "NONE"
       line_a = tr "~NODE-RELATION-EDIT.VARIABLE_FLOW_TARGET_A",
-        { targetTitle: targetTitle }
+        { targetTitle: spanWrap targetTitle, 'target' }
       line_b = tr "~NODE-RELATION-EDIT.VARIABLE_FLOW_TARGET_B",
-        { sourceTitle: sourceTitle }
+        { sourceTitle: spanWrap sourceTitle, 'source' }
 
     else
       line_a = tr "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_A",
-        { sourceTitle: sourceTitle }
+        { sourceTitle: spanWrap sourceTitle, 'source' }
       line_b = tr "~NODE-RELATION-EDIT.VARIABLE_FLOW_SOURCE_B",
-        { targetTitle: targetTitle }
+        { targetTitle: spanWrap targetTitle, 'target' }
 
     if not @state.selectedTransferModifier
       options.unshift (option {key: "placeholder", value: "unselected", disabled: "disabled"},
@@ -278,11 +279,11 @@ module.exports = LinkRelationView = React.createClass
       # note that localization will be a problem here due to the hard-coded order
       # of the elements and because we can't use the string-replacement capabilities
       # of the translate module since there is special formatting of node titles, etc.
-      (span {className: "source"}, line_a)
+      (span { dangerouslySetInnerHTML: {__html: line_a} })
       (select {value: currentOption, ref: "transfer", onChange: @updateRelation},
         options
       )
-      (span {}, line_b)
+      (span { dangerouslySetInnerHTML: {__html: line_b} })
       (span {}, "#{@state.stepUnits.toLowerCase()}.")
     )
 

--- a/src/stylus/components/inspector-panel.styl
+++ b/src/stylus/components/inspector-panel.styl
@@ -57,8 +57,7 @@ inspector-panel-inner-height = 500px
       transition 0.2s
       box-shadow -1px 2px 2px hsla(0,0,50,0.3)
       z-index 2
-      padding-right 50px
-      // overflow hidden
+      padding-right 70px
 
       .inspector-content, .bottom-pane
         padding 1em

--- a/test/simulation-test.coffee
+++ b/test/simulation-test.coffee
@@ -180,16 +180,17 @@ describe "Simulation", ->
         ]}
 
         # *** Tests for graphs with bounded ranges ***
-        # Note all nodes have min:0 and max:100 by default
-
+        # Note most nodes have min:0 and max:100 by default
+        # But collectors have a default max of 1000
         # 10: basic collector (A->[B])
-        {A:30, B:"20+", AB: "1 * in",
+        {A:30, B:"900+", AB: "1 * in",
         cap: true
         results: [
-          [30, 20]
-          [30, 50]
-          [30, 80]
-          [30, 100]
+          [30, 900]
+          [30, 930]
+          [30, 960]
+          [30, 990]
+          [30, 1000]
         ]}
 
         # 11: basic subtracting collector (A- -1 ->[B])

--- a/test/simulation-test.coffee
+++ b/test/simulation-test.coffee
@@ -346,13 +346,14 @@ describe "Simulation", ->
           expect(@nodeB.currentValue, "Node: #{@nodeB.title}").to.be.closeTo 55, 0.000001
 
         # sanity check
+        # transfer 10% of source (2) per step. 20 - 2 = 18 ,  50 + 2 = 52
         it "should transfer the appropriate percentage of the source node with a transfer-modifer", ->
           @nodeA.initialValue = 20
-          @transferModifier = LinkNodes(@nodeA, @transferNode, RelationFactory.half)
+          @transferModifier = LinkNodes(@nodeA, @transferNode, RelationFactory.proportionalSourceMore)
           @simulation.duration = 2
           @simulation.run()
-          expect(@nodeA.currentValue, "Node: #{@nodeA.title}").to.be.closeTo 10, 0.000001
-          expect(@nodeB.currentValue, "Node: #{@nodeB.title}").to.be.closeTo 60, 0.000001
+          expect(@nodeA.currentValue, "Node: #{@nodeA.title}").to.be.closeTo 18, 0.000001
+          expect(@nodeB.currentValue, "Node: #{@nodeB.title}").to.be.closeTo 52, 0.000001
 
 
 describe "The SimulationStore, with a network in the GraphStore", ->


### PR DESCRIPTION
This PR changes the way a source (and now a target) node can change their flow relationship.

The goal is to reduce the number of flow modifiers and allow both the source and target nodes to modify the flow.

* There are now just two flow-modifiers: proportional and inverse proportional flow.
* Target nodes can now affect the flow.

There have been modifications to the text and language files.  The text has to change significantly when the target node is changing the flow.

Also as part of this PR, the default MAX for collectors is 1000, and the default simulation length is 20 steps.  These changes were made so that the effect of flow-modifiers could be easily seen using system defaults in the mini-graphs.

Tests which that involved the MAX of collectors or the formulas for flow-modifications had to be adjusted.



