### PR TITLE
Set about icon font size explicity [#163228726]

### DIFF
--- a/src/stylus/components/menu.styl
+++ b/src/stylus/components/menu.styl
@@ -14,7 +14,7 @@
     i
       font-size 7px
       padding-left 1em
-    i[class^="icon-"]
+    i[class^="icon-codap-help"]
       font-size 30px
 
 .menu-hidden


### PR DESCRIPTION
Before fix:

![image](https://user-images.githubusercontent.com/112938/51267802-97898a00-198c-11e9-8954-005dc26f4000.png)

after fix:

![image](https://user-images.githubusercontent.com/112938/51267753-77f26180-198c-11e9-92b5-fc8b4015d5af.png)
