### PR TITLE
Several small collector / flow adjustments

### DIFF
--- a/src/code/models/node.coffee
+++ b/src/code/models/node.coffee
@@ -53,7 +53,7 @@ module.exports = class Node extends GraphPrimitive
     # semi-quantitative mode. (See getters and setters below).
     @_min = nodeSpec.min ? SEMIQUANT_MIN
     @_max = nodeSpec.max ? if @isAccumulator then SEMIQUANT_ACCUMULATOR_MAX else SEMIQUANT_MAX
-    @_initialValue = nodeSpec.initialValue ? 50
+    @_initialValue = nodeSpec.initialValue ? Math.round(SEMIQUANT_MAX/2)
 
     @color ?= Colors.choices[0].value
 
@@ -84,7 +84,7 @@ module.exports = class Node extends GraphPrimitive
       else
         SEMIQUANT_MIN
     set: (val) ->
-      @_min = val
+      if not @valueDefinedSemiQuantitatively then @_min = val
 
   @property 'max',
     get: ->
@@ -93,7 +93,18 @@ module.exports = class Node extends GraphPrimitive
       else
         if @isAccumulator then SEMIQUANT_ACCUMULATOR_MAX else SEMIQUANT_MAX
     set: (val) ->
-      @_max =  val
+      if not @valueDefinedSemiQuantitatively then @_max = val
+
+  @property 'isAccumulator',
+    get: ->
+      @_isAccumulator
+    set: (val) ->
+      @_isAccumulator = val
+      if(val && (@_max is SEMIQUANT_MAX))
+        @_max = SEMIQUANT_ACCUMULATOR_MAX
+      else
+        if(@_max is SEMIQUANT_ACCUMULATOR_MAX)
+          @_max = SEMIQUANT_MAX
 
   type: 'Node'
   isTransfer: false

--- a/src/code/models/node.coffee
+++ b/src/code/models/node.coffee
@@ -20,6 +20,9 @@ module.exports = class Node extends GraphPrimitive
     'isAccumulator', 'allowNegativeValues', 'combineMethod',
     'valueDefinedSemiQuantitatively', 'frames'
   ]
+  @SEMIQUANT_MIN: SEMIQUANT_MIN
+  @SEMIQUANT_MAX: SEMIQUANT_MAX
+  @SEMIQUANT_ACCUMULATOR_MAX: SEMIQUANT_ACCUMULATOR_MAX
 
   constructor: (nodeSpec={}, key) ->
     super()
@@ -81,7 +84,7 @@ module.exports = class Node extends GraphPrimitive
       else
         SEMIQUANT_MIN
     set: (val) ->
-      if not @valueDefinedSemiQuantitatively then @_min = val
+      @_min = val
 
   @property 'max',
     get: ->
@@ -90,7 +93,7 @@ module.exports = class Node extends GraphPrimitive
       else
         if @isAccumulator then SEMIQUANT_ACCUMULATOR_MAX else SEMIQUANT_MAX
     set: (val) ->
-      if not @valueDefinedSemiQuantitatively then @_max = val
+      @_max =  val
 
   type: 'Node'
   isTransfer: false

--- a/src/code/models/simulation.coffee
+++ b/src/code/models/simulation.coffee
@@ -113,11 +113,7 @@ SetAccumulatorValueFunction = (nodeValues) ->
 
       when 'transfer'
         transferValue = nodeValues[transferNode.key]
-        # transfer values are scaled if they have no modifier and
-        # their source is an independent node (has no inputs)
-        if isScaledTransferNode(transferNode)
-          transferValue /= 100
-
+        
         # can't overdraw non-negative collectors
         if @capNodeValues or (sourceNode.isAccumulator and not sourceNode.allowNegativeValues)
           transferValue = Math.min(transferValue, getTransferLimit(transferNode))

--- a/src/code/models/transfer.coffee
+++ b/src/code/models/transfer.coffee
@@ -1,10 +1,13 @@
 Node = require './node'
 tr = require "../utils/translate"
 
+DEFAULT_COMBINE_METHOD='product'
+
 module.exports = class Transfer extends Node
 
   type: 'Transfer'
   isTransfer: true
+  combineMethod: DEFAULT_COMBINE_METHOD
 
   setTransferLink: (link) ->
     @transferLink = link

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -519,7 +519,7 @@ GraphStore  = Reflux.createStore
         modelDescription += link.relation.formula + ";"
         if link.relation.type is 'transfer'
           transfer = link.transferNode
