### PR TITLE
Change CFM urls to use cloud-file-manager CloudFront urls

### DIFF
--- a/src/assets/sage.html
+++ b/src/assets/sage.html
@@ -47,10 +47,10 @@
     </script>
 
     <!-- Cloud File Manager -->
-    <script type="text/javascript" src="//concord-consortium.github.io/cloud-file-manager/js/globals.js"></script>
-    <script type="text/javascript" src="//concord-consortium.github.io/cloud-file-manager/js/app.js"></script>
+    <script type="text/javascript" src="//cloud-file-manager.concord.org/js/globals.js"></script>
+    <script type="text/javascript" src="//cloud-file-manager.concord.org/js/app.js"></script>
 
-    <link rel="stylesheet" href="//concord-consortium.github.io/cloud-file-manager/css/app.css">
+    <link rel="stylesheet" href="//cloud-file-manager.concord.org/css/app.css">
 
   </head>
   <body>


### PR DESCRIPTION
This should have been done months ago when I created the cloud-file-manager S3+CloudFront distribution.