### PR TITLE
Simplify mini-graphs viewing, refactor migration tests, restore commented out migration tests

### DIFF
--- a/src/code/data/migrations/26_remove_minigraphs_visibility.ts
+++ b/src/code/data/migrations/26_remove_minigraphs_visibility.ts
@@ -1,0 +1,23 @@
+/*
+ * decaffeinate suggestions:
+ * DS102: Remove unnecessary code created because of implicit returns
+ * DS207: Consider shorter variations of null checks
+ * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
+ */
+
+const _ = require("lodash");
+
+import { MigrationMixin } from "./migration-mixin";
+
+const migration = {
+  version: "1.25.0",
+  description: "Removes minigraphs settings",
+  date: "2018-11-23",
+
+  doUpdate(data) {
+    if (data.settings == null) { data.settings = {}; }
+    delete data.settings.showMinigraphs;
+  }
+};
+
+export const migration_26 = _.mixin(migration, MigrationMixin);

--- a/src/code/data/migrations/26_remove_minigraphs_visibility.ts
+++ b/src/code/data/migrations/26_remove_minigraphs_visibility.ts
@@ -1,10 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS102: Remove unnecessary code created because of implicit returns
- * DS207: Consider shorter variations of null checks
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
-
 const _ = require("lodash");
 
 import { MigrationMixin } from "./migration-mixin";

--- a/src/code/data/migrations/migrations.ts
+++ b/src/code/data/migrations/migrations.ts
@@ -31,6 +31,7 @@ import { migration_22 } from "./22_add_combine_method";
 import { migration_23 } from "./23_add_simulation_type";
 import { migration_24 } from "./24_fix_simulation_type";
 import { migration_25 } from "./25_ensure_combine_method";