-          modelDescription += "#{transfer.key}:#{transfer.initialValue};" if transfer
+          modelDescription += "#{transfer.key}:#{transfer.initialValue}:#{transfer.combineMethod};" if transfer
         modelDescription += "#{target.key}#{if target.isAccumulator then ':'+(target.value ? target.initialValue) else ''}|"
 
     linkDescription += nodes.length     # we need to redraw targets when new node is added

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -334,6 +334,17 @@ GraphStore  = Reflux.createStore
             for link in changedLinks
               originalRelations[link.key] = link.relation
 
+            # If we are chaning to accumulator, set the max to 1000
+            if data.isAccumulator == true
+              data.max = NodeModel.SEMIQUANT_ACCUMULATOR_MAX
+
+            # If we are chaning to non-accumulator, set the max to 100
+            else
+              data.max = NodeModel.SEMIQUANT_MAX
+            # We changed node type, set defaults:
+            data.min = NodeModel.SEMIQUANT_MIN
+            data.initialValue = Math.round(data.max/2)
+
           @undoRedoManager.startCommandBatch()
           @undoRedoManager.createAndExecuteCommand 'changeNode',
             execute: =>

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -334,17 +334,6 @@ GraphStore  = Reflux.createStore
             for link in changedLinks
               originalRelations[link.key] = link.relation
 
-            # If we are chaning to accumulator, set the max to 1000
-            if data.isAccumulator == true
-              data.max = NodeModel.SEMIQUANT_ACCUMULATOR_MAX
-
-            # If we are chaning to non-accumulator, set the max to 100
-            else
-              data.max = NodeModel.SEMIQUANT_MAX
-            # We changed node type, set defaults:
-            data.min = NodeModel.SEMIQUANT_MIN
-            data.initialValue = Math.round(data.max/2)
-
           @undoRedoManager.startCommandBatch()
           @undoRedoManager.createAndExecuteCommand 'changeNode',
             execute: =>

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -77,6 +77,7 @@ SimulationStore   = Reflux.createStore
     @settings.simulationPanelExpanded = true
     @settings.modelIsRunning = true
     @_updateModelIsRunnable()
+    @_runSimulation()
     @notifyChange()
 
   onCollapseSimulationPanel: ->

--- a/src/code/stores/simulation-store.coffee
+++ b/src/code/stores/simulation-store.coffee
@@ -77,7 +77,8 @@ SimulationStore   = Reflux.createStore
     @settings.simulationPanelExpanded = true
     @settings.modelIsRunning = true
     @_updateModelIsRunnable()
-    @_runSimulation()
+    if @settings.graphHasCollector
+      @_runSimulation()
     @notifyChange()
 
   onCollapseSimulationPanel: ->

--- a/src/code/views/node-value-inspector-view.coffee
+++ b/src/code/views/node-value-inspector-view.coffee
@@ -21,13 +21,13 @@ module.exports = React.createClass
     'min-value': @props.node.min
     'max-value': @props.node.max
 
-  componentWillReceiveProps: ->
+  componentWillReceiveProps: (nextProps)->
     # min and max are copied to state to disconnect the state and property, so
     # that we can set the text field and only update the model when the input field
     # is blured. This way we don't perform min/max validation while user is typing
     @setState
-      'min-value': @props.node.min
-      'max-value': @props.node.max
+      'min-value': nextProps.node.min
+      'max-value': nextProps.node.max
 
   trim: (inputValue) ->
     return Math.max(@props.node.min, Math.min(@props.node.max, inputValue))

--- a/src/code/views/simulation-run-panel-view.coffee
+++ b/src/code/views/simulation-run-panel-view.coffee
@@ -23,8 +23,10 @@ module.exports = React.createClass
       SimulationStore.actions.collapseSimulationPanel()
     else
       SimulationStore.actions.expandSimulationPanel()
-      if ! @state.showingMinigraphs
-        AppSettingsStore.actions.showMinigraphs true
+      # -- TBD: There was discussion about automatically showing
+      # -- MiniGraphs when this panel is opened  …  NP 2018-01
+      # if ! @state.showingMinigraphs
+      #   AppSettingsStore.actions.showMinigraphs true
 
   renderToggleButton: ->
     iconClass = if @state.simulationPanelExpanded then "inspectorArrow-collapse" else "inspectorArrow-expand"

--- a/src/code/views/simulation-run-panel-view.coffee
+++ b/src/code/views/simulation-run-panel-view.coffee
@@ -1,4 +1,6 @@
 SimulationStore = require '../stores/simulation-store'
