### PR TITLE
159348401 fix tests not running

### DIFF
--- a/test/codap-helper.coffee
+++ b/test/codap-helper.coffee
@@ -1,0 +1,17 @@
+global.window = { location: '' }
+global._      = require 'lodash'
+global.log    = require 'loglevel'
+global.Reflux = require 'reflux'
+
+Sinon          = require('sinon')
+requireModel = (name) -> require "#{__dirname}/../src/code/models/#{name}"
+CodapConnect = requireModel 'codap-connect'
+
+module.exports =
+  Stub: () ->
+    @sandbox = Sinon.sandbox.create()
+    @sandbox.stub CodapConnect, "instance", ->
+      sendUndoableActionPerformed: -> return ''
+      _createMissingDataAttributes: -> return ''
+  UnStub: () ->
+     CodapConnect.instance.restore()

--- a/test/complexity-test.coffee
+++ b/test/complexity-test.coffee
@@ -42,7 +42,7 @@ describe "The minimum complexity", ->
     @sandbox = Sinon.sandbox.create()
     @sandbox.stub CodapConnect, "instance", ->
       sendUndoableActionPerformed: -> return ''
-
+      _createMissingDataAttributes: -> return ''
     @graphStore = GraphStore
     @graphStore.init()
 
@@ -100,7 +100,7 @@ describe "The minimum simulation type", ->
     @sandbox = Sinon.sandbox.create()
     @sandbox.stub CodapConnect, "instance", ->
       sendUndoableActionPerformed: -> return ''
-
+      _createMissingDataAttributes: -> return ''
     @graphStore = GraphStore
     @graphStore.init()
 

--- a/test/loading-serialization-test.coffee
+++ b/test/loading-serialization-test.coffee
@@ -27,6 +27,7 @@ describe "Serialization and Loading", ->
     @sandbox = Sinon.sandbox.create()
     @sandbox.stub CodapConnect, "instance", ->
       sendUndoableActionPerformed: -> return ''
