### PR TITLE
Make the white area of a selected node draggable

### DIFF
--- a/src/code/views/node-view.tsx
+++ b/src/code/views/node-view.tsx
@@ -273,7 +273,7 @@ export class NodeView extends React.Component<NodeViewProps, NodeViewState> {
   }
 
   public componentDidUpdate() {
-    const handle = ".img-background";
+    const handle = this.props.selected ? ".selected-background" : ".img-background";
     const $elem = $(this.node!);
     return ($elem as any).draggable( "option", "handle", handle);
   }
@@ -324,6 +324,9 @@ export class NodeView extends React.Component<NodeViewProps, NodeViewState> {
                 onTouchEnd={handleBackgroundTouchEnd}
               >
                 {this.renderNodeInternal()}
+                {this.props.selected &&
+                <div className="selected-background" />
+              }
               </div>
               {this.props.data.isTransfer
                 ? <div className="node-title" />
@@ -338,7 +341,7 @@ export class NodeView extends React.Component<NodeViewProps, NodeViewState> {
                       nodeKey={this.props.nodeKey}
                       graphStore={this.props.graphStore}
                     />
-                  </div>}
+                </div>}
             </div>
           </div>
         </div>

--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -83,10 +83,10 @@ $node-design-height = 94px
       height $icon-width + 2
     .selected-background
       position absolute
-      margin-top 1px
-      width 90px
-      height 127px
-      background-color rgba(255,255,255,0);
+      margin-top 2px
+      width $big-elm-width
+      height $big-elm-height - $img-size + 4
+      background-color rgba(255,255,255,0)
   .centered-block
     enable-flex(direction: column, alignContent:center, alignItems:center, justify:flex-start)
     min-height 10px

--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -81,6 +81,12 @@ $node-design-height = 94px
       padding 0
       width $icon-width + 2
       height $icon-width + 2
+    .selected-background
+      position absolute
+      margin-top 1px
+      width 90px
+      height 127px
+      background-color rgba(255,255,255,0);
   .centered-block
     enable-flex(direction: column, alignContent:center, alignItems:center, justify:flex-start)
     min-height 10px
@@ -199,6 +205,7 @@ $node-design-height = 94px
 .node-link-button
   opacity 0.0
   cursor pointer
+  z-index 2
 
   &.correct-drag-top
     margin-top -13px

--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -264,3 +264,8 @@ $node-design-height = 94px
 
 .jsplumb-connector
   z-index 0
+
+.node-title-box
+  z-index 3
+  position absolute
+  margin-left -15px


### PR DESCRIPTION
Addresses [#162094889] to make the white area behind a selected node draggable, not just the node image itself. Implemented a solution involving a temporary extra div that is the same size as the node while the node is selected, raised the link button up a notch on z-index to ensure that functionality was not altered while the selected mode was in effect. 