### PR TITLE
DAT-Cross UI changes

### DIFF
--- a/src/code/mixins/app-view.coffee
+++ b/src/code/mixins/app-view.coffee
@@ -23,6 +23,7 @@ module.exports =
   addDeleteKeyHandler: (add) ->
     if add
       if AppSettingsStore.store.settings.lockdown
+        # In Lockdown mode users can only remove relationships between links
         deleteFunction = @props.graphStore.removeSelectedLinks.bind @props.graphStore
       else
         deleteFunction = @props.graphStore.deleteSelected.bind @props.graphStore

--- a/src/code/mixins/app-view.coffee
+++ b/src/code/mixins/app-view.coffee
@@ -22,13 +22,16 @@ module.exports =
 
   addDeleteKeyHandler: (add) ->
     if add
-      deleteFunction = @props.graphStore.deleteSelected.bind @props.graphStore
+      if AppSettingsStore.store.settings.lockdown
+        deleteFunction = @props.graphStore.removeSelectedLinks.bind @props.graphStore
+      else
+        deleteFunction = @props.graphStore.deleteSelected.bind @props.graphStore
+
       $(window).on 'keydown', (e) ->
         # 8 is backspace, 46 is delete
         if e.which in [8, 46] and not $(e.target).is('input, textarea')
           e.preventDefault()
-          if not AppSettingsStore.store.settings.lockdown
-            deleteFunction()
+          deleteFunction()
     else
       $(window).off 'keydown'
 

--- a/src/code/mixins/app-view.coffee
+++ b/src/code/mixins/app-view.coffee
@@ -3,6 +3,7 @@ CodapStore      = require "../stores/codap-store"
 GoogleFileStore = require "../stores/google-file-store"
 HashParams      = require "../utils/hash-parameters"
 tr              = require '../utils/translate'
+AppSettingsStore = require '../stores/app-settings-store'
 
 module.exports =
 
@@ -26,7 +27,8 @@ module.exports =
         # 8 is backspace, 46 is delete
         if e.which in [8, 46] and not $(e.target).is('input, textarea')
           e.preventDefault()
-          deleteFunction()
+          if not AppSettingsStore.store.settings.lockdown
+            deleteFunction()
     else
       $(window).off 'keydown'
 

--- a/src/code/stores/app-settings-store.coffee
+++ b/src/code/stores/app-settings-store.coffee
@@ -36,18 +36,18 @@ AppSettingsStore   = Reflux.createStore
       globalNav: true,
       actionBar: true,
       inspectorPanel: true,
-      showNodePalette: true
+      nodePalette: true
     }
-    uiParams = HashParams.getParam('uielements')
-    # For hosted situations where some ui elements are to be hidden, this parameter can be specified.
-    # If this parameter is present, Any unspecified elements are assumed to be disabled.
-    # Example usage for full (normal) display: uielements=globalNav,actionBar,canvas,inspectorPanel,showNodePalette
+    uiParams = HashParams.getParam('hide')
+    # For situations where some ui elements need to be hidden, this parameter can be specified.
+    # If this parameter is present, Any specified elements are disabled or hidden.
+    # Example usage: hide=globalNav,inspectorPanel
     if uiParams
       uiOpts = uiParams.split(",")
-      uiElements.globalNav = uiParams.indexOf("globalNav") > -1
-      uiElements.actionBar = uiParams.indexOf("actionBar") > -1
-      uiElements.inspectorPanel = uiParams.indexOf("inspectorPanel") > -1
-      uiElements.showNodePalette = uiParams.indexOf("showNodePalette") > -1
+      uiElements.globalNav = uiParams.indexOf("globalNav") == -1
+      uiElements.actionBar = uiParams.indexOf("actionBar") == -1
+      uiElements.inspectorPanel = uiParams.indexOf("inspectorPanel") == -1
+      uiElements.nodePalette = uiParams.indexOf("nodePalette") == -1
 
     lockdown = HashParams.getParam('lockdown') == "true"
 

--- a/src/code/stores/app-settings-store.coffee
+++ b/src/code/stores/app-settings-store.coffee
@@ -32,7 +32,6 @@ AppSettingsStore   = Reflux.createStore
     else
       SimulationType.DEFAULT
 