+      _createMissingDataAttributes: -> return ''
 
     @serializedForm = JSON.stringify SerializedTestData
     @fakePalette = [

--- a/test/loading-serialization-test.coffee
+++ b/test/loading-serialization-test.coffee
@@ -17,17 +17,14 @@ Node             = requireModel 'node'
 GraphStore       = require "#{__dirname}/../src/code/stores/graph-store"
 AppSettingsStore = require "#{__dirname}/../src/code/stores/app-settings-store"
 SimulationStore  = require "#{__dirname}/../src/code/stores/simulation-store"
-CodapConnect     = requireModel 'codap-connect'
 RelationFactory  = requireModel 'relation-factory'
+CodapHelper      = require "./codap-helper"
 
 SerializedTestData = require "./serialized-test-data/v-0.1"
 
 describe "Serialization and Loading", ->
   beforeEach ->
-    @sandbox = Sinon.sandbox.create()
-    @sandbox.stub CodapConnect, "instance", ->
-      sendUndoableActionPerformed: -> return ''
-      _createMissingDataAttributes: -> return ''
+    CodapHelper.Stub()
 
     @serializedForm = JSON.stringify SerializedTestData
     @fakePalette = [
@@ -54,7 +51,7 @@ describe "Serialization and Loading", ->
     ]
 
   afterEach ->
-    CodapConnect.instance.restore()
+    CodapHelper.UnStub()
 
 
   describe "For a model created by a user", ->

--- a/test/migrations-test.coffee
+++ b/test/migrations-test.coffee
@@ -7,7 +7,7 @@ should = require('chai').should()
 expect = chai.expect
 
 
-describe.only "Migrations",  ->
+describe "Migrations",  ->
   describe "update", ->
     beforeEach ->
       @result = Migrations.update(originalData)

--- a/test/node-list-test.coffee
+++ b/test/node-list-test.coffee
@@ -172,6 +172,7 @@ describe 'Node', ->
       sandbox.stub(CodapConnect, "instance", ->
         return {
           sendUndoableActionPerformed: -> return ''
+          _createMissingDataAttributes: -> return ''
         }
       )
 
@@ -225,6 +226,7 @@ describe "Graph Topology", ->
     sandbox.stub(CodapConnect, "instance", ->
       return {
         sendUndoableActionPerformed: -> return ''
+        _createMissingDataAttributes: -> return ''
       }
     )
 
@@ -367,6 +369,7 @@ describe "Graph Descriptions", ->
     sandbox.stub(CodapConnect, "instance", ->
       return {
         sendUndoableActionPerformed: -> return ''
+        _createMissingDataAttributes: -> return ''
       }
     )
 

--- a/test/node-list-test.coffee
+++ b/test/node-list-test.coffee
@@ -18,8 +18,8 @@ GraphPrimitive = requireModel 'graph-primitive'
 Link           = requireModel 'link'
 Node           = requireModel 'node'
 GraphStore    = require "#{__dirname}/../src/code/stores/graph-store"
-CodapConnect   = requireModel 'codap-connect'
 Relationship   = requireModel 'relationship'
+CodapHelper    = require './codap-helper'
 
 makeLink = (sourceNode, targetNode, formula) ->
   new Link
@@ -35,373 +35,347 @@ LinkNodes = (sourceNode, targetNode, formula) ->
   targetNode.addLink(link)
 
 
-describe 'GraphPrimitive', ->
-  it 'GraphPrimitive should exists', ->
-    GraphPrimitive.should.exist
-
-  describe 'the type', ->
-    undertest = new GraphPrimitive()
-    undertest.type.should.equal('GraphPrimitive')
-
-  describe 'the id', ->
-    beforeEach ->
-      GraphPrimitive.reset_counters()
-
-    describe 'of a GraphPrimitive', ->
-      it 'should increment the counter, and use the type name (GraphPrimitive)', ->
-        undertest = new GraphPrimitive()
-        undertest.id.should.equal('GraphPrimitive-1')
-
-    describe 'of a Link', ->
-      it 'should increment the counter, and use the type name (Link)', ->
-        undertest = new Link()
-        undertest.id.should.equal('Link-1')
-        secondLink = new Link()
-        secondLink.id.should.equal('Link-2')
-
-    describe 'of a Node', ->
-      it 'should increment the counter, and use the type name (Node)', ->
-        undertest = new Node()
-        undertest.id.should.equal('Node-1')
-        secondNode = new Node()
-        secondNode.id.should.equal('Node-2')
-
-describe 'Link', ->
-  describe 'terminalKey', ->
-    beforeEach ->
-      @link = new Link(
-        sourceNode: {key: 'source'},
-        sourceTerminal: 'a',
-        targetNode: {key: 'target'},
-        targetTerminal: 'b',
-        title: 'unkown link'
-      )
-    it "should have a reasonable text based terminalKey", ->
-      @link.terminalKey().should.equal("source ------> target")
-
-describe 'Node', ->
+describe 'NodeList', ->
   beforeEach ->
-    @node_a = new Node({title: "Node a"},'a')
-    @node_b = new Node({title: "Node b"},'b')
-    @node_c = new Node({title: "Node c"},'c')
+    CodapHelper.Stub()
+  afterEach ->
+    CodapHelper.UnStub()
 
-  ###
-    Note cyclic graph in A <-> B
-                   +---+
-          +-------->   |
-          |        | B |
-        +-+-+      |   |
-        |   <----------+
-        | A |      +---+
-        |   +------>   |
-        +---+      | C |
-                   |   |
-                   +---+
-  ###
-  describe 'its links', ->
+  describe 'GraphPrimitive', ->
+    it 'GraphPrimitive should exists', ->
+      GraphPrimitive.should.exist
+
+    describe 'the type', ->
+      undertest = new GraphPrimitive()
+      undertest.type.should.equal('GraphPrimitive')
+
+    describe 'the id', ->
+      beforeEach ->
+        GraphPrimitive.reset_counters()
+
+      describe 'of a GraphPrimitive', ->
+        it 'should increment the counter, and use the type name (GraphPrimitive)', ->
+          undertest = new GraphPrimitive()
+          undertest.id.should.equal('GraphPrimitive-1')
+
+      describe 'of a Link', ->
+        it 'should increment the counter, and use the type name (Link)', ->
+          undertest = new Link()
+          undertest.id.should.equal('Link-1')
+          secondLink = new Link()
+          secondLink.id.should.equal('Link-2')
+
+      describe 'of a Node', ->
+        it 'should increment the counter, and use the type name (Node)', ->
+          undertest = new Node()
+          undertest.id.should.equal('Node-1')
+          secondNode = new Node()
+          secondNode.id.should.equal('Node-2')
+
+  describe 'Link', ->
+    describe 'terminalKey', ->
+      beforeEach ->
+        @link = new Link(
+          sourceNode: {key: 'source'},
+          sourceTerminal: 'a',
+          targetNode: {key: 'target'},
+          targetTerminal: 'b',
+          title: 'unkown link'
+        )
+      it "should have a reasonable text based terminalKey", ->
+        @link.terminalKey().should.equal("source ------> target")
+
+  describe 'Node', ->
     beforeEach ->
-      @link_a = new Link
-        title: "link a"
-        sourceNode: @node_a
-        targetNode: @node_b
+      @node_a = new Node({title: "Node a"},'a')
+      @node_b = new Node({title: "Node b"},'b')
+      @node_c = new Node({title: "Node c"},'c')
 
-      @link_b = new Link
-        title: "link b"
-        sourceNode: @node_a
-        targetNode: @node_c
+    ###
+      Note cyclic graph in A <-> B
+                    +---+
+            +-------->   |
+            |        | B |
+          +-+-+      |   |
+          |   <----------+
+          | A |      +---+
+          |   +------>   |
+          +---+      | C |
+                    |   |
+                    +---+
+    ###
+    describe 'its links', ->
+      beforeEach ->
+        @link_a = new Link
+          title: "link a"
+          sourceNode: @node_a
+          targetNode: @node_b
 
-      @link_c = new Link
-        title: "link c"
-        sourceNode: @node_b
-        targetNode: @node_a
+        @link_b = new Link
+          title: "link b"
+          sourceNode: @node_a
+          targetNode: @node_c
 
-      @link_without_a = new Link
-        title: "link without a"
-        sourceNode: @node_b
-        targetNode: @node_c
+        @link_c = new Link
+          title: "link c"
+          sourceNode: @node_b
+          targetNode: @node_a
+
+        @link_without_a = new Link
+          title: "link without a"
+          sourceNode: @node_b
+          targetNode: @node_c
 
 
-    describe 'rejecting bad links', ->
-      describe 'links that dont include itself', ->
-        it "it shouldn't add a link it doesn't belong to",  ->
-          fn =  =>
-            @node_a.addLink(@link_without_a)
-          fn.should.throw("Bad link")
+      describe 'rejecting bad links', ->
+        describe 'links that dont include itself', ->
+          it "it shouldn't add a link it doesn't belong to",  ->
+            fn =  =>
+              @node_a.addLink(@link_without_a)
+            fn.should.throw("Bad link")
 
-      describe 'links that it already has', ->
-        beforeEach ->
-          @node_a.addLink(@link_a)
-        it 'should throw an error when re-linking',  ->
-          fn =  =>
+        describe 'links that it already has', ->
+          beforeEach ->
             @node_a.addLink(@link_a)
-          fn.should.throw("Duplicate link")
+          it 'should throw an error when re-linking',  ->
+            fn =  =>
+              @node_a.addLink(@link_a)
+            fn.should.throw("Duplicate link")
 
-    describe 'sorting links', ->
-      describe "a node with two out links, and one in link", ->
-        beforeEach ->
-          @node_a.addLink(@link_a)
-          @node_a.addLink(@link_b)
-          @node_a.addLink(@link_c)
+      describe 'sorting links', ->
+        describe "a node with two out links, and one in link", ->
+          beforeEach ->
+            @node_a.addLink(@link_a)
+            @node_a.addLink(@link_b)
+            @node_a.addLink(@link_c)
 
-        describe 'In Links', ->
-          it "should have 1 in link", ->
-            @node_a.inLinks().should.have.length(1)
+          describe 'In Links', ->
+            it "should have 1 in link", ->
+              @node_a.inLinks().should.have.length(1)
 
-        describe 'outLinks', ->
-          it "should have 2 outlinks", ->
-            @node_a.outLinks().should.have.length(2)
+          describe 'outLinks', ->
+            it "should have 2 outlinks", ->
+              @node_a.outLinks().should.have.length(2)
 
-        describe 'inNodes', ->
-          it "should have 1 inNode", ->
-            @node_a.inNodes().should.have.length(1)
-          it "should include node_c", ->
-            @node_a.inNodes().should.include(@node_b)
+          describe 'inNodes', ->
+            it "should have 1 inNode", ->
+              @node_a.inNodes().should.have.length(1)
+            it "should include node_c", ->
+              @node_a.inNodes().should.include(@node_b)
 
-        describe 'downstreamNodes', ->
-          it "should have some nodes", ->
-            @node_a.downstreamNodes().should.have.length(2)
+          describe 'downstreamNodes', ->
+            it "should have some nodes", ->
+              @node_a.downstreamNodes().should.have.length(2)
 
-        describe '#infoString', ->
-          it "should print a list of nodes its connected to", ->
-            expected = "Node a  --link a-->[Node b], --link b-->[Node c]"
-            @node_a.infoString().should.equal(expected)
+          describe '#infoString', ->
+            it "should print a list of nodes its connected to", ->
+              expected = "Node a  --link a-->[Node b], --link b-->[Node c]"
+              @node_a.infoString().should.equal(expected)
 
-  describe "GraphStore", ->
+    describe "GraphStore", ->
+      beforeEach ->
+
+        @nodeA = new Node({title: "a", x:10, y:10}, 'a')
+        @nodeB = new Node({title: "b", x:20, y:20}, 'b')
+        @graphStore = GraphStore.store
+        @graphStore.init()
+        @graphStore.addNode @nodeA
+        @graphStore.addNode @nodeB
+
+        @newLink = new Link({
+          sourceNode: @nodeA
+          targetNode: @nodeB
+          targetTerminal: "a"
+          sourceTerminal: "b"
+        })
+        @newLink.terminalKey = ->
+          "newLink"
+
+        @otherNewLink = new Link({
+          sourceNode: @nodeB
+          targetNode: @nodeA
+        })
+        @otherNewLink.terminalKey = ->
+          "otherNewLink"
+
+      describe "addLink", ->
+        describe "When the link doesn't already exist", ->
+          it "should add a new link", ->
+            should.not.exist @graphStore.linkKeys['newLink']
+            @graphStore.addLink(@newLink)
+            @graphStore.linkKeys['newLink'].should.equal(@newLink)
+            should.not.exist @graphStore.linkKeys['otherNewLink']
+            @graphStore.addLink(@otherNewLink)
+            @graphStore.linkKeys['otherNewLink'].should.equal(@otherNewLink)
+
+        describe "When the link does already exist", ->
+          beforeEach ->
+            @graphStore.linkKeys['newLink'] = 'oldValue'
+          it "should not add the new link", ->
+            @graphStore.addLink(@newLink)
+            @graphStore.linkKeys['newLink'].should.equal('oldValue')
+
+  describe "Graph Topology", ->
+
+    # A ->  B  -> D
+    # └< C <┘
+    describe "a graph with a totally independent cycle", ->
+      beforeEach ->
+        @nodeA    = new Node()
+        @nodeB    = new Node()
+        @nodeC    = new Node()
+        @nodeD    = new Node()
+        @formula  = "1 * in"
+
+        LinkNodes(@nodeA, @nodeB, @formula)
+        LinkNodes(@nodeB, @nodeC, @formula)
+        LinkNodes(@nodeC, @nodeA, @formula)
+        LinkNodes(@nodeB, @nodeD, @formula)
+
+        graphStore = GraphStore.store
+        graphStore.init()
+        graphStore.addNode @nodeA
+        graphStore.addNode @nodeB
+        graphStore.addNode @nodeC
+        graphStore.addNode @nodeD
+
+      it "should mark the nodes that can have initial values edited", ->
+        @nodeA.canEditInitialValue().should.equal true
+        @nodeB.canEditInitialValue().should.equal true
+        @nodeC.canEditInitialValue().should.equal true
+        @nodeD.canEditInitialValue().should.equal false
+
+      it "should mark the nodes that can have values edited while running", ->
+        @nodeA.canEditValueWhileRunning().should.equal false
+        @nodeB.canEditValueWhileRunning().should.equal false
+        @nodeC.canEditValueWhileRunning().should.equal false
+        @nodeD.canEditValueWhileRunning().should.equal false
+
+
+    # A -> B  -> C -> E
+    #      └< D <┘
+    describe "a graph with cycles with independent inputs", ->
+      beforeEach ->
+        @nodeA    = new Node()
+        @nodeB    = new Node()
+        @nodeC    = new Node()
+        @nodeD    = new Node()
+        @nodeE    = new Node()
+        @formula  = "1 * in"
+
+        LinkNodes(@nodeA, @nodeB, @formula)
+        LinkNodes(@nodeB, @nodeC, @formula)
+        LinkNodes(@nodeC, @nodeD, @formula)
+        LinkNodes(@nodeD, @nodeB, @formula)
+        LinkNodes(@nodeC, @nodeE, @formula)
+
+        graphStore = GraphStore.store
+        graphStore.init()
+        graphStore.addNode @nodeA
+        graphStore.addNode @nodeB
+        graphStore.addNode @nodeC
+        graphStore.addNode @nodeD
+        graphStore.addNode @nodeE
+
+      it "should mark the nodes that can have initial values edited", ->
+        @nodeA.canEditInitialValue().should.equal true
+        @nodeB.canEditInitialValue().should.equal false
+        @nodeC.canEditInitialValue().should.equal false
+        @nodeD.canEditInitialValue().should.equal false
+        @nodeE.canEditInitialValue().should.equal false
+
+      it "should mark the nodes that can have values edited while running", ->
+        @nodeA.canEditValueWhileRunning().should.equal true
+        @nodeB.canEditValueWhileRunning().should.equal false
+        @nodeC.canEditValueWhileRunning().should.equal false
+        @nodeD.canEditValueWhileRunning().should.equal false
+        @nodeE.canEditValueWhileRunning().should.equal false
+
+
+    # A -> B+ -> C
+    describe "a graph with collectors", ->
+      beforeEach ->
+        @nodeA    = new Node()
+        @nodeB    = new Node({isAccumulator: true})
+        @nodeC    = new Node()
+        @formula  = "1 * in"
+
+        LinkNodes(@nodeA, @nodeB, @formula)
+        LinkNodes(@nodeB, @nodeC, @formula)
+
+        graphStore = GraphStore.store
+        graphStore.init()
+        graphStore.addNode @nodeA
+        graphStore.addNode @nodeB
+        graphStore.addNode @nodeC
+
+      it "should mark the nodes that can have initial values edited", ->
+        @nodeA.canEditInitialValue().should.equal true
+        @nodeB.canEditInitialValue().should.equal true
+        @nodeC.canEditInitialValue().should.equal false
+
+      it "should mark the nodes that can have values edited while running", ->
+        @nodeA.canEditValueWhileRunning().should.equal true
+        @nodeB.canEditValueWhileRunning().should.equal false
+        @nodeC.canEditValueWhileRunning().should.equal false
+
+    # A -x-> B -> C
+    describe "a graph with undefined relations", ->
+      beforeEach ->
+        @nodeA    = new Node()
+        @nodeB    = new Node({isAccumulator: true})
+        @nodeC    = new Node()
+        @formula  = "1 * in"
+
+        LinkNodes(@nodeA, @nodeB)
+        LinkNodes(@nodeB, @nodeC, @formula)
+
+        graphStore = GraphStore.store
+        graphStore.init()
+        graphStore.addNode @nodeA
+        graphStore.addNode @nodeB
+        graphStore.addNode @nodeC
+
+      it "should mark the nodes that can have initial values edited", ->
+        @nodeA.canEditInitialValue().should.equal true
+        @nodeB.canEditInitialValue().should.equal true
+        @nodeC.canEditInitialValue().should.equal false
+
+      it "should mark the nodes that can have values edited while running", ->
+        @nodeA.canEditValueWhileRunning().should.equal true
+        @nodeB.canEditValueWhileRunning().should.equal true
+        @nodeC.canEditValueWhileRunning().should.equal false
+
+  describe "Graph Descriptions", ->
+
     beforeEach ->
-      sandbox = Sinon.sandbox.create()
-      sandbox.stub(CodapConnect, "instance", ->
-        return {
-          sendUndoableActionPerformed: -> return ''
-          _createMissingDataAttributes: -> return ''
-        }
-      )
 
-      @nodeA = new Node({title: "a", x:10, y:10}, 'a')
-      @nodeB = new Node({title: "b", x:20, y:20}, 'b')
-      @graphStore = GraphStore.store
-      @graphStore.init()
-      @graphStore.addNode @nodeA
-      @graphStore.addNode @nodeB
-
-      @newLink = new Link({
-        sourceNode: @nodeA
-        targetNode: @nodeB
-        targetTerminal: "a"
-        sourceTerminal: "b"
-      })
-      @newLink.terminalKey = ->
-        "newLink"
-
-      @otherNewLink = new Link({
-        sourceNode: @nodeB
-        targetNode: @nodeA
-      })
-      @otherNewLink.terminalKey = ->
-        "otherNewLink"
-
-    afterEach ->
-      CodapConnect.instance.restore()
-
-    describe "addLink", ->
-      describe "When the link doesn't already exist", ->
-        it "should add a new link", ->
-          should.not.exist @graphStore.linkKeys['newLink']
-          @graphStore.addLink(@newLink)
-          @graphStore.linkKeys['newLink'].should.equal(@newLink)
-          should.not.exist @graphStore.linkKeys['otherNewLink']
-          @graphStore.addLink(@otherNewLink)
-          @graphStore.linkKeys['otherNewLink'].should.equal(@otherNewLink)
-
-      describe "When the link does already exist", ->
-        beforeEach ->
-          @graphStore.linkKeys['newLink'] = 'oldValue'
-        it "should not add the new link", ->
-          @graphStore.addLink(@newLink)
-          @graphStore.linkKeys['newLink'].should.equal('oldValue')
-
-describe "Graph Topology", ->
-
-  beforeEach ->
-    sandbox = Sinon.sandbox.create()
-    sandbox.stub(CodapConnect, "instance", ->
-      return {
-        sendUndoableActionPerformed: -> return ''
-        _createMissingDataAttributes: -> return ''
-      }
-    )
-
-  afterEach ->
-    CodapConnect.instance.restore()
-
-  # A ->  B  -> D
-  # └< C <┘
-  describe "a graph with a totally independent cycle", ->
-    beforeEach ->
-      @nodeA    = new Node()
-      @nodeB    = new Node()
-      @nodeC    = new Node()
-      @nodeD    = new Node()
-      @formula  = "1 * in"
-
-      LinkNodes(@nodeA, @nodeB, @formula)
-      LinkNodes(@nodeB, @nodeC, @formula)
-      LinkNodes(@nodeC, @nodeA, @formula)
-      LinkNodes(@nodeB, @nodeD, @formula)
-
+      # A -> B+ -> C -x-> D
+      nodeA    = new Node({x: 10, y: 15, initialValue: 10})
+      nodeB    = new Node({x: 20, y: 25, initialValue: 20, isAccumulator: true})
+      nodeC    = new Node({x: 30, y: 35, initialValue: 30})
+      nodeD    = new Node({x: 40, y: 45, initialValue: 40})
+      formula  = "1 * in"
+      linkA = makeLink(nodeA, nodeB, formula)
+      linkB = makeLink(nodeB, nodeC, formula)
+      linkC = makeLink(nodeC, nodeD)
       graphStore = GraphStore.store
       graphStore.init()
-      graphStore.addNode @nodeA
-      graphStore.addNode @nodeB
-      graphStore.addNode @nodeC
-      graphStore.addNode @nodeD
-
-    it "should mark the nodes that can have initial values edited", ->
-      @nodeA.canEditInitialValue().should.equal true
-      @nodeB.canEditInitialValue().should.equal true
-      @nodeC.canEditInitialValue().should.equal true
-      @nodeD.canEditInitialValue().should.equal false
-
-    it "should mark the nodes that can have values edited while running", ->
-      @nodeA.canEditValueWhileRunning().should.equal false
-      @nodeB.canEditValueWhileRunning().should.equal false
-      @nodeC.canEditValueWhileRunning().should.equal false
-      @nodeD.canEditValueWhileRunning().should.equal false
+      graphStore.addNode nodeA
+      graphStore.addNode nodeB
+      graphStore.addNode nodeC
+      graphStore.addNode nodeD
+      graphStore.addLink linkA
+      graphStore.addLink linkB
+      graphStore.addLink linkC
 
 
-  # A -> B  -> C -> E
-  #      └< D <┘
-  describe "a graph with cycles with independent inputs", ->
-    beforeEach ->
-      @nodeA    = new Node()
-      @nodeB    = new Node()
-      @nodeC    = new Node()
-      @nodeD    = new Node()
-      @nodeE    = new Node()
-      @formula  = "1 * in"
-
-      LinkNodes(@nodeA, @nodeB, @formula)
-      LinkNodes(@nodeB, @nodeC, @formula)
-      LinkNodes(@nodeC, @nodeD, @formula)
-      LinkNodes(@nodeD, @nodeB, @formula)
-      LinkNodes(@nodeC, @nodeE, @formula)
-
+    it "should describe the visual links correctly", ->
       graphStore = GraphStore.store
-      graphStore.init()
-      graphStore.addNode @nodeA
-      graphStore.addNode @nodeB
-      graphStore.addNode @nodeC
-      graphStore.addNode @nodeD
-      graphStore.addNode @nodeE
+      desc = graphStore.getDescription(graphStore.getNodes(), graphStore.getLinks())
+      desc.links.should.equal "10,15;1 * in;20,25|20,25;1 * in;30,35|30,35;undefined;40,45|4"
 
-    it "should mark the nodes that can have initial values edited", ->
-      @nodeA.canEditInitialValue().should.equal true
-      @nodeB.canEditInitialValue().should.equal false
-      @nodeC.canEditInitialValue().should.equal false
-      @nodeD.canEditInitialValue().should.equal false
-      @nodeE.canEditInitialValue().should.equal false
-
-    it "should mark the nodes that can have values edited while running", ->
-      @nodeA.canEditValueWhileRunning().should.equal true
-      @nodeB.canEditValueWhileRunning().should.equal false
-      @nodeC.canEditValueWhileRunning().should.equal false
-      @nodeD.canEditValueWhileRunning().should.equal false
-      @nodeE.canEditValueWhileRunning().should.equal false
-
-
-  # A -> B+ -> C
-  describe "a graph with collectors", ->
-    beforeEach ->
-      @nodeA    = new Node()
-      @nodeB    = new Node({isAccumulator: true})
-      @nodeC    = new Node()
-      @formula  = "1 * in"
-
-      LinkNodes(@nodeA, @nodeB, @formula)
-      LinkNodes(@nodeB, @nodeC, @formula)
-
+    it "should describe the model graph correctly", ->
       graphStore = GraphStore.store
-      graphStore.init()
-      graphStore.addNode @nodeA
-      graphStore.addNode @nodeB
-      graphStore.addNode @nodeC
-
-    it "should mark the nodes that can have initial values edited", ->
-      @nodeA.canEditInitialValue().should.equal true
-      @nodeB.canEditInitialValue().should.equal true
-      @nodeC.canEditInitialValue().should.equal false
-
-    it "should mark the nodes that can have values edited while running", ->
-      @nodeA.canEditValueWhileRunning().should.equal true
-      @nodeB.canEditValueWhileRunning().should.equal false
-      @nodeC.canEditValueWhileRunning().should.equal false
-
-  # A -x-> B -> C
-  describe "a graph with undefined relations", ->
-    beforeEach ->
-      @nodeA    = new Node()
-      @nodeB    = new Node({isAccumulator: true})
-      @nodeC    = new Node()
-      @formula  = "1 * in"
-
-      LinkNodes(@nodeA, @nodeB)
-      LinkNodes(@nodeB, @nodeC, @formula)
-
-      graphStore = GraphStore.store
-      graphStore.init()
-      graphStore.addNode @nodeA
-      graphStore.addNode @nodeB
-      graphStore.addNode @nodeC
-
-    it "should mark the nodes that can have initial values edited", ->
-      @nodeA.canEditInitialValue().should.equal true
-      @nodeB.canEditInitialValue().should.equal true
-      @nodeC.canEditInitialValue().should.equal false
-
-    it "should mark the nodes that can have values edited while running", ->
-      @nodeA.canEditValueWhileRunning().should.equal true
-      @nodeB.canEditValueWhileRunning().should.equal true
-      @nodeC.canEditValueWhileRunning().should.equal false
-
-describe "Graph Descriptions", ->
-
-  beforeEach ->
-    sandbox = Sinon.sandbox.create()
-    sandbox.stub(CodapConnect, "instance", ->
-      return {
-        sendUndoableActionPerformed: -> return ''
-        _createMissingDataAttributes: -> return ''
-      }
-    )
-
-    # A -> B+ -> C -x-> D
-    nodeA    = new Node({x: 10, y: 15, initialValue: 10})
-    nodeB    = new Node({x: 20, y: 25, initialValue: 20, isAccumulator: true})
-    nodeC    = new Node({x: 30, y: 35, initialValue: 30})
-    nodeD    = new Node({x: 40, y: 45, initialValue: 40})
-    formula  = "1 * in"
-    linkA = makeLink(nodeA, nodeB, formula)
-    linkB = makeLink(nodeB, nodeC, formula)
-    linkC = makeLink(nodeC, nodeD)
-    graphStore = GraphStore.store
-    graphStore.init()
-    graphStore.addNode nodeA
-    graphStore.addNode nodeB
-    graphStore.addNode nodeC
-    graphStore.addNode nodeD
-    graphStore.addLink linkA
-    graphStore.addLink linkB
-    graphStore.addLink linkC
-
-  afterEach ->
-    CodapConnect.instance.restore()
-
-
-  it "should describe the visual links correctly", ->
-    graphStore = GraphStore.store
-    desc = graphStore.getDescription(graphStore.getNodes(), graphStore.getLinks())
-    desc.links.should.equal "10,15;1 * in;20,25|20,25;1 * in;30,35|30,35;undefined;40,45|4"
-
-  it "should describe the model graph correctly", ->
-    graphStore = GraphStore.store
-    desc = graphStore.getDescription(graphStore.getNodes(), graphStore.getLinks())
-    desc.model.should.equal "steps:10|cap:false|Node-71:10;1 * in;Node-72:20|Node-72:20:cap;1 * in;Node-73|"
+      desc = graphStore.getDescription(graphStore.getNodes(), graphStore.getLinks())
+      desc.model.should.equal "steps:10|cap:false|Node-71:10;1 * in;Node-72:20|Node-72:20:cap;1 * in;Node-73|"

--- a/test/node-test.coffee
+++ b/test/node-test.coffee
@@ -10,24 +10,17 @@ Sinon          = require('sinon')
 requireModel = (name) -> require "#{__dirname}/../src/code/models/#{name}"
 
 Node           = requireModel 'node'
-GraphStore    = require "#{__dirname}/../src/code/stores/graph-store"
-CodapConnect   = requireModel 'codap-connect'
+GraphStore     = require "#{__dirname}/../src/code/stores/graph-store"
+CodapHelper    = require './codap-helper'
 
 describe "A Node", ->
   beforeEach ->
-    sandbox = Sinon.sandbox.create()
-    sandbox.stub(CodapConnect, "instance", ->
-      return {
-        sendUndoableActionPerformed: -> return ''
-        _createMissingDataAttributes: -> return ''
-      }
-    )
+    CodapHelper.Stub()
     @graphStore = GraphStore.store
     @graphStore.init()
 
   afterEach ->
-    CodapConnect.instance.restore()
-
+    CodapHelper.UnStub()
 
   it "can be added with properties", ->
     newNode = new Node({title: "a", x:10, y:15}, 'a')

--- a/test/node-test.coffee
+++ b/test/node-test.coffee
@@ -19,6 +19,7 @@ describe "A Node", ->
     sandbox.stub(CodapConnect, "instance", ->
       return {
         sendUndoableActionPerformed: -> return ''
+        _createMissingDataAttributes: -> return ''
       }
     )
     @graphStore = GraphStore.store

--- a/test/simulation-test.coffee
+++ b/test/simulation-test.coffee
@@ -31,7 +31,7 @@ GraphStore        = requireStore('graph-store').store
 SimulationStore   = requireStore('simulation-store').store
 SimulationActions = requireStore('simulation-store').actions
 
-CodapConnect   = requireModel 'codap-connect'
+CodapHelper = require './codap-helper'
 
 
 LinkNodes = (sourceNode, targetNode, relationSpec) ->
@@ -360,13 +360,7 @@ describe "Simulation", ->
 
 describe "The SimulationStore, with a network in the GraphStore", ->
   beforeEach ->
-    @sandbox = Sinon.sandbox.create()
-    @sandbox.stub(CodapConnect, "instance", ->
-      return {
-        sendUndoableActionPerformed: -> return ''
-        _createMissingDataAttributes: -> return ''
-      }
-    )
+    CodapHelper.Stub()
 
     @nodeA    = new Node({title: "A", initialValue: 10})
     @nodeB    = new Node({title: "B", initialValue: 0 })
@@ -380,7 +374,7 @@ describe "The SimulationStore, with a network in the GraphStore", ->
     LinkNodes(@nodeA, @nodeB, { type: 'range', formula: @formula })
 
   afterEach ->
-    CodapConnect.instance.restore()
+    CodapHelper.UnStub()
 
   describe "for a fast simulation for 10 iterations", ->
 

--- a/test/simulation-test.coffee
+++ b/test/simulation-test.coffee
@@ -397,11 +397,11 @@ describe "The SimulationStore, with a network in the GraphStore", ->
           data.length.should.equal 10
 
           frame0 = data[0]
-          frame0.time.should.equal 1
+          frame0.time.should.equal 11
           frame0.nodes.should.eql [ { title: 'A', value: 10 }, { title: 'B', value: 1 } ]
 
           frame9 = data[9]
-          frame9.time.should.equal 10
+          frame9.time.should.equal 20
           frame9.nodes.should.eql [ { title: 'A', value: 10 }, { title: 'B', value: 1 } ]
 
       SimulationActions.createExperiment()

--- a/test/simulation-test.coffee
+++ b/test/simulation-test.coffee
@@ -364,6 +364,7 @@ describe "The SimulationStore, with a network in the GraphStore", ->
     @sandbox.stub(CodapConnect, "instance", ->
       return {
         sendUndoableActionPerformed: -> return ''
+        _createMissingDataAttributes: -> return ''
       }
     )
 


### PR DESCRIPTION
The mocha tests for building models weren't  running for about 4 months, because of a `describe.only` stanza that was accidentally left in place …

So this PR fixes that, and also cleans up some CodapConnect stubbing that was happening.

The changes are not actually as extensive as they look, but because of the how git-diffing worked in this instance, it seems like there are a lot of changes.

The main thing is that lots of ` @sandbox.stub CodapConnect, "instance", ->`  were replaced with a helper method `CodapHelper.Stub()`  (and `CodapHelper.UnStub()` ).   

This helper was extracted because as we start expecting more messages to be sent to CodapConnect, 
 (such as `_createMissingDataAttributes` it would be nice to only add them once.

@kswenson I have been bugging @dstrawberrygirl for many PR reviews.   If you wanted to peek at this, It might save her eyeballs. 👀 

Thanks!