### PR TITLE
Migration import fixes

### DIFF
--- a/src/code/data/migrations/23_add_simulation_type.coffee
+++ b/src/code/data/migrations/23_add_simulation_type.coffee
@@ -32,7 +32,11 @@ migration =
       data.settings.simulationType = AppSettingsStore.SimulationType.static
       data.settings.complexity     = AppSettingsStore.Complexity.expanded
     else if previousComplexity == 3
-      data.settings.simulationType = AppSettingsStore.SimulationType.time
+      hasCollectors = data.nodes.some((node) -> node.data.isAccumulator)
+      if hasCollectors
+        data.settings.simulationType = AppSettingsStore.SimulationType.time
+      else
+        data.settings.simulationType = AppSettingsStore.SimulationType.static
       data.settings.complexity     = AppSettingsStore.Complexity.expanded
 
 module.exports = _.mixin migration, require './migration-mixin'

--- a/src/code/data/migrations/23_add_simulation_type.coffee
+++ b/src/code/data/migrations/23_add_simulation_type.coffee
@@ -18,7 +18,8 @@ migration =
     #  0: simulation: diagramOnly / complexity: basic
     #  1: simulation: static      / complexity: basic
     #  2: simulation: static      / complexity: expanded
-    #  3: simulation: time        / complexity: expanded
+    #  3 (for models with nodes set up as collectors): simulation: time   / complexity: expanded
+    #  3 (no collectors in model):                     simulation: static / complexity: expanded
 
     previousComplexity = if data.settings.complexity? then data.settings.complexity else 2
 

--- a/src/code/utils/importer.coffee
+++ b/src/code/utils/importer.coffee
@@ -9,19 +9,10 @@ module.exports = class MySystemImporter
     undefined
 
   importData: (data) ->
-    importVersion = data.version
     Migrations.update(data)
     # Synchronous invocation of actions / w trigger
     ImportActions.import.trigger(data)
-    hasCollectors = @importNodes data.nodes
-
-    simType = @settings.settings.simulationType
-
-    if importVersion != data.version and simType == @settings.SimulationType.time and hasCollectors == false
-      # Downgrade to static equilibrium - older models with the "can have collectors" checkbox
-      # will always import as time-based simulations even if they don't have collectors
-      @settings.settings.simulationType = @settings.SimulationType.static
-
+    @importNodes data.nodes
     @importLinks data.links
     @graphStore.setFilename data.filename or 'New Model'
 
@@ -36,12 +27,10 @@ module.exports = class MySystemImporter
       new DiagramNode(data, key)
 
   importNodes: (importNodes) ->
-    hasCollectors = false
     for nodespec in importNodes
       node = @importNode(nodespec)
-      if node._isAccumulator then hasCollectors = true
       @graphStore.addNode node
-    return hasCollectors
+    return  # prevent unused default return value
 
   importLinks: (links) ->
     for link in links

--- a/src/code/utils/importer.coffee
+++ b/src/code/utils/importer.coffee
@@ -9,6 +9,7 @@ module.exports = class MySystemImporter
     undefined
 
   importData: (data) ->
+    importVersion = data.version
     Migrations.update(data)
     # Synchronous invocation of actions / w trigger
     ImportActions.import.trigger(data)
@@ -16,7 +17,7 @@ module.exports = class MySystemImporter
 
     simType = @settings.settings.simulationType
 
-    if simType == @settings.SimulationType.time and hasCollectors == false
+    if importVersion != data.version and simType == @settings.SimulationType.time and hasCollectors == false
       # Downgrade to static equilibrium - older models with the "can have collectors" checkbox
       # will always import as time-based simulations even if they don't have collectors
       @settings.settings.simulationType = @settings.SimulationType.static


### PR DESCRIPTION
This patch addresses checking for evidence of collectors in older models - all static equilibrium models would include the default "include collectors" checkbox and, at import, would be read incorrectly to newer builds as dynamic simulations. This should hopefully address the problem at import while not changing models saved on current versions.