### PR TITLE
Fix: Safari Link Editing values not saved when focus lost.

### DIFF
--- a/src/code/views/graph-view.tsx
+++ b/src/code/views/graph-view.tsx
@@ -568,16 +568,23 @@ export class GraphView extends Mixer<GraphViewProps, GraphViewState> {
 
   private handleMouseDown = (e) => {
     if (e.target === this.container!) {
-      // deselect links when background is clicked
-      this.forceRedrawLinks = true;
-      this.props.selectionManager.clearSelection();
-      const selectBox = $.extend({}, this.state.selectBox);
-      const offset = $(this.linkView!).offset() || {left: 0, top: 0};
-      selectBox.startX = e.pageX - offset.left;
-      selectBox.startY = e.pageY - offset.top;
-      selectBox.x = selectBox.startX;
-      selectBox.y = selectBox.startY;
-      return this.setState({drawingMarquee: true, selectBox});
+      const deselectAction = () => {
+        // deselect links when background is clicked
+        this.forceRedrawLinks = true;
+        this.props.selectionManager.clearSelection();
+        const selectBox = $.extend({}, this.state.selectBox);
+        const offset = $(this.linkView!).offset() || {left: 0, top: 0};
+        selectBox.startX = e.pageX - offset.left;
+        selectBox.startY = e.pageY - offset.top;
+        selectBox.x = selectBox.startX;
+        selectBox.y = selectBox.startY;
+        return this.setState({drawingMarquee: true, selectBox});
+      };
+      // In Safari, if we `setState` here, the link-labels being edited
+      // don't have time to fire Change handlers to trigger label updates.
+      // So we wait for all pending updates in the current event loop here.
+      // see https://www.pivotaltracker.com/story/show/164438776
+      setTimeout(deselectAction, 1);
     }
   }
 


### PR DESCRIPTION
From PT Story:
> Click on a link to select it. Then click again to bring up link editing dialog.
> Add some text, then click outside that text box and the text you typed is gone.
> It stays if you hit return, but I think many will not hit return.  (safari only)

> Also, once you do have label text there you can no longer click on the text to edit it. You used to be able to.

In Safari, if you are in the middle of editing a label on a link, then click on the background of the graph,
the link label change is lost.  The `onChange` event in `js-plumb-diagram-toolkit.ts` (Line 242) never fires.

I tried adding `blur` and `focusout` handlers to the input.  But none of those events are triggered when the user clicks on the
background of the graph, the reason is that the setState is called, changing the label values before the events can fire.
(Mouse down is called before Change or focus handlers on the text apparently).

By adding a `setTimeout` to the state-update code here, the actions triggered by the onChange of the label get
an opportunity to run first in the current event loop.

[#164438776]

https://www.pivotaltracker.com/story/show/164438776