### PR TITLE
Fix graph button when node is selected [#170183697]

### DIFF
--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -113,6 +113,7 @@ $node-design-height = 94px
 
   .graph-source
     right 60px
+    z-index: 9
   .top
     height 72px
   .bottom


### PR DESCRIPTION
Adds a z-index to the graph button so that it is clickable when the node selection box is visible behind the node.