-
     uiElements = {
       globalNav: true,
       actionBar: true,
@@ -41,13 +40,18 @@ AppSettingsStore   = Reflux.createStore
       showNodePalette: true
     }
     uiParams = HashParams.getParam('uielements')
+    # For hosted situations where some ui elements are to be hidden, this parameter can be specified.
+    # If this parameter is present, Any unspecified elements are assumed to be disabled.
+    # Example usage for full (normal) display: uielements=globalNav,actionBar,canvas,inspectorPanel,showNodePalette
     if uiParams
-      uiOpts = uiParams.split("")
-      uiElements.globalNav = uiOpts[0] == "1"
-      uiElements.actionBar = uiOpts[1] == "1"
-      uiElements.canvas = uiOpts[2] == "1"
-      uiElements.inspectorPanel = uiOpts[3] == "1"
-      uiElements.showNodePalette = uiOpts[4] == "1"
+      uiOpts = uiParams.split(",")
+      uiElements.globalNav = uiParams.indexOf("globalNav") > -1
+      uiElements.actionBar = uiParams.indexOf("actionBar") > -1
+      uiElements.canvas = uiParams.indexOf("canvas") > -1
+      uiElements.inspectorPanel = uiParams.indexOf("inspectorPanel") > -1
+      uiElements.showNodePalette = uiParams.indexOf("showNodePalette") > -1
+
+    lockdown = HashParams.getParam('lockdown') == "true"
 
     @settings =
       showingSettingsDialog: false
@@ -56,6 +60,7 @@ AppSettingsStore   = Reflux.createStore
       showingMinigraphs: false
       relationshipSymbols: false
       uiElements: uiElements
+      lockdown: lockdown
 
   onShowMinigraphs: (show) ->
     @settings.showingMinigraphs = show

--- a/src/code/stores/app-settings-store.coffee
+++ b/src/code/stores/app-settings-store.coffee
@@ -43,7 +43,6 @@ AppSettingsStore   = Reflux.createStore
     # If this parameter is present, Any specified elements are disabled or hidden.
     # Example usage: hide=globalNav,inspectorPanel
     if uiParams
-      uiOpts = uiParams.split(",")
       uiElements.globalNav = uiParams.indexOf("globalNav") == -1
       uiElements.actionBar = uiParams.indexOf("actionBar") == -1
       uiElements.inspectorPanel = uiParams.indexOf("inspectorPanel") == -1

--- a/src/code/stores/app-settings-store.coffee
+++ b/src/code/stores/app-settings-store.coffee
@@ -37,7 +37,8 @@ AppSettingsStore   = Reflux.createStore
       globalNav: true,
       actionBar: true,
       canvas: true,
-      inspectorPanel: true
+      inspectorPanel: true,
+      showNodePalette: true
     }
     uiParams = HashParams.getParam('uielements')
     if uiParams
@@ -46,6 +47,7 @@ AppSettingsStore   = Reflux.createStore
       uiElements.actionBar = uiOpts[1] == "1"
       uiElements.canvas = uiOpts[2] == "1"
       uiElements.inspectorPanel = uiOpts[3] == "1"
+      uiElements.showNodePalette = uiOpts[4] == "1"
 
     @settings =
       showingSettingsDialog: false

--- a/src/code/stores/app-settings-store.coffee
+++ b/src/code/stores/app-settings-store.coffee
@@ -23,7 +23,6 @@ SimulationType = {
   DEFAULT: 1
 }
 
-
 AppSettingsStore   = Reflux.createStore
   listenables: [AppSettingsActions, ImportActions]
 
@@ -33,12 +32,28 @@ AppSettingsStore   = Reflux.createStore
     else
       SimulationType.DEFAULT
 
+
+    uiElements = {
+      globalNav: true,
+      actionBar: true,
+      canvas: true,
+      inspectorPanel: true
+    }
+    uiParams = HashParams.getParam('uielements')
+    if uiParams
+      uiOpts = uiParams.split("")
+      uiElements.globalNav = uiOpts[0] == "1"
+      uiElements.actionBar = uiOpts[1] == "1"
+      uiElements.canvas = uiOpts[2] == "1"
+      uiElements.inspectorPanel = uiOpts[3] == "1"
+
     @settings =
       showingSettingsDialog: false
       complexity: Complexity.DEFAULT
       simulationType: simulationType
       showingMinigraphs: false
       relationshipSymbols: false
