### PR TITLE
Bug: Dismissing Add new, then dragging variable makes two.

### DIFF
--- a/src/code/stores/image-dialog-store.coffee
+++ b/src/code/stores/image-dialog-store.coffee
@@ -48,6 +48,7 @@ store = Reflux.createStore
     @resetPaletteItem()
 
   onClose: ->
+    @callback=null
     @close()
     @_updateChanges()
 


### PR DESCRIPTION
Fixes:
Dismissing the "add new" image dialog creates two variables when an existing image is dragged to create a new variable.

Explanation:
A callback function is registered to add a new variable when we begin the dragging of a new image icon.  Unless we remove that callback, the callback will be invoked later with a different variable, resulting in the creation of two variables.

Story:
[#153599556]
https://www.pivotaltracker.com/story/show/153599556