### PR TITLE
Fixed error thrown when selecting label input [#164435260]

### DIFF
--- a/src/code/views/graph-view.tsx
+++ b/src/code/views/graph-view.tsx
@@ -317,7 +317,10 @@ export class GraphView extends Mixer<GraphViewProps, GraphViewState> {
     return this.handleEvent(() => {
       const multipleSelections = evt.ctrlKey || evt.metaKey || evt.shiftKey;
       this.forceRedrawLinks = true;
-      return GraphStore.clickLink(connection.linkModel, multipleSelections);
+      // this event is also invoked for clicks in the label input field which has no linkModel
+      if (connection.linkModel) {
+        return GraphStore.clickLink(connection.linkModel, multipleSelections);
+      }
     });
   }
 


### PR DESCRIPTION
The graph link click handler was being called when the link label input was selected causing an error to throw because the clicked item was not a link.