+      uiElements: uiElements
 
   onShowMinigraphs: (show) ->
     @settings.showingMinigraphs = show

--- a/src/code/stores/app-settings-store.coffee
+++ b/src/code/stores/app-settings-store.coffee
@@ -35,7 +35,6 @@ AppSettingsStore   = Reflux.createStore
     uiElements = {
       globalNav: true,
       actionBar: true,
-      canvas: true,
       inspectorPanel: true,
       showNodePalette: true
     }
@@ -47,7 +46,6 @@ AppSettingsStore   = Reflux.createStore
       uiOpts = uiParams.split(",")
       uiElements.globalNav = uiParams.indexOf("globalNav") > -1
       uiElements.actionBar = uiParams.indexOf("actionBar") > -1
-      uiElements.canvas = uiParams.indexOf("canvas") > -1
       uiElements.inspectorPanel = uiParams.indexOf("inspectorPanel") > -1
       uiElements.showNodePalette = uiParams.indexOf("showNodePalette") > -1
 

--- a/src/code/views/app-view.coffee
+++ b/src/code/views/app-view.coffee
@@ -50,12 +50,14 @@ module.exports = React.createClass
             username: @state.username
             graphStore: @props.graphStore
             GraphStore: @GraphStore
+            display: AppSettingsStore.store.settings.uiElements.globalNav
           )
         (div {className: 'action-bar'},
           (NodeWell {
             palette: @state.palette
             toggleImageBrowser: @toggleImageBrowser
-            graphStore: @props.graphStore
+            graphStore: @props.graphStore,
+            display: AppSettingsStore.store.settings.uiElements.actionBar
           })
           (DocumentActions
             graphStore: @props.graphStore
@@ -67,7 +69,8 @@ module.exports = React.createClass
           (GraphView {
             graphStore: @props.graphStore,
             selectionManager: @props.graphStore.selectionManager,
-            selectedLink: @state.selectedLink})
+            selectedLink: @state.selectedLink,
+            display: AppSettingsStore.store.settings.uiElements.canvas})
         )
         (InspectorPanel
           node: @state.selectedNode
@@ -79,6 +82,7 @@ module.exports = React.createClass
           toggleImageBrowser: @toggleImageBrowser
           graphStore: @props.graphStore
           ref: "inspectorPanel"
+          display: AppSettingsStore.store.settings.uiElements.inspectorPanel
         )
         if @state.showingDialog
           (ImageBrowser

--- a/src/code/views/app-view.coffee
+++ b/src/code/views/app-view.coffee
@@ -42,6 +42,12 @@ module.exports = React.createClass
     @setState showImageBrowser: not @state.showImageBrowser
 
   render: ->
+    actionBarStyle = 'action-bar'
+    if AppSettingsStore.store.settings.uiElements.actionBar is false
+      actionBarStyle += ' hidden'
+    else if AppSettingsStore.store.settings.uiElements.globalNav is false
+      actionBarStyle += ' small'
+
     (div {className: 'app'},
       (div {className: if @state.iframed then 'iframed-workspace' else 'workspace'},
         if not @state.iframed && AppSettingsStore.store.settings.uiElements.globalNav != false
@@ -52,7 +58,7 @@ module.exports = React.createClass
             GraphStore: @GraphStore
             display: AppSettingsStore.store.settings.uiElements.globalNav
           )
-        (div {className: if AppSettingsStore.store.settings.uiElements.actionBar == false then 'action-bar hidden' else if AppSettingsStore.store.settings.uiElements.globalNav is false then 'action-bar small' else 'action-bar'},
+        (div {className: actionBarStyle},
           (NodeWell {
             palette: @state.palette
             toggleImageBrowser: @toggleImageBrowser

--- a/src/code/views/app-view.coffee
+++ b/src/code/views/app-view.coffee
@@ -65,7 +65,7 @@ module.exports = React.createClass
             iframed: @state.iframed
           )
         )
-        (div {className: if AppSettingsStore.store.settings.uiElements.canvas == false then 'canvas hidden' else if AppSettingsStore.store.settings.uiElements.globalNav is false then 'canvas full' else 'canvas'},
+        (div {className: if AppSettingsStore.store.settings.uiElements.globalNav is false then 'canvas full' else 'canvas'},
           (GraphView {
             graphStore: @props.graphStore,
             selectionManager: @props.graphStore.selectionManager,

--- a/src/code/views/app-view.coffee
+++ b/src/code/views/app-view.coffee
@@ -52,12 +52,12 @@ module.exports = React.createClass
             GraphStore: @GraphStore
             display: AppSettingsStore.store.settings.uiElements.globalNav
           )
-        (div {className: if AppSettingsStore.store.settings.uiElements.actionBar == false then 'action-bar hidden' else 'action-bar'},
+        (div {className: if AppSettingsStore.store.settings.uiElements.actionBar == false then 'action-bar hidden' else if AppSettingsStore.store.settings.uiElements.globalNav is false then 'action-bar small' else 'action-bar'},
           (NodeWell {
             palette: @state.palette
             toggleImageBrowser: @toggleImageBrowser
             graphStore: @props.graphStore
-            showNodePalette: AppSettingsStore.store.settings.uiElements.showNodePalette
+            uiElements: AppSettingsStore.store.settings.uiElements
           })
           (DocumentActions
             graphStore: @props.graphStore
@@ -65,7 +65,7 @@ module.exports = React.createClass
             iframed: @state.iframed
           )
         )
-        (div {className: if AppSettingsStore.store.settings.uiElements.canvas == false then 'canvas hidden' else 'canvas'},
+        (div {className: if AppSettingsStore.store.settings.uiElements.canvas == false then 'canvas hidden' else if AppSettingsStore.store.settings.uiElements.globalNav is false then 'canvas full' else 'canvas'},
           (GraphView {
             graphStore: @props.graphStore,
             selectionManager: @props.graphStore.selectionManager,

--- a/src/code/views/app-view.coffee
+++ b/src/code/views/app-view.coffee
@@ -44,7 +44,7 @@ module.exports = React.createClass
   render: ->
     (div {className: 'app'},
       (div {className: if @state.iframed then 'iframed-workspace' else 'workspace'},
-        if not @state.iframed
+        if not @state.iframed && AppSettingsStore.store.settings.uiElements.globalNav != false
           (GlobalNav
             filename: @state.filename
             username: @state.username
@@ -52,12 +52,12 @@ module.exports = React.createClass
             GraphStore: @GraphStore
             display: AppSettingsStore.store.settings.uiElements.globalNav
           )
-        (div {className: 'action-bar'},
+        (div {className: if AppSettingsStore.store.settings.uiElements.actionBar == false then 'action-bar hidden' else 'action-bar'},
           (NodeWell {
             palette: @state.palette
             toggleImageBrowser: @toggleImageBrowser
-            graphStore: @props.graphStore,
-            display: AppSettingsStore.store.settings.uiElements.actionBar
+            graphStore: @props.graphStore
+            showNodePalette: AppSettingsStore.store.settings.uiElements.showNodePalette
           })
           (DocumentActions
             graphStore: @props.graphStore
@@ -65,12 +65,11 @@ module.exports = React.createClass
             iframed: @state.iframed
           )
         )
-        (div {className: 'canvas'},
+        (div {className: if AppSettingsStore.store.settings.uiElements.canvas == false then 'canvas hidden' else 'canvas'},
           (GraphView {
             graphStore: @props.graphStore,
             selectionManager: @props.graphStore.selectionManager,
-            selectedLink: @state.selectedLink,
-            display: AppSettingsStore.store.settings.uiElements.canvas})
+            selectedLink: @state.selectedLink})
         )
         (InspectorPanel
           node: @state.selectedNode

--- a/src/code/views/document-actions-view.coffee
+++ b/src/code/views/document-actions-view.coffee
@@ -32,12 +32,11 @@ module.exports = React.createClass
 
   deleteClicked: ->
     if @state.lockdown
-      # only allow deletion of links in lockdown mode
+      # Only allow deletion of links in lockdown mode
       @props.graphStore.removeSelectedLinks()
-
     else
       @props.graphStore.deleteSelected()
-
+    # Clear stored selections after delete
     @props.graphStore.selectionManager.clearSelection()
 
   renderRunPanel: ->
@@ -53,9 +52,9 @@ module.exports = React.createClass
 
       unless @state.hideUndoRedo
         (div {className: 'misc-actions'},
-          # lockdown mode only highlight delete button when we have a link selected
-          @state.lockdown && @state.selectedLinks && @state.selectedLinks.length > 0 && (i {className: "icon-codap-trash", onClick: @deleteClicked}
-          )
+          # In Lockdown mode only show the Delete button when we have a link selected
+          @state.lockdown && @state.selectedLinks && @state.selectedLinks.length > 0 && (i {className: "icon-codap-trash", onClick: @deleteClicked})
+          # In normal operation, show the Delete button whenever we have a node or relationship selected
           !@state.lockdown && @state.selectedItems && @state.selectedItems.length > 0 && (i {className: "icon-codap-trash", onClick: @deleteClicked})
           (i {className: "icon-codap-arrow-undo #{buttonClass @state.canUndo}", onClick: @undoClicked, disabled: not @state.canUndo})
           (i {className: "icon-codap-arrow-redo #{buttonClass @state.canRedo}", onClick: @redoClicked, disabled: not @state.canRedo})

--- a/src/code/views/document-actions-view.coffee
+++ b/src/code/views/document-actions-view.coffee
@@ -20,8 +20,8 @@ module.exports = React.createClass
       selectedLinks      = manager.getLinkInspection() or []
 
       @setState
-        #selectedNodes: selectedNodes
-        #selectedLinks: selectedLinks
+        selectedNodes: selectedNodes
+        selectedLinks: selectedLinks
         selectedItems: selectedNodes.concat selectedLinks
 
   undoClicked: ->
@@ -32,12 +32,10 @@ module.exports = React.createClass
 
   deleteClicked: ->
     if @state.lockdown
+      # only allow deletion of links in lockdown mode
       @props.graphStore.removeSelectedLinks()
-      # if @state.selectedLinks && @state.selectedLinks.length
-        # only allow deletion of links in lockdown mode
-        # @props.graphStore.removeSelectedLinks()
 
-    else #if @state.selectedItems && @state.selectedItems.length > 0
+    else
       @props.graphStore.deleteSelected()
 
     @props.graphStore.selectionManager.clearSelection()
@@ -56,9 +54,9 @@ module.exports = React.createClass
       unless @state.hideUndoRedo
         (div {className: 'misc-actions'},
           # lockdown mode only highlight delete button when we have a link selected
-          # @state.lockdown && @state.selectedLinks && @state.selectedLinks.length > 0 && (i {className: "icon-codap-trash", onClick: @deleteClicked}
-          # )
-          @state.selectedItems && @state.selectedItems.length > 0 && (i {className: "icon-codap-trash", onClick: @deleteClicked})
+          @state.lockdown && @state.selectedLinks && @state.selectedLinks.length > 0 && (i {className: "icon-codap-trash", onClick: @deleteClicked}
+          )
+          !@state.lockdown && @state.selectedItems && @state.selectedItems.length > 0 && (i {className: "icon-codap-trash", onClick: @deleteClicked})
           (i {className: "icon-codap-arrow-undo #{buttonClass @state.canUndo}", onClick: @undoClicked, disabled: not @state.canUndo})
           (i {className: "icon-codap-arrow-redo #{buttonClass @state.canRedo}", onClick: @redoClicked, disabled: not @state.canRedo})
         )

--- a/src/code/views/document-actions-view.coffee
+++ b/src/code/views/document-actions-view.coffee
@@ -13,11 +13,34 @@ module.exports = React.createClass
 
   displayName: 'DocumentActions'
 
+  componentDidMount: ->
+    deleteFunction = @props.graphStore.deleteSelected.bind @props.graphStore
+    @props.graphStore.selectionManager.addSelectionListener (manager) =>
+      selectedNodes     = manager.getNodeInspection() or []
+      selectedLinks      = manager.getLinkInspection() or []
+
+      @setState
+        #selectedNodes: selectedNodes
+        #selectedLinks: selectedLinks
+        selectedItems: selectedNodes.concat selectedLinks
+
   undoClicked: ->
     @props.graphStore.undo()
 
   redoClicked: ->
     @props.graphStore.redo()
+
+  deleteClicked: ->
+    if @state.lockdown
+      @props.graphStore.removeSelectedLinks()
+      # if @state.selectedLinks && @state.selectedLinks.length
+        # only allow deletion of links in lockdown mode
+        # @props.graphStore.removeSelectedLinks()
+
+    else #if @state.selectedItems && @state.selectedItems.length > 0
+      @props.graphStore.deleteSelected()
+
+    @props.graphStore.selectionManager.clearSelection()
 
   renderRunPanel: ->
     if not @props.diagramOnly
@@ -32,6 +55,10 @@ module.exports = React.createClass
 
       unless @state.hideUndoRedo
         (div {className: 'misc-actions'},
+          # lockdown mode only highlight delete button when we have a link selected
+          # @state.lockdown && @state.selectedLinks && @state.selectedLinks.length > 0 && (i {className: "icon-codap-trash", onClick: @deleteClicked}
+          # )
+          @state.selectedItems && @state.selectedItems.length > 0 && (i {className: "icon-codap-trash", onClick: @deleteClicked})
           (i {className: "icon-codap-arrow-undo #{buttonClass @state.canUndo}", onClick: @undoClicked, disabled: not @state.canUndo})
           (i {className: "icon-codap-arrow-redo #{buttonClass @state.canRedo}", onClick: @redoClicked, disabled: not @state.canRedo})
         )

--- a/src/code/views/graph-view.coffee
+++ b/src/code/views/graph-view.coffee
@@ -45,7 +45,8 @@ module.exports = React.createClass
       selectedNodes     = manager.getNodeInspection() or []
       editingNode       = manager.getNodeTitleEditing()[0] or null
       selectedLink      = manager.getLinkInspection() or []
-      editingLink       = manager.getLinkTitleEditing()[0] or null
+      # only allow link labels if simulation is not in lockdown mode
+      editingLink       = if not AppSettingsStore.store.settings.lockdown then manager.getLinkTitleEditing()[0] or null else false
 
       @setState
         selectedNodes: selectedNodes

--- a/src/code/views/inspector-panel-view.coffee
+++ b/src/code/views/inspector-panel-view.coffee
@@ -125,6 +125,11 @@ module.exports = React.createClass
 
   render: ->
     className = "inspector-panel"
+    if (@props.display != undefined)
+      if @props.display == true
+        className = "inspector-panel"
+      else
+        className = "inspector-panel hidden"
     unless @state.nowShowing
       className = "#{className} collapsed"
 

--- a/src/code/views/node-view.coffee
+++ b/src/code/views/node-view.coffee
@@ -188,8 +188,9 @@ module.exports = NodeView = React.createClass
     @props.graphStore.changeNodeWithKey(@props.nodeKey, {title:newTitle})
 
   startEditing: ->
-    @initialTitle = @props.graphStore.nodeKeys[@props.nodeKey].title
-    @props.selectionManager.selectNodeForTitleEditing(@props.data)
+    if not AppSettingsStore.store.settings.lockdown
+      @initialTitle = @props.graphStore.nodeKeys[@props.nodeKey].title
+      @props.selectionManager.selectNodeForTitleEditing(@props.data)
 
   stopEditing: ->
     @props.graphStore.endNodeEdit()

--- a/src/code/views/node-well-view.coffee
+++ b/src/code/views/node-well-view.coffee
@@ -31,7 +31,7 @@ module.exports = React.createClass
       topNodePaletteClass    = 'top-node-palette-wrapper collapsed'
       topNodeTabPaletteClass = 'top-node-palette-tab collapsed'
 
-    (div {className: if @props.showNodePalette == false then 'wrapperwrapper hidden' else 'wrapperwrapper'},
+    (div {className: if @props.uiElements.showNodePalette == false then 'wrapperwrapper hidden' else if @props.uiElements.globalNav is false then 'wrapperwrapper top' else 'wrapperwrapper'},
       (div {className: topNodePaletteClass},
         (PaletteInspectorView {
           toggleImageBrowser: @props.toggleImageBrowser,

--- a/src/code/views/node-well-view.coffee
+++ b/src/code/views/node-well-view.coffee
@@ -31,7 +31,7 @@ module.exports = React.createClass
       topNodePaletteClass    = 'top-node-palette-wrapper collapsed'
       topNodeTabPaletteClass = 'top-node-palette-tab collapsed'
 
-    (div {className: if @props.uiElements.showNodePalette == false then 'wrapperwrapper hidden' else if @props.uiElements.globalNav is false then 'wrapperwrapper top' else 'wrapperwrapper'},
+    (div {className: if @props.uiElements.nodePalette is false then 'wrapperwrapper hidden' else if @props.uiElements.globalNav is false then 'wrapperwrapper top' else 'wrapperwrapper'},
       (div {className: topNodePaletteClass},
         (PaletteInspectorView {
           toggleImageBrowser: @props.toggleImageBrowser,

--- a/src/code/views/node-well-view.coffee
+++ b/src/code/views/node-well-view.coffee
@@ -30,7 +30,8 @@ module.exports = React.createClass
     if @state.collapsed
       topNodePaletteClass    = 'top-node-palette-wrapper collapsed'
       topNodeTabPaletteClass = 'top-node-palette-tab collapsed'
-    (div {className: 'wrapperwrapper'},
+
+    (div {className: if @props.showNodePalette == false then 'wrapperwrapper hidden' else 'wrapperwrapper'},
       (div {className: topNodePaletteClass},
         (PaletteInspectorView {
           toggleImageBrowser: @props.toggleImageBrowser,

--- a/src/stylus/app.styl
+++ b/src/stylus/app.styl
@@ -30,6 +30,8 @@ body
   enable-flex(column)
   .canvas
     top palette-and-actions-height
+    &.full
+      top 0
 
 label > input[type="checkbox"]
   margin-right 0.5em

--- a/src/stylus/components/global-nav.styl
+++ b/src/stylus/components/global-nav.styl
@@ -55,3 +55,6 @@
     width 100%
     height palette-and-actions-height - 1
     box-shadow 0px 0px 1px hsla(0,0,0,0.2)
+    &.small
+      width auto
+      z-index 2

--- a/src/stylus/components/inspector-panel.styl
+++ b/src/stylus/components/inspector-panel.styl
@@ -112,3 +112,5 @@ inspector-panel-inner-height = 500px
       width 0px
       margin 0px
       padding 0px
+  &.hidden
+    display: none

--- a/src/stylus/components/link-view.styl
+++ b/src/stylus/components/link-view.styl
@@ -1,5 +1,7 @@
 .canvas
   absolute(top: palette-and-actions-height + global-nav-height, left: 0, right: 0, bottom: 0)
+  &.full
+    top 0
 
 .graph-view
   margin 0px

--- a/src/stylus/components/top-node-palette.styl
+++ b/src/stylus/components/top-node-palette.styl
@@ -80,3 +80,5 @@ node-well-tab-height = 30px
       &.collapsed
         background-image url("../img/bb-chrome/chevron-down.png")
         // top: palette-and-actions-height + global-nav-height + 30px
+  &.top
+    top 0


### PR DESCRIPTION
For the DAT-Cross project:

- Added `lockdown` url hash parameter to limit the ability of users to delete nodes. lockdown=true means users can only remove relationships, not nodes themselves. The assumption is that these users will have models loaded on initialization and will not need a node palette.

- Added `hide` url hash parameter that can remove any of the following pieces from the layout:
```
globalNav
actionBar
inspectorPanel
nodePalette
```

Additional style settings have been added to ensure a viable layout when any of these elements are removed from the UI. In most cases, `display:none` is sufficient to visibly remove them without significant code rework to handle them not being present.

- Added `delete` button to the action bar next to `undo/redo` buttons. This only appears if anything is selected, and can be clicked to delete the selected nodes and relationships. In `lockdown` mode, this only appears if one or more links are selected and will only remove selected relationships

A full test of the end-user experience for DAT-Cross students would require adding the following parameters to the url:
`#hide=inspectorPanel,nodePalette&simplified=true&lockdown=true`

Until loading can be added from the iFramed interactive, the nodePalette should probably be displayed so that the simulation can be tested:
`#hide=inspectorPanel&simplified=true&lockdown=true`