### PR TITLE
Removed updated style for node-title-box which caused arrows to be positioned incorrectly

### DIFF
--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -264,8 +264,3 @@ $node-design-height = 94px
 
 .jsplumb-connector
   z-index 0
-
-.node-title-box
-  z-index 3
-  position absolute
-  margin-left -15px


### PR DESCRIPTION
Removes css added in commit b3c9036523a0fd8135ab1318c2433f0b8cd20f8a.  This was causing the arrow position calculations that js-plumb does to be off.