### PR TITLE
Multiple ui updates (each in own tagged commit)

### DIFF
--- a/src/code/utils/lang/el.json
+++ b/src/code/utils/lang/el.json
@@ -198,7 +198,7 @@
     "~MENU.ABOUT.ABOUT": "Σχετικά",
     "~SAGEMODELER.SHARE_DIALOG.SERVER_URL": "SageModeler Server URL:",
     "~DOCUMENT.ACTIONS.EXPERIMENT_NUM": "Πείραμα #",
+    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide",
     "~SIMULATION.GUIDE": "Include a guide",
-    "~SIMULATION.CONFIGURE_GUIDE": "configure guide",
-    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide"
+    "~SIMULATION.CONFIGURE_GUIDE": "configure guide"
 }

--- a/src/code/utils/lang/en-US-master.json
+++ b/src/code/utils/lang/en-US-master.json
@@ -6,7 +6,7 @@
     "~MENU.REVERT_TO_ORIGINAL": "Revert To Original",
     "~MENU.REVERT_TO_LAST_SAVE": "Revert To Last Save",
     "~MENU.UNTITLED_MODEL": "Untitled model",
-    "~MENU.ABOUT": "About",
+    "~MENU.ABOUT": "Help",
     "~MENU.ABOUT.HELP": "Go to help website",
     "~MENU.ABOUT.ABOUT": "About SageModeler",
 

--- a/src/code/utils/lang/en-US.json
+++ b/src/code/utils/lang/en-US.json
@@ -6,7 +6,7 @@
     "~MENU.REVERT_TO_ORIGINAL": "Revert To Original",
     "~MENU.REVERT_TO_LAST_SAVE": "Revert To Last Save",
     "~MENU.UNTITLED_MODEL": "Untitled model",
-    "~MENU.ABOUT": "About",
+    "~MENU.ABOUT": "Help",
     "~MENU.ABOUT.HELP": "Go to help website",
     "~MENU.ABOUT.ABOUT": "About SageModeler",
 
@@ -28,7 +28,7 @@
     "~NODE-EDIT.ADD_REMOTE": "Add remote",
     "~NODE-EDIT.DELETE": "Delete",
 
-
+                                         
     "~NODE-VALUE-EDIT.INITIAL-VALUE": "Initial Value",
     "~NODE-VALUE-EDIT.DEFINING_WITH_NUMBERS": "You are defining values with numbers.",
     "~NODE-VALUE-EDIT.DEFINING_WITH_WORDS": "You are defining values with words.",
@@ -43,7 +43,7 @@
     "~NODE-VALUE-EDIT.HIGH": "High",
     "~NODE-VALUE-EDIT.DEPENDENT_VARIABLE": "This node is a dependent variable",
 
-
+                                       
     "~NODE-RELATION-EDIT.COMBINATION_METHOD": "Combine variables using:",
     "~NODE-RELATION-EDIT.ARITHMETIC_MEAN": "average",
     "~NODE-RELATION-EDIT.SCALED_PRODUCT": "limiting factor",
@@ -98,26 +98,26 @@
     "~ADD-NEW-IMAGE.MY-COMPUTER-TAB": "My Computer",
     "~ADD-NEW-IMAGE.LINK-TAB": "Link",
 
-
+                                      
     "~PALETTE-INSPECTOR.ADD_IMAGE": "New Image",
     "~PALETTE-INSPECTOR.ADD_IMAGE_SHORT": "New",
     "~PALETTE-INSPECTOR.ABOUT_IMAGE": "About This Image",
     "~PALETTE-INSPECTOR.DELETE": "Delete Image",
     "~PALETTE-INSPECTOR.REPLACE": "Replace Image",
 
-
+                                   
     "~PALETTE-DIALOG.TITLE": "Delete image?",
     "~PALETTE-DIALOG.DELETE": "Delete",
     "~PALETTE-DIALOG.REPLACE": "and replace with",
     "~PALETTE-DIALOG.OK": "ok",
     "~PALETTE-DIALOG.CANCEL": "✖ cancel",
 
-
+                                   
     "~METADATA.TITLE": "Title",
     "~METADATA.LINK": "Link",
     "~METADATA.CREDIT": "Credit",
 
-
+                                  
     "~IMAGE-BROWSER.PREVIEW": "Preview Your Image",
     "~IMAGE-BROWSER.ADD_IMAGE": "Add Image",
     "~IMAGE-BROWSER.SEARCH_HEADER": "Search for images",
@@ -151,7 +151,7 @@
     "~COLOR.MEDIUM_GRAY": "Gray",
     "~COLOR.DATA": "Codap Orange",
 
-
+                            
     "~FILE.CHECKING_AUTH": "Checking authorization...",
     "~FILE.CONFIRM": "Are you sure?",
     "~FILE.DOWNLOADING": "Downloading...",
@@ -176,7 +176,7 @@
     "~DOCUMENT.ACTIONS.REDO": "Redo",
     "~DOCUMENT.ACTIONS.NO_DEFINED_LINKS": "There must be at least one link with a defined relationship.",
 
