### PR TITLE
Fix: Sage/CODAP will increment experiment numbers in different langua…

### DIFF
--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -257,12 +257,11 @@ module.exports = class CodapConnect
     handleSimulationAttributes = (listAttributeResponse) =>
       if listAttributeResponse?.success
         values = _.pluck(listAttributeResponse.values, 'name')
-        if  _.includes(values, @defaultExperimentName)
-          @renameExperimentNumberColumn(experimentNumberLabel)
-        else if (! _.includes(values, experimentNumberLabel))
-          @createExperimentNumberColumn experimentNumberLabel
-        else
-          log.info "No update requred: #{experimentNumberLabel} exists."
+        if not _.includes(values, experimentNumberLabel)
+          if _.includes(values, @defaultExperimentName)
+            @renameExperimentNumberColumn experimentNumberLabel
+          else
+            @createExperimentNumberColumn experimentNumberLabel
       else
         log.warn "CODAP: unable to list Simulation attributes"
 
@@ -477,7 +476,7 @@ module.exports = class CodapConnect
           , (ret2) ->
             if ret2?.success
               lastCase = ret2.values['case']
-              lastExperimentNumber = parseInt(lastCase.values[tr '~CODAP.SIMULATION.EXPERIMENT']) || 0
+              lastExperimentNumber = parseInt(lastCase.values[tr '~CODAP.SIMULATION.EXPERIMENT'], 10) || 0
               SimulationStore.actions.setExperimentNumber lastExperimentNumber + 1
 
       @initGameHandler ret

--- a/src/code/models/codap-connect.coffee
+++ b/src/code/models/codap-connect.coffee
@@ -252,6 +252,20 @@ module.exports = class CodapConnect
         else if node.codapID and node.codapName
           log.warn "Error: CODAP attribute rename failed!"
 
+
+
+  # updateExperimentColumn
+  #
+  # At the time of document creation in CODAP we don't always know
+  # the final language the document is going to be rendered in. For
+  # example, An author sets up a CODAP document with Sage, and some
+  # other CODAP plugins. Next, they make copies of this document for
+  # several languages. Regardless of the author's language setting,
+  # the experiment number column has the un-localized label. Later
+  # when an i18 user collects experiment data for the first time, we
+  # then rename the column from the default to that user's language.
+  # We could partially avoid this if data CODAP table attributes
+  # supported `titles` for localized names.
   updateExperimentColumn: ->
     experimentNumberLabel = tr '~CODAP.SIMULATION.EXPERIMENT'
     handleSimulationAttributes = (listAttributeResponse) =>


### PR DESCRIPTION
When SAGE is embedded in CODAP and a non-english lanuage is selected
then the experiment column (table attribute) got renamed, and broke the 
experiment increment behavior.

The fix 

1. Guard against missing values
2. Rename the CODAP EXP# attribute to the native i18n name (the first time -- if EXP# exists)
3. Create the i18n EXP# attribute if it *still* doesn't exist

Story:
Experiment increment doesn't work in translated versions of SageModeler/CODAP

[#159214059]
https://www.pivotaltracker.com/story/show/159214059