### PR TITLE
[#155049999] Set CODAP property: preventBringToFront

### DIFF
--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -42,7 +42,10 @@ module.exports = class CodapConnect
       {
         action: 'update'
         resource: 'interactiveFrame'
-        values: { title: tr "~CODAP.INTERACTIVE_FRAME.TITLE"}
+        values: {
+          title: tr "~CODAP.INTERACTIVE_FRAME.TITLE"
+          preventBringToFront: true
+        }
       },
       {
         action: 'get'


### PR DESCRIPTION
CODAP will soon be adjusting the default setting for preventBringToFront
from true to false. This goes along with other changes intended to make
plugins behave more like other components in the CODAP workspace. Sage
relies on being placed in the background, especially in standalone mode,
so we initialize with the property, instead of relying on the default.