+import { migration_26 } from "./26_remove_minigraphs_visibility";
 
 export const migrations = [
   migration_01,
@@ -58,12 +59,17 @@ export const migrations = [
   migration_23,
   migration_24,
   migration_25,
+  migration_26
 ];
 
-export const migrationUpdate = (data) => {
+export const migrationUpdate = (data, upToVersion: string | null = null) => {
   for (const m of migrations) {
     if (m.update) {
       data = m.update(data);
+    }
+    if (upToVersion && m.version === upToVersion) {
+      // Optionally, apply migrations up to provided version. Useful for testing.
+      return data;
     }
   }
   return data;

--- a/src/code/models/node.ts
+++ b/src/code/models/node.ts
@@ -359,6 +359,10 @@ export class Node extends GraphPrimitive {
   public paletteItemIs(paletteItem) {
     return paletteItem.uuid === this.paletteItem;
   }
+
+  public hasGraphData() {
+    return this.frames.length > 0;
+  }
 }
 
 Node.initialize();

--- a/src/code/stores/app-settings-store.ts
+++ b/src/code/stores/app-settings-store.ts
@@ -110,9 +110,6 @@ export const AppSettingsStore: AppSettingsStoreClass = Reflux.createStore({
 
   onSetComplexity(val) {
     this.settings.complexity = val;
-    if (val === 0) {
-      this.settings.showingMinigraphs = false;
-    }
     return this.notifyChange();
   },
 
@@ -144,7 +141,6 @@ export const AppSettingsStore: AppSettingsStoreClass = Reflux.createStore({
     return {
       complexity: this.settings.complexity,
       simulationType: this.settings.simulationType,
-      showingMinigraphs: this.settings.showingMinigraphs,
       relationshipSymbols: this.settings.relationshipSymbols
     };
   }

--- a/src/code/stores/app-settings-store.ts
+++ b/src/code/stores/app-settings-store.ts
@@ -16,7 +16,6 @@ import { Mixin } from "../mixins/components";
 export declare class AppSettingsActionsClass {
   public setComplexity(val: any): void;  // TODO: get concrete class
   public setSimulationType(val: any): void;  // TODO: get concrete class
-  public showMinigraphs(show: boolean): void;
   public relationshipSymbols(show: boolean): void;
   public setTouchDevice(val: any): void;  // TODO: get concrete class
 }
@@ -31,7 +30,6 @@ export const AppSettingsActions: AppSettingsActionsClass = Reflux.createActions(
   [
     "setComplexity",
     "setSimulationType",
-    "showMinigraphs",
     "relationshipSymbols",
     "setTouchDevice"
   ]
@@ -65,7 +63,6 @@ interface AppSettingsSettings {
   showingSettingsDialog: boolean;
   complexity: number;
   simulationType: number;
-  showingMinigraphs: boolean;
   relationshipSymbols: boolean;
   uiElements: any;
   lockdown: any;
@@ -104,17 +101,11 @@ export const AppSettingsStore: AppSettingsStoreClass = Reflux.createStore({
       showingSettingsDialog: false,
       complexity: Complexity.DEFAULT,
       simulationType,
-      showingMinigraphs: false,
       relationshipSymbols: false,
       uiElements,
       lockdown,
       touchDevice: false
     } as AppSettingsSettings;
-  },
-
-  onShowMinigraphs(show) {
-    this.settings.showingMinigraphs = show;
-    return this.notifyChange();
   },
 
   onSetComplexity(val) {

--- a/src/code/views/graph-view.tsx
+++ b/src/code/views/graph-view.tsx
@@ -208,7 +208,6 @@ export class GraphView extends Mixer<GraphViewProps, GraphViewState> {
               onDelete={this.handleNodeDeleted}
               graphStore={this.props.graphStore}
               selectionManager={this.props.selectionManager}
-              showMinigraph={this.state.showingMinigraphs}
               isTimeBased={this.state.isTimeBased}
               showGraphButton={this.state.codapHasLoaded && !diagramOnly}
             />)}

--- a/src/code/views/node-view.tsx
+++ b/src/code/views/node-view.tsx
@@ -204,7 +204,6 @@ interface NodeViewProps {
   editTitle: boolean;
   graphStore: any; // TODO: get concrete type
   dataColor: string;
-  showMinigraph: boolean;
   isTimeBased: boolean;
   innerColor: string;
   selectionManager?: any; // TODO: get concrete type
@@ -347,6 +346,12 @@ export class NodeView extends React.Component<NodeViewProps, NodeViewState> {
   }
 
   private renderSliderView() {
+    if (!this.props.data.hasGraphData()) {
+      // Do not show slider view when mini graph would be empty anyway. In practice it happens when the simulation
+      // mode is disabled.
+      return null;
+    }
+
     const showHandle = this.props.data.canEditInitialValue();
     let value = this.props.data.currentValue != null ? this.props.data.currentValue : this.props.data.initialValue;
     if (showHandle) {
@@ -400,7 +405,7 @@ export class NodeView extends React.Component<NodeViewProps, NodeViewState> {
 
     const nodeImage = getNodeImage(this.props.data);
 
-    if (this.props.showMinigraph) {
+    if (this.props.data.hasGraphData()) {
       return (
         <NodeSvgGraphView
           isTimeBased={this.props.isTimeBased}

--- a/src/code/views/simulation-inspector-view.tsx
+++ b/src/code/views/simulation-inspector-view.tsx
@@ -111,18 +111,6 @@ export class SimulationInspectorView extends Mixer<SimulationInspectorProps, Sim
         <div className={runPanelClasses}>
           <div className="title">{tr("~SIMULATION.VIEW_SETTINGS")}</div>
           <div className="row">
-            <label key="minigraphs-label">
-              <input
-                key="minigraphs-checkbox"
-                type="checkbox"
-                value="show-mini"
-                checked={this.state.showingMinigraphs}
-                onChange={this.handleShowingMinigraphs}
-              />
-              {tr("~DOCUMENT.ACTIONS.SHOW_MINI_GRAPHS")}
-            </label>
-          </div>
-          <div className="row">
             <label key="symbols-label">
               <input
                 key="symbols-checkbox"
@@ -141,10 +129,6 @@ export class SimulationInspectorView extends Mixer<SimulationInspectorProps, Sim
 
   private handleCapNodeValues = (e) => {
     SimulationActions.capNodeValues(e.target.checked);
-  }
-
-  private handleShowingMinigraphs = (e) => {
-    AppSettingsActions.showMinigraphs(e.target.checked);
   }
 
   private handleRelationshipSymbols = (e) => {

--- a/src/code/views/simulation-run-panel-view.tsx
+++ b/src/code/views/simulation-run-panel-view.tsx
@@ -179,9 +179,4 @@ export class SimulationRunPanelView extends Mixer<SimulationRunPanelViewProps, S
       SimulationActions.expandSimulationPanel();
     }
   }
-
-  // -- TBD: There was discussion about automatically showing
-  // -- MiniGraphs when this panel is opened  …  NP 2018-01
-  // if ! @state.showingMinigraphs
-  //   AppSettingsStore.actions.showMinigraphs true
 }

--- a/test/loading-serialization-test.ts
+++ b/test/loading-serialization-test.ts
@@ -98,7 +98,7 @@ describe("Serialization and Loading", () => {
       it("should serialize all the properties of the model", () => {
         const model = JSON.parse(jsonString);
 
-        model.version.should.equal("1.24.0");
+        model.version.should.equal("1.25.0");
         model.nodes.length.should.equal(3);
         model.links.length.should.equal(2);
       });
@@ -158,12 +158,10 @@ describe("Serialization and Loading", () => {
       it("should be able to serialize the settings", () => {
         AppSettingsStore.settings.simulationType = "static";
         AppSettingsStore.settings.complexity = "expanded";
-        AppSettingsStore.settings.showingMinigraphs = true;
         jsonString = this.graphStore.toJsonString(this.fakePalette);
         const model = JSON.parse(jsonString);
         model.settings.simulationType.should.equal("static");
         model.settings.complexity.should.equal("expanded");
-        model.settings.showingMinigraphs.should.equal(true);
       });
 
       it("should be able to serialize the simulation settings", () => {
@@ -202,7 +200,6 @@ describe("Serialization and Loading", () => {
       this.graphStore.loadData(data);
       AppSettingsStore.settings.simulationType.should.equal("static");
       AppSettingsStore.settings.complexity.should.equal("expanded");
-      AppSettingsStore.settings.showMinigraphs.should.equal(true);
     });
 
     it("nodes should have paletteItem properties after loading", () => {

--- a/test/migrations-test.ts
+++ b/test/migrations-test.ts
@@ -99,9 +99,12 @@ describe("Migrations",  () =>
       })
     );
 
-    describe("v-1.4 changes", () => it("should have settings and cap value", () => undefined));
-        // Removed or changed in 1.9:
-        // @result.settings.capNodeValues.should.equal false
+    describe("v-1.4 changes", () => {
+      it("should have settings and cap value", () => {
+        const result = migrationUpdate(data, "1.4.0");
+        result.settings.capNodeValues.should.equal(false);
+      });
+    });
 
     describe("v-1.5 changes", () => {
       it("should have images and paletteItems for nodes", () => {
@@ -118,10 +121,12 @@ describe("Migrations",  () =>
       });
     });
 
-    // Removed in 1.19
-    // describe "v-1.6 changes", ->
-    //   it "should have diagramOnly setting", ->
-    //     @result.settings.diagramOnly.should.equal false
+    describe("v-1.6 changes", () => {
+      it("should have diagramOnly setting", () => {
+        const result = migrationUpdate(data, "1.6.0");
+        result.settings.diagramOnly.should.equal(false);
+      });
+    });
 
     describe("v-1.7 changes", () =>
       it("should have settings for the simulation", () => {
@@ -129,11 +134,6 @@ describe("Migrations",  () =>
         result.settings.simulation.should.not.equal(undefined);
       })
     );
-        // Removed or changed in 1.8:
-        // @result.settings.simulation.period.should.equal 10
-        // @result.settings.simulation.stepSize.should.equal 1
-        // @result.settings.simulation.periodUnits.should.equal "YEAR"
-        // @result.settings.simulation.stepUnits.should.equal "YEAR"
 
     describe("v-1.8 changes", () =>
       it("should have settings for the simulation", () => {
@@ -143,16 +143,20 @@ describe("Migrations",  () =>
       })
     );
 
-    // describe "v-1.9 changes", ->
-    //   it "should have speed setting", ->
-    //     @result.settings.simulation.speed.should.equal 4
+    describe("v-1.9 changes", () =>
+      it("should have speed setting", () => {
+        const result = migrationUpdate(data, "1.9.0");
+        result.settings.simulation.speed.should.equal(4);
+      })
+    );
 
-    // Removed in 1.13
-    // describe "v-1.10 changes", ->
-    //   it "should have newIntegration setting", ->
-    //     @result.settings.simulation.newIntegration.should.equal false
+    describe("v-1.10.0 changes", () =>
+      it("should have newIntegration setting", () => {
+        const result = migrationUpdate(data, "1.10.0");
+        result.settings.simulation.newIntegration.should.equal(false);
+      })
+    );
 
-    // Removed in 1.25
     describe("v-1.11.0 changes", () =>
       it("should have minigraphs setting", () => {
         const result = migrationUpdate(data, "1.11.0");
@@ -182,13 +186,13 @@ describe("Migrations",  () =>
       })
     );
 
-    // removed in 1.20.0
-    // describe "v-1.17.0 changes", ->
-    //   it "should have experiment number and frame", ->
-    //     experiment = @result.settings.simulation.experimentNumber
-    //     frame = @result.settings.simulation.experimentFrame
-    //     should.equal(experiment, 0)
-    //     should.equal(frame, 0)
+    describe("v-1.17.0 changes", () => {
+      it("should have experiment number and frame", () => {
+        const result = migrationUpdate(data, "1.17.0");
+        result.settings.simulation.experimentNumber.should.equal(0)
+        result.settings.simulation.experimentFrame.should.equal(0);
+      });
+    });
 
     describe("v-1.18.0 changes", () =>
       it("should have link relation type", () => {
@@ -197,10 +201,12 @@ describe("Migrations",  () =>
       })
     );
 
-    // removed in 1.22.0
-    // describe "v-1.19.0 changes", ->
-    //   it "should have complexity setting", ->
-    //     @result.settings.complexity.should.equal 3
+    describe("v-1.19.0 changes", () =>
+      it("should have link relation type", () => {
+        const result = migrationUpdate(data, "1.19.0");
+        result.settings.complexity.should.equal(2);
+      })
+    );
 
     describe("v-1.22.0 changes", () =>
       it("should have complexity and simulation settings", () => {
@@ -250,4 +256,3 @@ describe("Migrations",  () =>
     );
   })
 );
-

--- a/test/migrations-test.ts
+++ b/test/migrations-test.ts
@@ -13,27 +13,27 @@ chai.config.includeStack = true;
 
 const should = chai.should();
 
-export {};
-
 describe("Migrations",  () =>
   describe("update", () => {
+    let data;
     beforeEach(() => {
-      this.result = migrationUpdate(v01data);
+      data = _.cloneDeep(v01data);
     });
 
     describe("the final version number", () =>
-      it("should be 1.24.0", () => {
-        this.result.version.should.equal("1.24.0");
+      it("should be 1.25.0", () => {
+        migrationUpdate(data).version.should.equal("1.25.0");
       })
     );
 
     describe("the nodes", () => {
       it("should have two nodes", () => {
-        this.result.nodes.length.should.equal(2);
+        migrationUpdate(data).nodes.length.should.equal(2);
       });
 
       it("should have key: and data: attributes", () => {
-        for (const node of this.result.nodes) {
+        const result = migrationUpdate(data);
+        for (const node of result.nodes) {
           node.key.should.not.equal(undefined);
           node.data.should.not.equal(undefined);
         }
@@ -42,23 +42,25 @@ describe("Migrations",  () =>
 
     describe("the palette", () => {
       it("should exist", () => {
-        this.result.palette.should.not.equal(undefined);
+        migrationUpdate(data).palette.should.not.equal(undefined);
       });
       it("should include a blank node", () => {
-        const blank = _.find(this.result.palette, pitem => pitem.key === "img/nodes/blank.png");
+        const result = migrationUpdate(data);
+        const blank = _.find(result.palette, pitem => pitem.key === "img/nodes/blank.png");
         blank.should.not.equal(undefined);
       });
     });
 
     describe("the links", () =>
       it("should have one link", () => {
-        this.result.links.length.should.equal(1);
+        migrationUpdate(data).links.length.should.equal(1);
       })
     );
 
     describe("v-1.1 changes", () => {
       it("should have initial node values", () => {
-        for (const node of this.result.nodes) {
+        const result = migrationUpdate(data);
+        for (const node of result.nodes) {
           node.data.initialValue.should.not.equal(undefined);
           node.data.isAccumulator.should.not.equal(undefined);
           node.data.isAccumulator.should.equal(false);
@@ -66,7 +68,8 @@ describe("Migrations",  () =>
       });
 
       it("should have valid relationship values", () => {
-        for (const link of this.result.links) {
+        const result = migrationUpdate(data);
+        for (const link of result.links) {
           link.relation.should.not.equal(undefined);
           // WAS expect(link.relation.text).to.be.undefined();
           expect(link.relation.text).to.equal(undefined);
@@ -78,7 +81,8 @@ describe("Migrations",  () =>
 
     describe("v-1.2 node changes", () =>
       it("should have initial node values", () => {
-        for (const node of this.result.nodes) {
+        const result = migrationUpdate(data, "1.2.0");
+        for (const node of result.nodes) {
           node.data.valueDefinedSemiQuantitatively.should.not.equal(undefined);
           node.data.valueDefinedSemiQuantitatively.should.equal(true);
         }
@@ -87,7 +91,8 @@ describe("Migrations",  () =>
 
     describe("v-1.3 node changes", () =>
       it("should have initial node values", () => {
-        for (const node of this.result.nodes) {
+        const result = migrationUpdate(data, "1.3.0");
+        for (const node of result.nodes) {
           node.data.min.should.equal(0);
           node.data.max.should.equal(100);
         }
@@ -100,14 +105,16 @@ describe("Migrations",  () =>
 
     describe("v-1.5 changes", () => {
       it("should have images and paletteItems for nodes", () => {
-        for (const node of this.result.nodes) {
+        const result = migrationUpdate(data, "1.5.0");
+        for (const node of result.nodes) {
           node.data.image.should.not.equal(null);
           node.data.paletteItem.should.not.equal(null);
         }
       });
 
       it("paletteItems should have a uuid", () => {
-        this.result.palette.map((paletteItem) => paletteItem.uuid.should.not.equal(null));
+        const result = migrationUpdate(data, "1.5.0");
+        result.palette.map((paletteItem) => paletteItem.uuid.should.not.equal(null));
       });
     });
 
@@ -118,7 +125,8 @@ describe("Migrations",  () =>
 
     describe("v-1.7 changes", () =>
       it("should have settings for the simulation", () => {
-        this.result.settings.simulation.should.not.equal(undefined);
+        const result = migrationUpdate(data, "1.7.0");
+        result.settings.simulation.should.not.equal(undefined);
       })
     );
         // Removed or changed in 1.8:
@@ -129,41 +137,47 @@ describe("Migrations",  () =>
 
     describe("v-1.8 changes", () =>
       it("should have settings for the simulation", () => {
-        this.result.settings.simulation.duration.should.equal(10);
-        this.result.settings.simulation.stepUnits.should.equal(TimeUnits.defaultUnit);
+        const result = migrationUpdate(data, "1.8.0");
+        result.settings.simulation.duration.should.equal(10);
+        result.settings.simulation.stepUnits.should.equal(TimeUnits.defaultUnit);
       })
     );
 
-//    describe "v-1.9 changes", ->
-//      it "should have speed setting", ->
-//        @result.settings.simulation.speed.should.equal 4
+    // describe "v-1.9 changes", ->
+    //   it "should have speed setting", ->
+    //     @result.settings.simulation.speed.should.equal 4
 
     // Removed in 1.13
     // describe "v-1.10 changes", ->
     //   it "should have newIntegration setting", ->
     //     @result.settings.simulation.newIntegration.should.equal false
 
+    // Removed in 1.25
     describe("v-1.11.0 changes", () =>
       it("should have minigraphs setting", () => {
-        this.result.settings.showMinigraphs.should.equal(false);
+        const result = migrationUpdate(data, "1.11.0");
+        result.settings.showMinigraphs.should.equal(false);
       })
     );
 
     describe("v-1.12.0 changes", () =>
       it("should have frames array", () => {
-        this.result.nodes.map((node) => node.data.frames.should.not.equal(undefined));
+        const result = migrationUpdate(data, "1.12.0");
+        result.nodes.map((node) => node.data.frames.should.not.equal(undefined));
       })
     );
 
     describe("v-1.15.0 changes", () =>
       it("should have link reasoning", () => {
-        this.result.links.map((link) => link.reasoning.should.not.equal(undefined));
+        const result = migrationUpdate(data, "1.15.0");
+        result.links.map((link) => link.reasoning.should.not.equal(undefined));
       })
     );
 
     describe("v-1.16.0 changes", () =>
       it("should not have simulation speed settings", () => {
-        const { speed } = this.result.settings.simulation;
+        const result = migrationUpdate(data, "1.16.0");
+        const { speed } = result.settings.simulation;
         should.equal(speed, undefined);
       })
     );
@@ -178,7 +192,8 @@ describe("Migrations",  () =>
 
     describe("v-1.18.0 changes", () =>
       it("should have link relation type", () => {
-        this.result.links.map((link) => link.relation.type.should.not.equal(undefined));
+        const result = migrationUpdate(data, "1.18.0");
+        result.links.map((link) => link.relation.type.should.not.equal(undefined));
       })
     );
 
@@ -189,8 +204,9 @@ describe("Migrations",  () =>
 
     describe("v-1.22.0 changes", () =>
       it("should have complexity and simulation settings", () => {
-        this.result.settings.simulationType.should.equal(1);
-        this.result.settings.complexity.should.equal(1);
+        const result = migrationUpdate(data, "1.22.0");
+        result.settings.simulationType.should.equal(1);
+        result.settings.complexity.should.equal(1);
       })
     );
 
@@ -200,7 +216,7 @@ describe("Migrations",  () =>
         // containg collector nodes was not corectly migrating the simulationType
         // to time-based. In other words, the wrong value is 1 and the value
         // we want is 2.
-        const brokenExample = v1220data;
+        const brokenExample = _.cloneDeep(v1220data);
         // Pre-test our broken json is our expected version of 1.22.0
         expect(brokenExample.version).to.equal("1.22.0");
         expect(brokenExample.settings.simulationType).to.equal(1); // wrong value!
@@ -213,7 +229,7 @@ describe("Migrations",  () =>
     describe("v-1.24.0 changes", () =>
       describe("a known failing case: missing `combineMethod` in serialization", () => {
         // We don"t seem to be serializing the combinMethod
-        const brokenExample = v1220MissingCombineMethodData;
+        const brokenExample = _.cloneDeep(v1220MissingCombineMethodData);
         // Pre-test our broken json is our expected version of 1.22.0
         expect(brokenExample.version).to.equal("1.22.0");
         // expect to not find any `combineMethod` for our nodes.
@@ -223,6 +239,13 @@ describe("Migrations",  () =>
         migrationUpdate(brokenExample);
         // Now we want all 4 nodes to have combineMethod
         _.each(brokenExample.nodes, n => expect(n.data.combineMethod).to.exist);
+      })
+    );
+
+    describe("v-1.25.0 changes", () =>
+      it("should remove showing minigraphs app setting", () => {
+        const result = migrationUpdate(data, "1.25.0");
+        expect(result.settings.showMinigraphs).to.equal(undefined);
       })
     );
   })


### PR DESCRIPTION
This PR implements UI changes requested in https://www.pivotaltracker.com/story/show/162022659.

Also, there's quite significant change to migration testing. IMHO it didn't work too well before.

1. Migration change data object in place. But the test data wasn't cloned. It didn't make much sense.
2. Migration tests were always running all the migrations, up to the most recent version. It was causing that old migration tests had to be deleted if the new migration was touching the same data. E.g. my recent removal of mini-graph setting was affecting initial mini-graph setting migration. I've changed tests to run migrations only to a given point, so migrations can be correctly tested and we don't have to remove any old tests.
3. Also, I've restored some commented out migration tests, as now it's possible.