### PR TITLE
Stop UI elements appearing in Diagram-Only mode

### DIFF
--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -391,7 +391,7 @@ GraphStore  = Reflux.createStore
 
     if isDoubleClick
       @selectionManager.selectNodeForInspection(link.targetNode)
-      if AppSettingsStore.store.settings.simulationType != 0
+      if AppSettingsStore.store.settings.simulationType != AppSettingsStore.store.SimulationType.diagramOnly
         InspectorPanelStore.actions.openInspectorPanel('relations', {link: link})
     else
       # set single click handler to run 250ms from now so we can wait to see if this is a double click

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -391,7 +391,8 @@ GraphStore  = Reflux.createStore
 
     if isDoubleClick
       @selectionManager.selectNodeForInspection(link.targetNode)
-      InspectorPanelStore.actions.openInspectorPanel('relations', {link: link})
+      if AppSettingsStore.store.settings.simulationType != 0
+        InspectorPanelStore.actions.openInspectorPanel('relations', {link: link})
     else
       # set single click handler to run 250ms from now so we can wait to see if this is a double click
       singleClickHandler = =>

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -127,7 +127,7 @@ module.exports = NodeView = React.createClass
       now = (new Date()).getTime()
       if now - (@lastClickLinkTime || 0) <= 250
         # Only open inspector if we're not in diagram-only mode
-        if AppSettingsStore.store.settings.simulationType != 0
+        if AppSettingsStore.store.settings.simulationType != AppSettingsStore.store.SimulationType.diagramOnly
           InspectorPanelStore.actions.openInspectorPanel 'relations'
       @lastClickLinkTime = now
 

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -1,6 +1,7 @@
 {input, div, i, img, span, label, img} = React.DOM
 tr = require "../utils/translate"
 
+AppSettingsStore    = require "../stores/app-settings-store"
 SimulationActions = require("../stores/simulation-store").actions
 SquareImage = React.createFactory require "./square-image-view"
 StackedImage = React.createFactory require "./stacked-image-view"
@@ -125,7 +126,9 @@ module.exports = NodeView = React.createClass
     if @props.data.inLinks().length > 0
       now = (new Date()).getTime()
       if now - (@lastClickLinkTime || 0) <= 250
-        InspectorPanelStore.actions.openInspectorPanel 'relations'
+        # Only open inspector if we're not in diagram-only mode
+        if AppSettingsStore.store.settings.simulationType != 0
+          InspectorPanelStore.actions.openInspectorPanel 'relations'
       @lastClickLinkTime = now
 
   propTypes:

--- a/src/code/views/simulation-inspector-view.coffee
+++ b/src/code/views/simulation-inspector-view.coffee
@@ -76,7 +76,7 @@ module.exports = React.createClass
           (RadioF {value: SimulationType.diagramOnly, disabled: diagramOnlyDisabled})
           (span {className: if diagramOnlyDisabled then "disabled"}, tr '~SIMULATION.COMPLEXITY.DIAGRAM_ONLY')
         )
-        (div {},
+        (div {key: 'simulation-static-options'},
           (label {key: 'simulation-type-static'},
             (RadioF {value: SimulationType.static, disabled: staticDisabled})
             (span {className: if staticDisabled then "disabled"}, tr '~SIMULATION.COMPLEXITY.STATIC')
@@ -86,7 +86,7 @@ module.exports = React.createClass
               complexityRadioButtons
           )
         )
-        (div {},
+        (div {key: 'simulation-complexity-options'},
           (label {key: 'simulation-type-time'},
             (RadioF {value: SimulationType.time})
             (span {}, tr '~SIMULATION.COMPLEXITY.TIME')


### PR DESCRIPTION
Double-clicking a link shouldn't open the relationship window, neither should double-clicking a node when we're in that mode. This fix blocks those actions specifically, while leaving the menu functionality intact to enable the user to change to a different mode if they wish.