### PR TITLE
Let users undo node adding when Sage is embedded in CODAP

### DIFF
--- a/src/code/models/codap-connect.ts
+++ b/src/code/models/codap-connect.ts
@@ -246,7 +246,10 @@ export class CodapConnect {
           const message = {
             action: "create",
             resource: `dataContext[${this.dataContextName}].collection[${this.samplesCollectionName}].attribute`,
-            values: newAttributes
+            values: newAttributes,
+            meta: {
+              dirtyDocument: false
+            }
           };
           return this.codapPhone.call(message, response => {
             if (response.success) {
@@ -343,7 +346,23 @@ export class CodapConnect {
     }
   }
 
-
+  public sendDeleteAttribute(node) {
+    const codapKey = node.codapID || node.codapName;
+    if (codapKey) {
+      const message = {
+        action: "delete",
+        resource: `dataContext[${this.dataContextName}].collection[${this.samplesCollectionName}].attribute[${codapKey}]`,
+        meta: {
+          dirtyDocument: false
+        }
+      };
+      return this.codapPhone.call(message, response => {
+        if (!response.success) {
+          log.warn("Error: CODAP attribute delete failed!");
+        }
+      });
+    }
+  }
 
   // updateExperimentColumn
   //

--- a/src/code/stores/graph-store.ts
+++ b/src/code/stores/graph-store.ts
@@ -310,11 +310,20 @@ export const GraphStore  = Reflux.createStore({
   addNode(node) {
     this.endNodeEdit();
     node.title = this.ensureUniqueTitle(node);
-    return this.undoRedoManager.createAndExecuteCommand("addNode", {
-      execute: () => this._addNode(node),
-      undo: () => this._removeNode(node)
-    }
-    );
+    console.log("Added node");
+    this.undoRedoManager.createAndExecuteCommand("addNode", {
+      execute: () => {
+        this._addNode(node);
+      },
+      undo: () => {
+        // Remove related variable from CODAP. Note that this is not part of the _removeNode.
+        // When we undo "add" operation, it makes perfect sense to cleanup CODAP attribute.
+        // However, when node was around for some time, there's some data, and user deletes it, it's safer
+        // to leave this data around. User might want to delete it or not.
+        CodapConnect.instance(DEFAULT_CONTEXT_NAME).sendDeleteAttribute(node);
+        this._removeNode(node);
+      }
+    });
   },
 
   removeNode(nodeKey) {


### PR DESCRIPTION
The main reason why we couldn't undo node add when Sage was embedded in CODAP was the fact that Sage was creating a new attribute in CODAP. This action makes CODAP document dirty and resets undo stack. When we pass `{ dirtyDocument: false }` metadata, CODAP won't mark document dirty and won't reset undo stack.

This whole undo logic is a bit questionable for me, but it works like that in other places (e.g. when we change a node). So, I'm just following an existing pattern.

There's a second part of this PR. What should we do about CODAP attribute when we undo node add and we have to remove this node?
Regular node remove action doesn't delete CODAP attribute. It makes some sense, as there might be some interesting data already. However, in the case of immediate undo action, I think it makes sense to remove the attribute, as there won't be any data. I've described that in comments. I'll double check that with Dan.

Also, this PR depends on CODAP PR: https://github.com/concord-consortium/codap/pull/262

It works without, but only partially. You'll be able to undo just a single action, as delete attribute action will reset undo stack in CODAP. When CODAP PR is merged, you'll be able to undo multiple node add actions.