### PR TITLE
Fixed nextID generation after file is loaded [#160661756]

### DIFF
--- a/src/code/models/graph-primitive.coffee
+++ b/src/code/models/graph-primitive.coffee
@@ -3,8 +3,26 @@
 # They share a common ID generation mechanism mostly.
 module.exports = class GraphPrimitive
   @counters: {}
-  @reset_counters: ->
+
+  @resetCounters: ->
     GraphPrimitive.counters = {}
+
+  @initCounters: (options) ->
+    {links, nodes} = options
+    # transfer nodes are in the node list so first pull them out
+    transferNodes = _.filter(nodes, (node) -> /^Transfer-/.test(node.id))
+    diagramNodes = _.filter(nodes, (node) -> /^Node-/.test(node.id))
+    GraphPrimitive.counters =
+      Link: GraphPrimitive.findMaxID(links) + 1,
+      Transfer: GraphPrimitive.findMaxID(transferNodes) + 1
+      Node: GraphPrimitive.findMaxID(diagramNodes) + 1
+
+  @findMaxID: (list) ->
+    maxID = 0
+    for item in list
+      id = item.id.split("-").pop()
+      maxID = Math.max(maxID, parseInt(id, 10))
+    maxID
 
   @nextID: (type) ->
     if not GraphPrimitive.counters[type]

--- a/src/code/stores/graph-store.coffee
+++ b/src/code/stores/graph-store.coffee
@@ -15,6 +15,7 @@ CodapActions        = require '../actions/codap-actions'
 InspectorPanelStore = require "../stores/inspector-panel-store"
 CodapConnect        = require '../models/codap-connect'
 RelationFactory     = require "../models/relation-factory"
+GraphPrimitive      = require '../models/graph-primitive'
 DEFAULT_CONTEXT_NAME = 'building-models'
 
 GraphStore  = Reflux.createStore
@@ -469,6 +470,7 @@ GraphStore  = Reflux.createStore
   deleteAll: ->
     for node of @nodeKeys
       @removeNode node
+    GraphPrimitive.resetCounters()
     @setFilename 'New Model'
     @undoRedoManager.clearHistory()
 

--- a/src/code/utils/importer.coffee
+++ b/src/code/utils/importer.coffee
@@ -2,6 +2,7 @@ Migrations          = require '../data/migrations/migrations'
 DiagramNode         = require '../models/node'
 TransferNode        = require '../models/transfer'
 ImportActions       = require '../actions/import-actions'
+GraphPrimitive      = require '../models/graph-primitive'
 
 module.exports = class MySystemImporter
 
@@ -14,6 +15,8 @@ module.exports = class MySystemImporter
     ImportActions.import.trigger(data)
     @importNodes data.nodes
     @importLinks data.links
+    # set the nextID counters
+    GraphPrimitive.initCounters({nodes: @graphStore.getNodes(), links: @graphStore.getLinks()})
     @graphStore.setFilename data.filename or 'New Model'
 
   importNode: (nodeSpec) ->
@@ -29,10 +32,14 @@ module.exports = class MySystemImporter
   importNodes: (importNodes) ->
     for nodespec in importNodes
       node = @importNode(nodespec)
+      # ensure id matches key for imported documents
+      node.id = node.key
       @graphStore.addNode node
     return  # prevent unused default return value
 
   importLinks: (links) ->
     for link in links
       @graphStore.importLink link
+      # ensure id matches key for imported documents
+      link.id = link.key
     return  # prevent unused default return value

--- a/test/node-list-test.coffee
+++ b/test/node-list-test.coffee
@@ -51,7 +51,7 @@ describe 'NodeList', ->
 
     describe 'the id', ->
       beforeEach ->
-        GraphPrimitive.reset_counters()
+        GraphPrimitive.resetCounters()
 
       describe 'of a GraphPrimitive', ->
         it 'should increment the counter, and use the type name (GraphPrimitive)', ->


### PR DESCRIPTION
Fixes a bug where new nodes sometimes could not be dropped because the node id already existed in the loaded file.

This change sets the counters used in the nextID generation to be the max  + 1 of each node type.