### PR TITLE
Fixed CFM dialog vertical centering in Firefox [#161082471]

### DIFF
--- a/src/assets/sage.html
+++ b/src/assets/sage.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <title>SageModeler</title>

--- a/src/templates/index.html.ejs
+++ b/src/templates/index.html.ejs
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title>SageModeler</title>

--- a/src/templates/sagemodeler.html.ejs
+++ b/src/templates/sagemodeler.html.ejs
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
   <title>Sage</title>


### PR DESCRIPTION
Added <!DOCTYPE html> so that jQuery's window.height() function does not return 0 in Firefox (which caused the dialogs to not center vertically).