### PR TITLE
Fix image upload, fix and refactor Mixin implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:webpack": "webpack --mode production --devtool false",
     "build:webpack:watch": "webpack --watch --mode production --devtool false",
     "clean": "rimraf dist",
-    "lint": "tslint -c tslint.json 'src/code/**/*.{ts,tsx}",
+    "lint": "tslint -c tslint.json 'src/code/**/*.{ts,tsx}'",
     "lint:fix": "tslint -c tslint.json --fix 'src/code/**/*.{ts,tsx}",
     "strings:build": "./node_modules/.bin/strip-json-comments src/code/utils/lang/en-US-master.json > src/code/utils/lang/en-US.json",
     "strings:pull:usage": "echo Usage: `npm run strings:pull -- -a <poeditor_api_key>`",

--- a/src/code/mixins/components.ts
+++ b/src/code/mixins/components.ts
@@ -1,23 +1,36 @@
 import * as React from "react";
 import * as _ from "lodash";
 
-export class Mixin<P, S> extends React.Component<P, S> {
+interface IMixin<P, S> extends React.ComponentLifecycle<P, S> {
+  props: P;
+  state: S;
+  setState: (newState: S, callback?: () => any) => void;
+}
+
+export class Mixin<P, S> implements IMixin<P, S> {
   public static InitialState: () => any;
 
   protected mixer: any;
 
-  constructor(mixer: any, props: P) {
-    super(props);
+  constructor(mixer: any) {
     this.mixer = mixer;
   }
 
-  public setState(state: S) {
-    this.mixer.setState(state);
+  public get props() {
+    return this.mixer.props;
+  }
+
+  public get state() {
+    return this.mixer.state;
+  }
+
+  public setState(state: S, callback?: () => any) {
+    this.mixer.setState(state, callback);
   }
 }
 
 export class Mixer<P, S> extends React.Component<P, S> {
-  protected mixins: Array<React.Component<any, any>>;
+  protected mixins: Array<IMixin<any, any>>;
 
   public setInitialState(s: any, ...rest) {
     this.state = _.extend(s, ...rest);

--- a/src/code/mixins/draggable.ts
+++ b/src/code/mixins/draggable.ts
@@ -16,7 +16,7 @@ export class DraggableMixin extends Mixin<DraggableMixinProps, DraggableMixinSta
   private removeClasses: string[];
 
   constructor(mixer: any, props = {}, options: DraggableMixinOptions = {}) {
-    super(mixer, props);
+    super(mixer);
     this.doMove = options.doMove || (() => undefined);
     this.removeClasses = options.removeClasses || ["proto-node"];
   }

--- a/src/code/mixins/image-dialog-view.tsx
+++ b/src/code/mixins/image-dialog-view.tsx
@@ -23,16 +23,18 @@ export class ImageDialogViewMixin extends Mixin<ImageDialogViewMixinProps, Image
     return ImageDialogActions.update(imageInfo);
   }
 
-  public imageDropped(imageInfo) {
-    return this.imageSelected(imageInfo);
-  }
-
   public hasValidImageExtension(imageName) {
     return hasValidImageExtension(imageName);
   }
 
   public renderPreviewImage() {
     return <PreviewImageDialogView imageInfo={this.props.selectedImage} />;
+  }
+
+  // Event handler, usually used together with drop zone view.
+  // That's why it's necessary to ensure that it's bound to correct `this` object.
+  public handleImageDrop = (imageInfo) => {
+    return this.imageSelected(imageInfo);
   }
 }
 

--- a/src/code/views/app-view.tsx
+++ b/src/code/views/app-view.tsx
@@ -61,7 +61,7 @@ export class AppView extends Mixer<AppViewProps, AppViewState> {
 
   constructor(props: AppViewProps) {
     super(props);
-    this.mixins = [new ImageDialogMixin(this, props), new AppSettingsMixin(this, props)];
+    this.mixins = [new ImageDialogMixin(this), new AppSettingsMixin(this)];
 
     let iframed;
     try {

--- a/src/code/views/document-actions-view.tsx
+++ b/src/code/views/document-actions-view.tsx
@@ -94,7 +94,7 @@ export class DocumentActionsView extends Mixer<DocumentActionsViewProps, Documen
 
   constructor(props: DocumentActionsViewProps) {
     super(props);
-    this.mixins = [new CodapMixin(this, props), new UndoRedoUIMixin(this, props), new AppSettingsMixin(this, props)];
+    this.mixins = [new CodapMixin(this), new UndoRedoUIMixin(this), new AppSettingsMixin(this)];
     const outerState: DocumentActionsViewOuterState = {
       selectedNodes: [],
       selectedLinks: [],

--- a/src/code/views/experiment-panel-view.tsx
+++ b/src/code/views/experiment-panel-view.tsx
@@ -19,7 +19,7 @@ export class ExperimentPanelView extends Mixer<ExperimentPanelViewProps, Experim
 
   constructor(props: ExperimentPanelViewProps) {
     super(props);
-    this.mixins = [new SimulationMixin(this, props)];
+    this.mixins = [new SimulationMixin(this)];
     const outerState: ExperimentPanelViewOuterState = {};
     this.setInitialState(outerState, SimulationMixin.InitialState());
   }

--- a/src/code/views/global-nav-view.tsx
+++ b/src/code/views/global-nav-view.tsx
@@ -29,7 +29,7 @@ export class GlobalNavView extends Mixer<GlobalNavViewProps, GlobalNavViewState>
 
   constructor(props: GlobalNavViewProps) {
     super(props);
-    this.mixins = [new GoogleFileMixin(this, props), new UndoRedoUIMixin(this, props)];
+    this.mixins = [new GoogleFileMixin(this), new UndoRedoUIMixin(this)];
     const outerState: GlobalNavViewOuterState = {
       dirty: false,
       saved: false,

--- a/src/code/views/graph-view.tsx
+++ b/src/code/views/graph-view.tsx
@@ -73,7 +73,7 @@ export class GraphView extends Mixer<GraphViewProps, GraphViewState> {
 
   constructor(props: GraphViewProps) {
     super(props);
-    this.mixins = [new GraphMixin(this, props), new SimulationMixin(this, props), new AppSettingsMixin(this, props), new CodapMixin(this, props), new LaraMixin(this, props)];
+    this.mixins = [new GraphMixin(this), new SimulationMixin(this), new AppSettingsMixin(this), new CodapMixin(this), new LaraMixin(this)];
     const outerState: GraphViewOuterState = {
       selectedNodes: [],
       editingNode: null,

--- a/src/code/views/image-browser-view.tsx
+++ b/src/code/views/image-browser-view.tsx
@@ -28,7 +28,7 @@ export class ImageBrowserView extends Mixer<ImageBrowserViewProps, ImageBrowserV
   constructor(props: ImageBrowserViewProps) {
     super(props);
 
-    this.mixins = [new ImageDialogMixin(this, props), new PaletteMixin(this, props)];
+    this.mixins = [new ImageDialogMixin(this), new PaletteMixin(this)];
     const outerState: ImageBrowserViewOuterState = {};
     this.setInitialState(outerState, ImageDialogMixin.InitialState(), PaletteMixin.InitialState());
   }

--- a/src/code/views/image-link-dialog-view.tsx
+++ b/src/code/views/image-link-dialog-view.tsx
@@ -33,7 +33,7 @@ export class ImageLinkDialogView extends Mixer<ImageLinkDialogViewProps, ImageLi
         {this.state.selectedImage
           ? this.imageDialogViewMixin.renderPreviewImage()
           : <div>
-              <DropZoneView header={tr("~IMAGE-BROWSER.DROP_IMAGE_FROM_BROWSER")} dropped={this.imageDialogViewMixin.imageDropped} />
+              <DropZoneView header={tr("~IMAGE-BROWSER.DROP_IMAGE_FROM_BROWSER")} dropped={this.imageDialogViewMixin.handleImageDrop} />
               <p>{tr("~IMAGE-BROWSER.TYPE_OR_PASTE_LINK")}</p>
               <p>
                 {tr("~IMAGE-BROWSER.IMAGE_URL")}

--- a/src/code/views/image-link-dialog-view.tsx
+++ b/src/code/views/image-link-dialog-view.tsx
@@ -21,8 +21,8 @@ export class ImageLinkDialogView extends Mixer<ImageLinkDialogViewProps, ImageLi
 
   constructor(props: ImageLinkDialogViewProps) {
     super(props);
-    this.imageDialogViewMixin = new ImageDialogViewMixin(this, props);
-    this.mixins = [new ImageDialogMixin(this, props), this.imageDialogViewMixin];
+    this.imageDialogViewMixin = new ImageDialogViewMixin(this);
+    this.mixins = [new ImageDialogMixin(this), this.imageDialogViewMixin];
     const outerState: ImageLinkDialogViewOuterState = {};
     this.setInitialState(outerState, ImageDialogMixin.InitialState(), ImageDialogViewMixin.InitialState());
   }

--- a/src/code/views/image-my-computer-dialog-view.tsx
+++ b/src/code/views/image-my-computer-dialog-view.tsx
@@ -34,7 +34,7 @@ export class ImageMyComputerDialogView extends Mixer<ImageMyComputerDialogViewPr
         {this.state.selectedImage
           ? this.imageDialogViewMixin.renderPreviewImage()
           : <div>
-              <DropZoneView header={tr("~IMAGE-BROWSER.DROP_IMAGE_FROM_DESKTOP")} dropped={this.imageDialogViewMixin.imageDropped} />
+              <DropZoneView header={tr("~IMAGE-BROWSER.DROP_IMAGE_FROM_DESKTOP")} dropped={this.imageDialogViewMixin.handleImageDrop} />
               <p>{tr("~IMAGE-BROWSER.CHOOSE_FILE")}</p>
               <p><input ref={el => this.file = el} type="file" onChange={this.handlePreviewImage} /></p>
             </div>}

--- a/src/code/views/image-my-computer-dialog-view.tsx
+++ b/src/code/views/image-my-computer-dialog-view.tsx
@@ -21,9 +21,9 @@ export class ImageMyComputerDialogView extends Mixer<ImageMyComputerDialogViewPr
 
   constructor(props: ImageMyComputerDialogViewProps) {
     super(props);
-    this.imageDialogViewMixin = new ImageDialogViewMixin(this, props);
+    this.imageDialogViewMixin = new ImageDialogViewMixin(this);
 
-    this.mixins = [new ImageDialogMixin(this, props), this.imageDialogViewMixin];
+    this.mixins = [new ImageDialogMixin(this), this.imageDialogViewMixin];
     const outerState: ImageMyComputerDialogViewOuterState = {};
     this.setInitialState(outerState, ImageDialogMixin.InitialState(), ImageDialogViewMixin.InitialState());
   }

--- a/src/code/views/image-picker-view.tsx
+++ b/src/code/views/image-picker-view.tsx
@@ -52,7 +52,7 @@ export class ImagePickerView extends Mixer<ImagePickerViewProps, ImagePickerView
 
   constructor(props: ImagePickerViewProps) {
     super(props);
-    this.mixins = [new PaletteMixin(this, props)];
+    this.mixins = [new PaletteMixin(this)];
     const outerState: ImagePickerViewOuterState = {opened: false};
     this.setInitialState(outerState, PaletteMixin.InitialState());
   }

--- a/src/code/views/image-search-dialog-view.tsx
+++ b/src/code/views/image-search-dialog-view.tsx
@@ -146,9 +146,9 @@ export class ImageSearchDialogView extends Mixer<ImageSearchDialogViewProps, Ima
 
   constructor(props: ImageSearchDialogViewProps) {
     super(props);
-    this.imageDialogViewMixin = new ImageDialogViewMixin(this, props);
+    this.imageDialogViewMixin = new ImageDialogViewMixin(this);
 
-    this.mixins = [new ImageDialogMixin(this, props), this.imageDialogViewMixin];
+    this.mixins = [new ImageDialogMixin(this), this.imageDialogViewMixin];
 
     const outerState: ImageSearchDialogViewOuterState = {
       searching: false,

--- a/src/code/views/inspector-panel-view.tsx
+++ b/src/code/views/inspector-panel-view.tsx
@@ -149,7 +149,7 @@ export class InspectorPanelView extends Mixer<InspectorPanelViewProps, Inspector
 
   constructor(props: InspectorPanelViewProps) {
     super(props);
-    this.mixins = [new InspectorPanelMixin(this, props)];
+    this.mixins = [new InspectorPanelMixin(this)];
     const outerState: InspectorPanelViewOuterState = {};
     this.setInitialState(outerState, InspectorPanelMixin.InitialState());
   }

--- a/src/code/views/link-relation-view.tsx
+++ b/src/code/views/link-relation-view.tsx
@@ -102,7 +102,7 @@ export class LinkRelationView extends Mixer<LinkRelationViewProps, LinkRelationV
 
   constructor(props: LinkRelationViewProps) {
     super(props);
-    this.mixins = [new SimulationMixin(this, props), new AppSettingsMixin(this, props)];
+    this.mixins = [new SimulationMixin(this), new AppSettingsMixin(this)];
 
     const status = this.checkStatus(this.props.link);
     const outerState: LinkRelationViewOuterState = {

--- a/src/code/views/modal-palette-delete-view.tsx
+++ b/src/code/views/modal-palette-delete-view.tsx
@@ -21,7 +21,7 @@ export class ModalPaletteDeleteView extends Mixer<ModalPaletteDeleteViewProps, M
 
   constructor(props: ModalPaletteDeleteViewProps) {
     super(props);
-    this.mixins = [new PaletteDeleteDialogMixin(this, props)];
+    this.mixins = [new PaletteDeleteDialogMixin(this)];
     const outerState: ModalPaletteDeleteViewOuterState = {
     };
     this.setInitialState(outerState, PaletteDeleteDialogMixin.InitialState());

--- a/src/code/views/node-inspector-view.tsx
+++ b/src/code/views/node-inspector-view.tsx
@@ -24,7 +24,7 @@ export class NodeInspectorView extends Mixer<NodeInspectorViewProps, NodeInspect
 
   constructor(props: NodeInspectorViewProps) {
     super(props);
-    this.nodeTitleMixin = new NodeTitleMixin(this, props);
+    this.nodeTitleMixin = new NodeTitleMixin(this);
     this.mixins = [this.nodeTitleMixin];
 
     const outerState: NodeInspectorViewOuterState = {};

--- a/src/code/views/node-svg-graph-view.tsx
+++ b/src/code/views/node-svg-graph-view.tsx
@@ -36,7 +36,7 @@ export class NodeSvgGraphView extends Mixer<NodeSvgGraphViewProps, NodeSvgGraphV
 
   constructor(props: NodeSvgGraphViewProps) {
     super(props);
-    this.mixins = [new SimulationMixin(this, props)];
+    this.mixins = [new SimulationMixin(this)];
     const outerState: NodeSvgGraphViewOuterState = {};
     this.setInitialState(outerState, SimulationMixin.InitialState());
   }

--- a/src/code/views/node-value-inspector-view.tsx
+++ b/src/code/views/node-value-inspector-view.tsx
@@ -35,7 +35,7 @@ export class NodeValueInspectorView extends Mixer<NodeValueInspectorViewProps, N
 
   constructor(props: NodeValueInspectorViewProps) {
     super(props);
-    this.mixins = [new SimulationMixin(this, props), new AppSettingsMixin(this, props)];
+    this.mixins = [new SimulationMixin(this), new AppSettingsMixin(this)];
     const outerState: NodeValueInspectorViewOuterState = {
       "editing-min": false,
       "editing-max": false,

--- a/src/code/views/node-view.tsx
+++ b/src/code/views/node-view.tsx
@@ -56,7 +56,7 @@ class NodeTitleView extends Mixer<NodeTitleViewProps, NodeTitleViewState> {
 
   constructor(props: NodeTitleViewProps) {
     super(props);
-    this.nodeTitleMixin = new NodeTitleMixin(this, props);
+    this.nodeTitleMixin = new NodeTitleMixin(this);
     this.mixins = [this.nodeTitleMixin];
 
     const outerState: NodeTitleViewOuterState = this.getStateFromProps(props);

--- a/src/code/views/node-well-view.tsx
+++ b/src/code/views/node-well-view.tsx
@@ -29,7 +29,7 @@ export class NodeWellView extends Mixer<NodeWellViewProps, NodeWellViewState> {
 
   constructor(props: NodeWellViewProps) {
     super(props);
-    this.mixins = [new PaletteMixin(this, props)];
+    this.mixins = [new PaletteMixin(this)];
     const outerState: NodeWellViewOuterState = {
       nodes: [],
       collapsed: true

--- a/src/code/views/palette-add-view.tsx
+++ b/src/code/views/palette-add-view.tsx
@@ -26,7 +26,7 @@ export class PaletteAddView extends Mixer<PaletteAddViewProps, PaletteAddViewSta
 
   constructor(props: PaletteAddViewProps) {
     super(props);
-    this.mixins = [new DraggableMixin(this, props)];
+    this.mixins = [new DraggableMixin(this)];
     const outerState: PaletteAddViewOuterState = {};
     this.setInitialState(outerState, DraggableMixin.InitialState());
   }

--- a/src/code/views/palette-inspector-view.tsx
+++ b/src/code/views/palette-inspector-view.tsx
@@ -29,7 +29,7 @@ export class PaletteInspectorView extends Mixer<PaletteInspectorViewProps, Palet
 
   constructor(props: PaletteInspectorViewProps) {
     super(props);
-    this.mixins = [new PaletteMixin(this, props), new NodesMixin(this, props)];
+    this.mixins = [new PaletteMixin(this), new NodesMixin(this)];
     const outerState: PaletteInspectorViewOuterState = {
     };
     this.setInitialState(outerState, PaletteMixin.InitialState(), NodesMixin.InitialState());

--- a/src/code/views/relation-inspector-view.tsx
+++ b/src/code/views/relation-inspector-view.tsx
@@ -39,7 +39,7 @@ export class RelationInspectorView extends Mixer<RelationInspectorViewProps, Rel
   // (link-relation-view uses @props.graphStore.changeLink() to update the link)
   constructor(props: RelationInspectorViewProps) {
     super(props);
-    this.mixins = [new InspectorPanelMixin(this, props), new GraphMixin(this, props)];
+    this.mixins = [new InspectorPanelMixin(this), new GraphMixin(this)];
     const outerState: RelationInspectorViewOuterState = {};
     this.setInitialState(outerState, InspectorPanelMixin.InitialState());
   }

--- a/src/code/views/simulation-inspector-view.tsx
+++ b/src/code/views/simulation-inspector-view.tsx
@@ -28,7 +28,7 @@ export class SimulationInspectorView extends Mixer<SimulationInspectorProps, Sim
 
   constructor(props: {}) {
     super(props);
-    this.mixins = [new SimulationMixin(this, props), new AppSettingsMixin(this, props)];
+    this.mixins = [new SimulationMixin(this), new AppSettingsMixin(this)];
     const outerProps: SimulationInspectorOuterProps = {};
     this.setInitialState(outerProps, SimulationMixin.InitialState(), AppSettingsMixin.InitialState());
   }

--- a/src/code/views/simulation-run-panel-view.tsx
+++ b/src/code/views/simulation-run-panel-view.tsx
@@ -27,7 +27,7 @@ export class SimulationRunPanelView extends Mixer<SimulationRunPanelViewProps, S
 
   constructor(props: SimulationRunPanelViewProps) {
     super(props);
-    this.mixins = [new SimulationMixin(this, props), new AppSettingsMixin(this, props)];
+    this.mixins = [new SimulationMixin(this), new AppSettingsMixin(this)];
     const outerState: SimulationRunPanelViewOuterState = {};
     this.setInitialState(outerState, SimulationMixin.InitialState(), AppSettingsMixin.InitialState());
   }


### PR DESCRIPTION
1. Fixes some trivial errors related to incorrect `this` binding.
2. Previous Mixin implementation was unable to receive new `props`. I've fixed. Mixins no longer extend React.Component. Instead, they just implement their own `IMixin` interface that resembles React.Component. I think it should be a bit cleaner, as there's no need for mixin to be a "real" React Component.

That seems to fix all the errors related to image search/upload dialog.