-
+                             
     "~DOCUMENT.CODAP_ACTIONS.TABLES": "Tables",
     "~DOCUMENT.CODAP_ACTIONS.TABLES.NEW": "New Table",
     "~DOCUMENT.CODAP_ACTIONS.TABLES.DELETE_CONFIRM": "Are you sure you want to delete \"%{tableName}\"?",

--- a/src/code/utils/lang/es.json
+++ b/src/code/utils/lang/es.json
@@ -193,12 +193,12 @@
     "~DOCUMENT.CODAP_ACTIONS.TABLES.ATTRIBUTE_NAME": "Atributo",
     "~DOCUMENT.CODAP_ACTIONS.GRAPH": "Gráfico",
     "~DOCUMENT.CODAP_ACTIONS.TEXT": "Texto",
-    "~MENU.ABOUT": "About",
+    "~MENU.ABOUT": "Help",
     "~MENU.ABOUT.HELP": "Go to help website",
     "~MENU.ABOUT.ABOUT": "About SageModeler",
     "~SAGEMODELER.SHARE_DIALOG.SERVER_URL": "SageModeler Server URL:",
     "~DOCUMENT.ACTIONS.EXPERIMENT_NUM": "Experiment #",
+    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide",
     "~SIMULATION.GUIDE": "Include a guide",
-    "~SIMULATION.CONFIGURE_GUIDE": "configure guide",
-    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide"
+    "~SIMULATION.CONFIGURE_GUIDE": "configure guide"
 }

--- a/src/code/utils/lang/et.json
+++ b/src/code/utils/lang/et.json
@@ -193,12 +193,12 @@
     "~DOCUMENT.CODAP_ACTIONS.TABLES.ATTRIBUTE_NAME": "AttributeName",
     "~DOCUMENT.CODAP_ACTIONS.GRAPH": "Joonis",
     "~DOCUMENT.CODAP_ACTIONS.TEXT": "Tekst",
-    "~MENU.ABOUT": "About",
+    "~MENU.ABOUT": "Help",
     "~MENU.ABOUT.HELP": "Go to help website",
     "~MENU.ABOUT.ABOUT": "About SageModeler",
     "~SAGEMODELER.SHARE_DIALOG.SERVER_URL": "SageModeler Server URL:",
     "~DOCUMENT.ACTIONS.EXPERIMENT_NUM": "Experiment #",
+    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide",
     "~SIMULATION.GUIDE": "Include a guide",
-    "~SIMULATION.CONFIGURE_GUIDE": "configure guide",
-    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide"
+    "~SIMULATION.CONFIGURE_GUIDE": "configure guide"
 }

--- a/src/code/utils/lang/he.json
+++ b/src/code/utils/lang/he.json
@@ -193,12 +193,12 @@
     "~DOCUMENT.CODAP_ACTIONS.TABLES.ATTRIBUTE_NAME": "מאפיין",
     "~DOCUMENT.CODAP_ACTIONS.GRAPH": "גרף",
     "~DOCUMENT.CODAP_ACTIONS.TEXT": "טקסט",
-    "~MENU.ABOUT": "About",
+    "~MENU.ABOUT": "Help",
     "~MENU.ABOUT.HELP": "Go to help website",
     "~MENU.ABOUT.ABOUT": "About SageModeler",
     "~SAGEMODELER.SHARE_DIALOG.SERVER_URL": "SageModeler Server URL:",
     "~DOCUMENT.ACTIONS.EXPERIMENT_NUM": "Experiment #",
+    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide",
     "~SIMULATION.GUIDE": "Include a guide",
-    "~SIMULATION.CONFIGURE_GUIDE": "configure guide",
-    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide"
+    "~SIMULATION.CONFIGURE_GUIDE": "configure guide"
 }

--- a/src/code/utils/lang/nb.json
+++ b/src/code/utils/lang/nb.json
@@ -198,7 +198,7 @@
     "~MENU.ABOUT.ABOUT": "Om SageModeler",
     "~SAGEMODELER.SHARE_DIALOG.SERVER_URL": "URL til SageModeler-serveren:",
     "~DOCUMENT.ACTIONS.EXPERIMENT_NUM": "Eksperiment #",
-    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide",
-    "~SIMULATION.CONFIGURE_GUIDE": "configure guide",
-    "~SIMULATION.GUIDE": "Include a guide"
+    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Bruksanvisning",
+    "~SIMULATION.GUIDE": "Legg til bruksanvisning",
+    "~SIMULATION.CONFIGURE_GUIDE": "konfigurer bruksanvisning"
 }

--- a/src/code/utils/lang/nn.json
+++ b/src/code/utils/lang/nn.json
@@ -198,7 +198,7 @@
     "~MENU.ABOUT.ABOUT": "Om SageModeler",
     "~SAGEMODELER.SHARE_DIALOG.SERVER_URL": "URL til SageModeler sin server:",
     "~DOCUMENT.ACTIONS.EXPERIMENT_NUM": "Eksperiment #",
