### PR TITLE
Graphs should update when Combine Variables Using menu changes.

### DIFF
--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -514,7 +514,6 @@ GraphStore  = Reflux.createStore
       linkDescription += "#{source.x},#{source.y};"
       linkDescription += link.relation.formula + ";"
       linkDescription += "#{target.x},#{target.y}|"
-
       if link.relation.isDefined
         isCappedAccumulator = source.isAccumulator and not source.allowNegativeValues
         capValue = if isCappedAccumulator then ':cap' else ''
@@ -524,7 +523,7 @@ GraphStore  = Reflux.createStore
           transfer = link.transferNode
           modelDescription += "#{transfer.key}:#{transfer.initialValue}:#{transfer.combineMethod};" if transfer
         modelDescription += "#{target.key}#{if target.isAccumulator then ':'+(target.value ? target.initialValue) else ''}|"
-
+        modelDescription += target.combineMethod
     linkDescription += nodes.length     # we need to redraw targets when new node is added
 
     return {

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -522,8 +522,8 @@ GraphStore  = Reflux.createStore
         if link.relation.type is 'transfer'
           transfer = link.transferNode
           modelDescription += "#{transfer.key}:#{transfer.initialValue}:#{transfer.combineMethod};" if transfer
-        modelDescription += "#{target.key}#{if target.isAccumulator then ':'+(target.value ? target.initialValue) else ''}|"
-        modelDescription += target.combineMethod
+        modelDescription += "#{target.key}#{if target.isAccumulator then ':'+(target.value ? target.initialValue) else ''}"
+        modelDescription += "#{if target.combineMethod? then ";#{target.combineMethod}" else ''}|"
     linkDescription += nodes.length     # we need to redraw targets when new node is added
 
     return {

--- a/test/node-list-test.coffee
+++ b/test/node-list-test.coffee
@@ -353,7 +353,7 @@ describe 'NodeList', ->
       # A -> B+ -> C -x-> D
       nodeA    = new Node({x: 10, y: 15, initialValue: 10})
       nodeB    = new Node({x: 20, y: 25, initialValue: 20, isAccumulator: true})
-      nodeC    = new Node({x: 30, y: 35, initialValue: 30})
+      nodeC    = new Node({x: 30, y: 35, initialValue: 30, combineMethod: 'average'})
       nodeD    = new Node({x: 40, y: 45, initialValue: 40})
       formula  = "1 * in"
       linkA = makeLink(nodeA, nodeB, formula)
@@ -378,4 +378,4 @@ describe 'NodeList', ->
     it "should describe the model graph correctly", ->
       graphStore = GraphStore.store
       desc = graphStore.getDescription(graphStore.getNodes(), graphStore.getLinks())
-      desc.model.should.equal "steps:10|cap:false|Node-71:10;1 * in;Node-72:20|Node-72:20:cap;1 * in;Node-73|"
+      desc.model.should.equal "steps:10|cap:false|Node-71:10;1 * in;Node-72:20|Node-72:20:cap;1 * in;Node-73;average|"


### PR DESCRIPTION
This had stopped working, because we used to save `combineMethod` as a property on flow links. Flow links are no longer a thing, so now we store this as a property on the Nodes.  We have to add `combineMethod` to the serialization hash, so that the graphView knows when it needs to re-run the simulation.

Story:
Graphs should update when Combine Variables Using menu changes.
[#154029978]
https://www.pivotaltracker.com/story/show/154029978