### PR TITLE
Fix logic related to sliders, dont show them when it's not necessary

### DIFF
--- a/src/code/views/node-view.tsx
+++ b/src/code/views/node-view.tsx
@@ -292,7 +292,7 @@ export class NodeView extends React.Component<NodeViewProps, NodeViewState> {
       <div className={this.nodeClasses()} ref={el => this.node = el} style={style}>
         <div className={this.linkTargetClasses()} data-node-key={this.props.nodeKey}>
           <div className="slider" data-node-key={this.props.nodeKey}>
-            {this.props.simulating ? <div>{this.renderSliderView()}</div> : undefined}
+            {this.props.simulating && this.props.data.canEditInitialValue() && <div>{this.renderSliderView()}</div>}
           </div>
           <div>
             <div className="actions">
@@ -346,28 +346,16 @@ export class NodeView extends React.Component<NodeViewProps, NodeViewState> {
   }
 
   private renderSliderView() {
-    if (!this.props.data.hasGraphData()) {
-      // Do not show slider view when mini graph would be empty anyway. In practice it happens when the simulation
-      // mode is disabled.
-      return null;
-    }
-
-    const showHandle = this.props.data.canEditInitialValue();
-    let value = this.props.data.currentValue != null ? this.props.data.currentValue : this.props.data.initialValue;
-    if (showHandle) {
-      value = this.props.data.initialValue;
-    }
-
     return (
       <SVGSliderView
         orientation="vertical"
         filled={true}
         height={44}
         width={15}
-        showHandle={showHandle}
+        showHandle={true}
         showLabels={false}
         onValueChange={this.handleChangeValue}
-        value={value}
+        value={this.props.data.initialValue}
         displaySemiQuant={this.props.data.valueDefinedSemiQuantitatively}
         max={this.props.data.max}
         min={this.props.data.min}


### PR DESCRIPTION
This is related to Dan's comment here:
https://www.pivotaltracker.com/story/show/162022659/comments/196975446
Previously, I misunderstood one of the points in this story.

We won't show sliders without handle that were acting as a kind of a tiny bar graph. It's redundant now, as we always see a mini-graph when it's available.