### PR TITLE
Fixed vary draw relationship label location [#162461761]

### DIFF
--- a/src/stylus/components/svg-graph-view.styl
+++ b/src/stylus/components/svg-graph-view.styl
@@ -51,7 +51,8 @@
   .graph-hint
     position absolute
     width 100px
-    right 0px
+    top 30px
+    left 30px
     text-align center
     line-height 1em
     color #AAA


### PR DESCRIPTION
Here is the new centered label position:

![image](https://user-images.githubusercontent.com/112938/51035860-64ed2500-1579-11e9-9aa9-bfb735b51413.png)