+AppSettingsStore = require '../stores/app-settings-store'
+
 tr              = require '../utils/translate'
 RecordButton    = React.createFactory require './record-button-view'
 Dropdown        = React.createFactory require './dropdown-view'
@@ -10,7 +12,7 @@ module.exports = React.createClass
 
   displayName: 'SimulationRunPanel'
 
-  mixins: [ SimulationStore.mixin ]
+  mixins: [ SimulationStore.mixin, AppSettingsStore.mixin ]
 
 
   setDuration: (e) ->
@@ -21,6 +23,8 @@ module.exports = React.createClass
       SimulationStore.actions.collapseSimulationPanel()
     else
       SimulationStore.actions.expandSimulationPanel()
+      if ! @state.showingMinigraphs
+        AppSettingsStore.actions.showMinigraphs true
 
   renderToggleButton: ->
     iconClass = if @state.simulationPanelExpanded then "inspectorArrow-collapse" else "inspectorArrow-expand"

--- a/src/stylus/components/value-inspector.styl
+++ b/src/stylus/components/value-inspector.styl
@@ -45,7 +45,7 @@
         padding 4px
         margin -8px
         box-shadow 1px 1px 3px -2px rgba(0,0,0,0.75)
-        width 18px
+        min-width 18px
         text-align center
         font-size 8pt
         cursor pointer

--- a/test/simulation-test.coffee
+++ b/test/simulation-test.coffee
@@ -312,7 +312,7 @@ describe "Simulation", ->
 
     describe "for transfer nodes", ->
       beforeEach ->
-        @nodeA    = new Node({title: "A", isAccumulator: true, initialValue: 20})
+        @nodeA    = new Node({title: "A", isAccumulator: true, initialValue: 100})
         @nodeB    = new Node({title: "B", isAccumulator: true, initialValue: 50})
         @transferLink = LinkNodes(@nodeA, @nodeB, RelationFactory.transferred)
         @transferNode = @transferLink.transferNode
@@ -325,17 +325,18 @@ describe "Simulation", ->
       describe "should transfer appropriate amount from the source node to the target node", ->
 
         # sanity check
-        it "should transfer 1/100th the value of the source node with no transfer-modifier", ->
+        it "should transfer (transwerNode.initialValue 50) to B with no transfer-modifier", ->
+          @transferNode.initialValue = 50
           @simulation.run()
-          expect(@nodeA.currentValue, "Node: #{@nodeA.title}").to.be.closeTo 19.5, 0.000001
-          expect(@nodeB.currentValue, "Node: #{@nodeB.title}").to.be.closeTo 50.5, 0.000001
+          expect(@nodeA.currentValue, "Node: #{@nodeA.title}").to.be.closeTo 50, 0.000001
+          expect(@nodeB.currentValue, "Node: #{@nodeB.title}").to.be.closeTo 100, 0.000001
 
         # sanity check
-        it "should transfer 1/100th the value of the source node with no transfer-modifier", ->
+        it "should transfer (transwerNode.initialValue 80) to B with no transfer-modifier", ->
           @transferNode.initialValue = 80
           @simulation.run()
-          expect(@nodeA.currentValue, "Node: #{@nodeA.title}").to.be.closeTo 19.2, 0.000001
-          expect(@nodeB.currentValue, "Node: #{@nodeB.title}").to.be.closeTo 50.8, 0.000001
+          expect(@nodeA.currentValue, "Node: #{@nodeA.title}").to.be.closeTo 20, 0.000001
+          expect(@nodeB.currentValue, "Node: #{@nodeB.title}").to.be.closeTo 130, 0.000001
 
         # sanity check
         it "should limit the transfer to the quantity in the source node", ->


### PR DESCRIPTION
@sfentress would you mind looking at this PR?  

It's smaller than the last, and related. Hopefully, it's a quick read.

Summary of Changes:
* The calculation for a flow by default should use `limiting factor` (aka `product`)
* Simulation reruns when the transfer's `combine method` is changed, so graphs update.
* Remove a special case of dividing a collectors value by 100 if there is no input. (This is the one you and Dan were discussing in the last PR)
* Immediately enable `display mini-graphs` if we are running a simulation with collectors. 

Some tests needed to be adjusted to handle the divide by 100 change.


Related PT Stories:
https://www.pivotaltracker.com/story/show/153639811
https://www.pivotaltracker.com/story/show/153639752
https://www.pivotaltracker.com/story/show/154029978
https://www.pivotaltracker.com/story/show/153639400
https://www.pivotaltracker.com/story/show/153639740
https://www.pivotaltracker.com/story/show/153639575