### PR TITLE
Fixed valve icon not coming up [#161824729] and transfer Relationships are lost on restore [#161828639]

### DIFF
--- a/src/code/models/node.ts
+++ b/src/code/models/node.ts
@@ -40,6 +40,8 @@ export class Node extends GraphPrimitive {
     Node.SEMIQUANT_ACCUMULATOR_MAX = SEMIQUANT_ACCUMULATOR_MAX;
   }
 
+  public type: string = "Node";
+
   protected links: any; // TODO: get concrete type
   protected x: any; // TODO: get concrete type
   protected y: any; // TODO: get concrete type
@@ -63,10 +65,11 @@ export class Node extends GraphPrimitive {
   protected isTransfer: any; // TODO: get concrete type
   protected _isAccumulator: any; // TODO: get concrete type
 
-  constructor(nodeSpec, key?) {
+  constructor(nodeSpec, key?, isTransfer?) {
+    super(isTransfer ? "Transfer" : "Node");
+
     let val, val1, val10, val2, val3, val4, val5, val6, val7, val8, val9;
     if (nodeSpec == null) { nodeSpec = {}; }
-    super("Node");
     if (key) {
       this.key = key;
     }

--- a/src/code/models/transfer.ts
+++ b/src/code/models/transfer.ts
@@ -12,6 +12,9 @@ const DEFAULT_COMBINE_METHOD = "product";
 
 export class TransferModel extends Node {
   public type = "Transfer";
+  public isTransfer = true;
+  public combineMethod = DEFAULT_COMBINE_METHOD;
+
   protected transferLink: any; // TODO: get concrete type
 
   public setTransferLink(link) {

--- a/src/code/models/transfer.ts
+++ b/src/code/models/transfer.ts
@@ -17,6 +17,10 @@ export class TransferModel extends Node {
 
   protected transferLink: any; // TODO: get concrete type
 
+  constructor(options, key?) {
+    super(options, key, true);
+  }
+
   public setTransferLink(link) {
     this.transferLink = link;
     return this.title = this.computeTitle();


### PR DESCRIPTION
Missed setting the `isTransfer` and `combineMethod` variables in decaf conversion.

CoffeeScript code was: 

```
Node = require './node'
tr = require "../utils/translate"

DEFAULT_COMBINE_METHOD='product'

module.exports = class Transfer extends Node

  type: 'Transfer'
  isTransfer: true
  combineMethod: DEFAULT_COMBINE_METHOD

  setTransferLink: (link) ->
    @transferLink = link
    @title = @computeTitle()

  computeTitle: ->
    if @transferLink
      tr '~TRANSFER_NODE.TITLE', { sourceTitle: @transferLink.sourceNode.title, \
                                    targetTitle: @transferLink.targetNode.title }
    else
      undefined
```