-    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide",
-    "~SIMULATION.CONFIGURE_GUIDE": "configure guide",
-    "~SIMULATION.GUIDE": "Include a guide"
+    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Bruksrettleiing",
+    "~SIMULATION.GUIDE": "Legg til bruksrettleiing",
+    "~SIMULATION.CONFIGURE_GUIDE": "konfigurer bruksrettleiing"
 }

--- a/src/code/utils/lang/pl.json
+++ b/src/code/utils/lang/pl.json
@@ -193,12 +193,12 @@
     "~DOCUMENT.CODAP_ACTIONS.TABLES.ATTRIBUTE_NAME": "Atrubut",
     "~DOCUMENT.CODAP_ACTIONS.GRAPH": "Wykres",
     "~DOCUMENT.CODAP_ACTIONS.TEXT": "Tekst",
-    "~MENU.ABOUT": "About",
+    "~MENU.ABOUT": "Help",
     "~MENU.ABOUT.HELP": "Go to help website",
     "~MENU.ABOUT.ABOUT": "About SageModeler",
     "~SAGEMODELER.SHARE_DIALOG.SERVER_URL": "SageModeler Server URL:",
     "~DOCUMENT.ACTIONS.EXPERIMENT_NUM": "Experiment #",
+    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide",
     "~SIMULATION.GUIDE": "Include a guide",
-    "~SIMULATION.CONFIGURE_GUIDE": "configure guide",
-    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide"
+    "~SIMULATION.CONFIGURE_GUIDE": "configure guide"
 }

--- a/src/code/utils/lang/tr.json
+++ b/src/code/utils/lang/tr.json
@@ -193,12 +193,12 @@
     "~DOCUMENT.CODAP_ACTIONS.TABLES.ATTRIBUTE_NAME": "Özellik",
     "~DOCUMENT.CODAP_ACTIONS.GRAPH": "Grafik",
     "~DOCUMENT.CODAP_ACTIONS.TEXT": "Metin",
-    "~MENU.ABOUT": "About",
+    "~MENU.ABOUT": "Help",
     "~MENU.ABOUT.HELP": "Go to help website",
     "~MENU.ABOUT.ABOUT": "About SageModeler",
     "~SAGEMODELER.SHARE_DIALOG.SERVER_URL": "SageModeler Server URL:",
     "~DOCUMENT.ACTIONS.EXPERIMENT_NUM": "Experiment #",
+    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide",
     "~SIMULATION.GUIDE": "Include a guide",
-    "~SIMULATION.CONFIGURE_GUIDE": "configure guide",
-    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide"
+    "~SIMULATION.CONFIGURE_GUIDE": "configure guide"
 }

--- a/src/code/utils/lang/zh-TW.json
+++ b/src/code/utils/lang/zh-TW.json
@@ -193,12 +193,12 @@
     "~DOCUMENT.CODAP_ACTIONS.TABLES.ATTRIBUTE_NAME": "變項",
     "~DOCUMENT.CODAP_ACTIONS.GRAPH": "圖表",
     "~DOCUMENT.CODAP_ACTIONS.TEXT": "文字",
-    "~MENU.ABOUT": "About",
+    "~MENU.ABOUT": "Help",
     "~MENU.ABOUT.HELP": "Go to help website",
     "~MENU.ABOUT.ABOUT": "About SageModeler",
     "~SAGEMODELER.SHARE_DIALOG.SERVER_URL": "SageModeler Server URL:",
     "~DOCUMENT.ACTIONS.EXPERIMENT_NUM": "Experiment #",
+    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide",
     "~SIMULATION.GUIDE": "Include a guide",
-    "~SIMULATION.CONFIGURE_GUIDE": "configure guide",
-    "~DOCUMENT.CODAP_ACTIONS.GUIDE": "Guide"
+    "~SIMULATION.CONFIGURE_GUIDE": "configure guide"
 }

--- a/src/code/views/about-view.tsx
+++ b/src/code/views/about-view.tsx
@@ -63,7 +63,7 @@ export class AboutView extends React.Component<AboutViewProps, AboutViewState> {
   }
 
   private showHelp = () => {
-    const url = "https://building-models-resources.concord.org/SageIntro/sageIntro-v5_01.html";
+    const url = "https://sagemodeler.concord.org/help/index.html";
     const win = window.open(url, "_blank");
     (win as Window).focus();
   }

--- a/src/stylus/components/palette-inspector.styl
+++ b/src/stylus/components/palette-inspector.styl
@@ -65,6 +65,7 @@ pal-image-size()
         margin-right 1em
         vertical-align text-top
         float right
+        pointer-events none
     .palette-about-image-info
       margin-top 20px
       line-height 1.75em


### PR DESCRIPTION
- Prevent dragging of "info" image on palette [#169639253]
- Change link to help under the "about" menu [#169481216]
- Change "about" text under button to "help." [#169481178]

NOTE: poeditor reordered some of the entries in the json files causing the diffs to be noisy.  The only real change should be for `~MENU.ABOUT`