### PR TITLE
Reverse order of target/link drawing [#164832960]

### DIFF
--- a/src/code/views/graph-view.tsx
+++ b/src/code/views/graph-view.tsx
@@ -375,8 +375,11 @@ export class GraphView extends Mixer<GraphViewProps, GraphViewState> {
     if (this.diagramToolkit) {
       this.ignoringEvents = true;
       this.diagramToolkit.suspendDrawing();
-      this.redrawLinks();
+      // draw nodes (targets) first so that they are before links when jsplumb searches for drag/drop targets
+      // if reversed the links adjacent to the transfer nodes cause the transfer nodes to lose focus when a link
+      // is dragged to a transfer node
       this.redrawTargets();
+      this.redrawLinks();
       this.diagramToolkit.resumeDrawing();
       this.ignoringEvents = false;
       return this.checkForLinkButtonClientClass();


### PR DESCRIPTION
This fixes an issue where a link dragged to a transfer node will cause the transfer nonde to lose drag focus.