### PR TITLE
In "model diagram" mode hide table and graph buttons [#163402991]

### DIFF
--- a/src/code/stores/app-settings-store.ts
+++ b/src/code/stores/app-settings-store.ts
@@ -52,7 +52,7 @@ interface SimulationTypeType {
   time: number;
   DEFAULT: number;
 }
-const SimulationType: SimulationTypeType = {
+export const SimulationType: SimulationTypeType = {
   diagramOnly: 0,
   static: 1,
   time: 2,

--- a/src/code/views/document-actions-view.tsx
+++ b/src/code/views/document-actions-view.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { AppSettingsMixinProps, AppSettingsMixinState, AppSettingsMixin } from "../stores/app-settings-store";
+import { AppSettingsMixinProps, AppSettingsMixinState, AppSettingsMixin, SimulationType } from "../stores/app-settings-store";
 import { CodapMixinProps, CodapMixinState, CodapMixin } from "../stores/codap-store";
 import { UndoRedoUIMixin, UndoRedoUIMixinProps, UndoRedoUIMixinState } from "../stores/undo-redo-ui-store";
 import { tr } from "../utils/translate";
@@ -184,15 +184,16 @@ export class DocumentActionsView extends Mixer<DocumentActionsViewProps, Documen
   }
 
   private renderCODAPToolbar() {
+    const showTableAndGraphButtons = this.state.simulationType !== SimulationType.diagramOnly;
     return (
       <div className="misc-actions toolbar">
-        {this.renderToolbarButton({
+        {showTableAndGraphButtons && this.renderToolbarButton({
           icon: "moonicon-icon-table",
           label: tr("~DOCUMENT.CODAP_ACTIONS.TABLES"),
           onClick: this.handleCODAPTableToolClicked
         })}
         {this.state.showCODAPTableMenu ? <CODAPTableMenu toggleMenu={this.handleCODAPTableToolClicked} /> : undefined}
-        {this.renderToolbarButton({
+        {showTableAndGraphButtons && this.renderToolbarButton({
           icon: "moonicon-icon-graph",
           label: tr("~DOCUMENT.CODAP_ACTIONS.GRAPH"),
           onClick: this.handleCODAPGraphToolClicked


### PR DESCRIPTION
Test link: https://sage.concord.org/branch/163402991-hide-buttons/sage.html?standalone=true