### PR TITLE
Fixed missing units attribute in simulation step dropdown [#164511759]

### DIFF
--- a/src/code/views/simulation-run-panel-view.tsx
+++ b/src/code/views/simulation-run-panel-view.tsx
@@ -5,7 +5,7 @@ import { AppSettingsMixinProps } from "../stores/app-settings-store";
 
 import { tr } from "../utils/translate";
 import { RecordButtonView  } from "./record-button-view";
-import { DropDownView } from "./dropdown-view";
+import { DropDownView, DropDownViewItem } from "./dropdown-view";
 import { ExperimentPanelView } from "./experiment-panel-view";
 
 import { SimulationMixin, SimulationMixinState } from "../stores/simulation-store";
@@ -101,9 +101,7 @@ export class SimulationRunPanelView extends Mixer<SimulationRunPanelViewProps, S
       disabled: !this.state.modelIsRunnable
     };
     const {timeUnitOptions} = this.state;
-    const items = Object.keys(timeUnitOptions).map((key) => {
-      return {name: timeUnitOptions[key].name};
-    });
+    const items = Object.keys(timeUnitOptions).map((key) => timeUnitOptions[key]);
     return (
       <div className="horizontal">
         <RecordButtonView {...props}>
@@ -126,7 +124,7 @@ export class SimulationRunPanelView extends Mixer<SimulationRunPanelViewProps, S
           isActionMenu={false}
           onSelect={SimulationActions.setStepUnits}
           anchor={this.state.stepUnitsName}
-          items={items}
+          items={items as DropDownViewItem[]}
         />
       </div>
     );


### PR DESCRIPTION
As part of the work to add types to the generic dropdown view the unit attribute was removed from the simulation step dropdown which caused a translation error.