### PR TITLE
Fixes 🐞 stateful dependencies in mocha tests.

### DIFF
--- a/test/node-list-test.ts
+++ b/test/node-list-test.ts
@@ -14,6 +14,7 @@ import { Relationship } from "../src/code/models/relationship";
 
 import { GraphStore } from "../src/code/stores/graph-store";
 
+import { SimulationStore } from "../src/code/stores/simulation-store";
 import { Stub, UnStub } from "./codap-helper";
 
 const makeLink = (sourceNode, targetNode, formula?) =>
@@ -411,6 +412,9 @@ describe("NodeList", () => {
       const linkC = makeLink(nodeC, nodeD);
       const graphStore = GraphStore;
       graphStore.init();
+      // Model link descriptions depend on these settings:
+      SimulationStore.settings.capNodeValues = false;
+      SimulationStore.settings.duration = 10;
       graphStore.addNode(nodeA);
       graphStore.addNode(nodeB);
       graphStore.addNode(nodeC);

--- a/test/simulation-test.ts
+++ b/test/simulation-test.ts
@@ -431,6 +431,7 @@ describe("The SimulationStore, with a network in the GraphStore", () => {
   describe("for a fast simulation for 10 iterations", () => {
 
     beforeEach(() => {
+      SimulationStore.settings.experimentFrame = 0;
       SimulationActions.setDuration.trigger(10);
       SimulationActions.expandSimulationPanel.trigger();
     });
@@ -449,11 +450,11 @@ describe("The SimulationStore, with a network in the GraphStore", () => {
           data.length.should.equal(10);
 
           const frame0 = data[0];
-          frame0.time.should.equal(11);
+          frame0.time.should.equal(1);
           frame0.nodes.should.eql([ { title: "A", value: 10 }, { title: "B", value: 1 } ]);
 
           const frame9 = data[9];
-          frame9.time.should.equal(20);
+          frame9.time.should.equal(10);
           frame9.nodes.should.eql([ { title: "A", value: 10 }, { title: "B", value: 1 } ]);
     });
 


### PR DESCRIPTION
Some mocha tests have stateful dependencies.  Running 2x breaks tests.

The test suite runs fine the first time if run with `npm test`.
If however the suite is run with `npm run test -- --watch`
subsequent runs will fail because the simulation retains (and mutates)
state related to the number of simulation steps.

The fix is to explicitly set default simulation parameters in test blocks for:

* expirimentFrameNumber
* duration
* capNodeValues

[#164835954]

https://www.pivotaltracker.com/story/show/164835954