### PR TITLE
Reimplement splash screen, make it reusable, reorder JS loading

### DIFF
--- a/src/assets/css/splash-screen.css
+++ b/src/assets/css/splash-screen.css
@@ -25,10 +25,10 @@
   border: 1px solid #000;
   background-color: #fff;
   z-index: 2;
+  text-align: center;
 }
 #splash-inner-dialog img {
-  width: 300px;
-  height: 236px;
+  width: 100%;
 }
 #splash-inner-dialog {
   margin: 20px;
@@ -38,4 +38,13 @@
   padding-left: 22px;
   background-image: url("data:image/gif;base64,R0lGODlhEAAQAPIAAP///wAAAMLCwkJCQgAAAGJiYoKCgpKSkiH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCgAAACwAAAAAEAAQAAADMwi63P4wyklrE2MIOggZnAdOmGYJRbExwroUmcG2LmDEwnHQLVsYOd2mBzkYDAdKa+dIAAAh+QQJCgAAACwAAAAAEAAQAAADNAi63P5OjCEgG4QMu7DmikRxQlFUYDEZIGBMRVsaqHwctXXf7WEYB4Ag1xjihkMZsiUkKhIAIfkECQoAAAAsAAAAABAAEAAAAzYIujIjK8pByJDMlFYvBoVjHA70GU7xSUJhmKtwHPAKzLO9HMaoKwJZ7Rf8AYPDDzKpZBqfvwQAIfkECQoAAAAsAAAAABAAEAAAAzMIumIlK8oyhpHsnFZfhYumCYUhDAQxRIdhHBGqRoKw0R8DYlJd8z0fMDgsGo/IpHI5TAAAIfkECQoAAAAsAAAAABAAEAAAAzIIunInK0rnZBTwGPNMgQwmdsNgXGJUlIWEuR5oWUIpz8pAEAMe6TwfwyYsGo/IpFKSAAAh+QQJCgAAACwAAAAAEAAQAAADMwi6IMKQORfjdOe82p4wGccc4CEuQradylesojEMBgsUc2G7sDX3lQGBMLAJibufbSlKAAAh+QQJCgAAACwAAAAAEAAQAAADMgi63P7wCRHZnFVdmgHu2nFwlWCI3WGc3TSWhUFGxTAUkGCbtgENBMJAEJsxgMLWzpEAACH5BAkKAAAALAAAAAAQABAAAAMyCLrc/jDKSatlQtScKdceCAjDII7HcQ4EMTCpyrCuUBjCYRgHVtqlAiB1YhiCnlsRkAAAOwAAAAAAAAAAAA==");
   background-repeat: no-repeat;
+}
+#splash-text {
+  text-align: justify;
+  font-size: 15px;
+}
+.splash-cell {
+  width: 270px;
+  display: inline-block;
+  vertical-align: middle;
 }

