### PR TITLE
Show CODAP text box and table at the bottom

### DIFF
--- a/src/code/models/codap-connect.ts
+++ b/src/code/models/codap-connect.ts
@@ -586,7 +586,8 @@ export class CodapConnect {
       resource: "component",
       values: {
         type: "text",
-        title: "Text"
+        title: "Text",
+        position: "bottom"
       }
     });
   }
@@ -598,10 +599,11 @@ export class CodapConnect {
         resource: "component",
         values: {
           type: "caseTable",
-          dataContext: this.dataContextName
+          dataContext: this.dataContextName,
+          position: "bottom"
         }
       });
-      return this.tableCreated = true;
+      this.tableCreated = true;
     }
   }
 
@@ -611,7 +613,8 @@ export class CodapConnect {
       resource: "component",
       values: {
         type: "caseTable",
-        dataContext: dataContextName
+        dataContext: dataContextName,
+        position: "bottom"
       }
     });
   }


### PR DESCRIPTION
This depends on CODAP PR https://github.com/concord-consortium/codap/pull/263 to work.
But nothing prevents us from merging this in, it won't break anything. Actually, the `position` parameter is documented in CODAP API, so it should be supported anyway.