### PR TITLE
Tests: to verify upstream fix for `combineMethod` not being serialized.

### DIFF
--- a/test/loading-serialization-test.coffee
+++ b/test/loading-serialization-test.coffee
@@ -205,6 +205,7 @@ describe "Serialization and Loading", ->
       @graphStore.nodeKeys['a'].image.should.equal "img/nodes/chicken.png"
       @graphStore.nodeKeys['b'].image.should.equal "img/nodes/egg.png"
 
+
     it "should load the nodes previous frames", ->
       data = JSON.parse(@serializedForm)
       data.nodes[1].frames = [50]
@@ -212,3 +213,24 @@ describe "Serialization and Loading", ->
       @graphStore.nodeKeys['a'].frames.length.should.equal 0
       @graphStore.nodeKeys['b'].frames.length.should.equal 1
       @graphStore.nodeKeys['b'].frames[0].should.equal 50
+
+    it "Should load saved `combineMethod` for nodes if present", ->
+      sampleNodes = '{
+        "filename": "sample model",
+        "nodes": [
+          {
+            "key": "a",
+            "combineMethod": "average"
+          },{
+            "key": "b",
+            "combineMethod": "product"
+          },{
+            "key": "c"
+          }
+        ]
+      }'
+      data = JSON.parse(sampleNodes)
+      @graphStore.loadData(data)
+      @graphStore.nodeKeys['a'].combineMethod.should.equal "average"
+      @graphStore.nodeKeys['b'].combineMethod.should.equal "product"
+      should.not.exist(@graphStore.nodeKeys['c'].combineMethod)


### PR DESCRIPTION
I started working on [this bug](https://www.pivotaltracker.com/story/show/154706564) -- but could not reproduce it.  

The bug states that node `combineMethod` ("Combine Variables Using" in the link inspector) wasn't being saved correctly.  

I smoked tested it, and verified that the value was being stored for both flows, and non-flow connections. (The story seemed to indicate that this might be an issue with flow / transfer links only).

I assume that this bug was fixed in prior work.

This commit is for two tests that verify that the node `combineMethod` of nodes is being stored correctly, and confirms that the value is serialized.

Story:
"Setting for combining variables is not being saved or restored properly."

[#154706564]
https://www.pivotaltracker.com/story/show/154706564