--- a/src/assets/js/splash-screen.js
+++ b/src/assets/js/splash-screen.js
@@ -1,31 +1,64 @@
-(function () {
+window.showSplashScreen = function (version, buildDate) {
+  // First, generate HTML markup and append splash screen to body element.
+  var splashContainer = document.createElement("div");
+  splashContainer.setAttribute("id", "splash-container");
+  splashContainer.innerHTML =
+    '<div id="splash-container">' +
+    '  <div id="splash-background"></div>' +
+    '  <div id="splash-dialog">' +
+    '    <div id="splash-inner-dialog">' +
+    '      <div class="splash-cell">' +
+    '        <img src="img/logo.png"/>' +
+    '      </div>' +
+    '      <div id="splash-text" class="splash-cell">' +
+    '        <p>' +
+    '          Created by the Concord Consortium and the CREATE for STEM Institute at Michigan State University.' +
+    '        </p>' +
+    '        <p>' +
+    '          This open-source software is licensed under the MIT license.' +
+    '        </p>' +
+    '        <p>' +
+    '          Copyright © 2018 All rights reserved.' +
+    '        </p>' +
+    '      </div>' +
+    '      <div class="splash-cell">' +
+    '        Version ' + version + ' (' + buildDate + ')' +
+    '      </div>' +
+    '      <div class="splash-cell">' +
+    '        <span id="splash-loading">Loading</span>' +
+    '      </div>' +
+    '    </div>' +
+    '  </div>' +
+    '</div>';
+  document.body.appendChild(splashContainer);
+
+  // Now, setup when it's going to disappear.
+  var removeSplashContainer = function () {
+    splashContainer.parentElement.removeChild(splashContainer);
+    // trigger a callback that is used in index.html.ejs to show the open or create dialog
+    if (window.onSplashScreenClosed) {
+      window.onSplashScreenClosed();
+    }
+  };
+
+  // remove the splash screen on any click
+  splashContainer.onclick = function () {
+    clearTimeout(checkerTimeout);
+    removeSplashContainer();
+  };
+
   var app = document.getElementById("app");
-  var splashContainer = document.getElementById("splash-container");
-  if (app && splashContainer) {
-
-    var removeSplashContainer = function () {
-      splashContainer.parentElement.removeChild(splashContainer);
-    };
-
-    // remove the splash screen on any click
-    splashContainer.onclick = function () {
-      clearTimeout(checkerTimeout);
+  var checkerTimeout;
+  var checkForAppRender = function () {
+    // if the app has rendered then clear the splashscreen, otherwise check again in 100ms
+    if (app.children.length > 0) {
       removeSplashContainer();
-    };
+    }
+    else {
+      checkerTimeout = setTimeout(checkForAppRender, 100);
+    }
+  };
 
-    var checkerTimeout;
-    var checkForAppRender = function () {
-      // if the app has rendered then clear the splashscreen, otherwise check again in 100ms
-      if (app.children.length > 0) {
-        removeSplashContainer();
-      }
-      else {
-        checkerTimeout = setTimeout(checkForAppRender, 100);
-      }
-    };
-
-    // show the initial splash screen for two seconds
-    checkerTimeout = setTimeout(checkForAppRender, 3000);
-  }
-})();
-
+  // show the initial splash screen for four seconds
+  checkerTimeout = setTimeout(checkForAppRender, 4000);
+};

--- a/src/templates/index.html.ejs
+++ b/src/templates/index.html.ejs
@@ -56,37 +56,20 @@
   <link rel="stylesheet" href="icon_font_style.css">
   <link rel="stylesheet" href="codap-ivy-fonts.css">
   <link rel="stylesheet" href="css/splash-screen.css">
+  <script src="js/splash-screen.js"></script>
 </head>
 <body>
   <div class="content-box">
     <div id='app'></div>
-    <div id='splash-container'>
-      <div id='splash-background'></div>
-      <div id='splash-dialog'>
-        <div id='splash-inner-dialog'>
-          <div>
-            <img src="img/logo.png" />
-          </div>
-          <div>
-            <p>
-              Created by the Concord Consortium and the<br/>CREATE for STEM Institute at Michigan State University.
-            </p>
-            <p>
-              Version <%= htmlWebpackPlugin.options.__VERSION__ %> (<%= htmlWebpackPlugin.options.__BUILD_DATE__ %>)
-            </p>
-            <p>
-              <span id="splash-loading">Loading</span>
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
   </div>
+  <script type="text/javascript" charset="utf-8">
+    showSplashScreen("<%= htmlWebpackPlugin.options.__VERSION__ %>", "<%= htmlWebpackPlugin.options.__BUILD_DATE__ %>");
+  </script>
   <script src="js/jsPlumb.js"></script>
+
   <% for (key in htmlWebpackPlugin.files.chunks) { %>
   <script src="<%= htmlWebpackPlugin.files.chunks[key].entry %>" type="text/javascript"></script>
   <% } %>
-  <script src="js/splash-screen.js"></script>
 
   <script type="text/javascript" charset="utf-8">
     if(self == top) {


### PR DESCRIPTION
[#162022115]

I've moved HTML generation to JS file. Now we can reuse in Sage Modeler standalone site. Also, I've slightly reordered JS loading. That way splash screen shows almost immediately when the big JS files are still loading. I've tested that using Chrome network throttling. 