### PR TITLE
Add Simulation V2 which provides RK4 integration method

### DIFF
--- a/src/code/models/node.ts
+++ b/src/code/models/node.ts
@@ -43,7 +43,7 @@ export class Node extends GraphPrimitive {
 
   public type: string = "Node";
   public title: string;
-  public currentValue: number | null;
+  public currentValue: number;
 
   public readonly combineMethod: any; // TODO: get concrete type
   public readonly valueDefinedSemiQuantitatively: any; // TODO: get concrete type
@@ -207,11 +207,11 @@ export class Node extends GraphPrimitive {
     }
   }
 
-  public outLinks(relationType = null) {
+  public outLinks(relationType: string | null = null) {
     return _.filter(this.links, link => (link.sourceNode === this) && ((relationType === null) || (relationType === link.relation.type)));
   }
 
-  public inLinks(relationType = null) {
+  public inLinks(relationType: string | null = null) {
     return _.filter(this.links, link => (link.targetNode === this) && ((relationType === null) || (relationType === link.relation.type)));
   }
 

--- a/src/code/models/node.ts
+++ b/src/code/models/node.ts
@@ -43,7 +43,7 @@ export class Node extends GraphPrimitive {
 
   public type: string = "Node";
   public title: string;
-  public currentValue: number;
+  public currentValue: number | null;
 
   public readonly combineMethod: any; // TODO: get concrete type
   public readonly valueDefinedSemiQuantitatively: any; // TODO: get concrete type

--- a/src/code/models/simulation-v1.ts
+++ b/src/code/models/simulation-v1.ts
@@ -245,7 +245,6 @@ export class SimulationV1 {
 
 
   public run() {
-    console.log("simulation v1 start");
     console.time("sim-v1-run");
     this.stopRun = false;
     let time = 0;

--- a/src/code/models/simulation-v1.ts
+++ b/src/code/models/simulation-v1.ts
@@ -163,7 +163,7 @@ const SetAccumulatorValueFunction = function(nodeValues) {
   return this.currentValue = this.filterFinalValue(startValue + deltaValue);
 };
 
-export class Simulation {
+export class SimulationV1 {
   private opts: any;
   private nodes: any[];
   private duration: number;
@@ -246,6 +246,7 @@ export class Simulation {
 
   public run() {
     console.log("simulation v1 start");
+    console.time("sim-v1-run");
     this.stopRun = false;
     let time = 0;
     this.framesBundle = [];
@@ -324,6 +325,7 @@ export class Simulation {
     }
 
     this.onFrames(this.framesBundle);    // send all at once
+    console.timeEnd("sim-v1-run");
     return this.onEnd();
   }
 }

--- a/src/code/models/simulation-v2.ts
+++ b/src/code/models/simulation-v2.ts
@@ -142,7 +142,7 @@ const EvaluateAccumulatorValueFunction = function(timeStep) {
       deltaValue += relation.evaluate(inV, outV, sourceNode.max, this.max);
       break;
     case "transfer":
-      let transferValue = sourceNode.previousValue;
+      let transferValue = transferNode.previousValue;
       // can't overdraw non-negative collectors
       if (this.capNodeValues || sourceNode.limitMinValue) {
         transferValue = Math.min(transferValue, getTransferLimit(transferNode));

--- a/src/code/models/simulation-v2.ts
+++ b/src/code/models/simulation-v2.ts
@@ -6,7 +6,6 @@
  */
 const _ = require("lodash");
 const log = require("loglevel");
-import { urlParams } from "../utils/url-params";
 import { Node } from "./node";
 
 const LOOP_RESOLVING_STEPS = 30;

--- a/src/code/models/simulation-v2.ts
+++ b/src/code/models/simulation-v2.ts
@@ -9,6 +9,7 @@
 
 const _ = require("lodash");
 const log = require("loglevel");
+import { urlParams } from "../utils/url-params";
 
 const isScaledTransferNode = (node) => {
   if (!node.isTransfer) { return false; }
@@ -65,15 +66,16 @@ const filterFinalValue = function(value) {
 };
 
 // keep as function so it can be bound to a node
-const RangeIntegrationFunction = function(incrementAccumulators) {
-
+const EvaluateStaticRelationshipsFunction = function(loopId: string) {
   // if we've already calculated a currentValue for ourselves this step, return it
-  if (this.currentValue != null) { return this.currentValue; }
-
-  // if we have no incoming links, we always remain our previous or initial value
-  // collectors aren't calculated in this phase, but they do capture initial/previous values
-  const startValue = this.previousValue != null ? this.previousValue : this.initialValue;
-  if (this.isAccumulator && !incrementAccumulators) { return startValue; }
+  if (this.currentValue != null) {
+    return this.currentValue;
+  }
+  if (loopId === this.loopId) {
+    window.alert("Cycle detected!");
+    throw new Error("cycle detected");
+  }
+  this.loopId = loopId;
 
   // regular nodes and flow nodes only have 'range' and 'transfer-modifier' links
   const links = this.inLinks("range").concat(this.inLinks("transfer-modifier"));
@@ -82,9 +84,11 @@ const RangeIntegrationFunction = function(incrementAccumulators) {
   _.each(links, link => {
     if (!link.relation.isDefined) { return; }
     const { sourceNode } = link;
-    let inV = sourceNode.previousValue != null ? sourceNode.previousValue : sourceNode.initialValue;
-    inV = scaleInput(inV, sourceNode, this);
-    const outV = startValue;
+    if (sourceNode.currentValue == null) {
+      sourceNode.evaluateStaticRelationships(loopId);
+    }
+    const inV = scaleInput(sourceNode.currentValue, sourceNode, this);
+    const outV = this.previousValue;
     return inValues.push(link.relation.evaluate(inV, outV, link.sourceNode.max, this.max));
   });
 
@@ -92,7 +96,7 @@ const RangeIntegrationFunction = function(incrementAccumulators) {
   // otherwise, if any link points to a collector, it should use the scaled product
   const useScaledProduct = (this.combineMethod === "product") || this.isTransfer;
 
-  let value = inValues.length ? combineInputs(inValues, useScaledProduct) : startValue;
+  let value = inValues.length ? combineInputs(inValues, useScaledProduct) : this.previousValue;
 
   // can't transfer more than is present in source
   if (this.capNodeValues && isUnscaledTransferNode(this)) {
@@ -100,9 +104,7 @@ const RangeIntegrationFunction = function(incrementAccumulators) {
   }
 
   // if we need to cap, do it at end of all calculations
-  value = this.filterFinalValue(value);
-
-  return value;
+  this.currentValue = this.filterFinalValue(value);
 };
 
 // Sets the value of node.initialValue before the simulations starts. If there
@@ -112,42 +114,40 @@ const RangeIntegrationFunction = function(incrementAccumulators) {
 const SetInitialAccumulatorValueFunction = function() {
   const initialValueLinks = this.inLinks("initial-value");
   const inValues: any = [];
-  _.each(initialValueLinks, (link) => {
+  initialValueLinks.forEach(link => {
     if (!link.relation.isDefined) { return; }
     const { sourceNode } = link;
     return inValues.push(sourceNode.initialValue);
   });
   if (inValues.length) {
-    return this.initialValue = combineInputs(inValues);
+    this.initialValue = combineInputs(inValues);
   }
 };
 
 // keep as function so it can be bound to a node
-const SetAccumulatorValueFunction = function(nodeValues) {
+const EvaluateAccumulatorValueFunction = function(timeStep) {
   // collectors only have accumulator and transfer links
   const links = this.inLinks("accumulator").concat(this.inLinks("transfer")).concat(this.outLinks("transfer"));
 
-  const startValue = this.previousValue != null ? this.previousValue : this.initialValue;
-  if (!(links.length > 0)) { return startValue; }
+  if (links.length === 0) {
+    this.currentValue = this.previousValue;
+  }
 
   let deltaValue = 0;
   for (const link of links) {
     const {sourceNode, targetNode, relation, transferNode} = link;
-    const inV = nodeValues[sourceNode.key];
-    const outV = startValue;
+    const inV = sourceNode.previousValue;
+    const outV = this.previousValue;
     switch (relation.type) {
     case "accumulator":
-      deltaValue += relation.evaluate(inV, outV, sourceNode.max, this.max) / this.accumulatorInputScale;
+      deltaValue += relation.evaluate(inV, outV, sourceNode.max, this.max);
       break;
-
     case "transfer":
-      let transferValue = nodeValues[transferNode.key];
-
+      let transferValue = sourceNode.previousValue;
       // can't overdraw non-negative collectors
       if (this.capNodeValues || sourceNode.limitMinValue) {
         transferValue = Math.min(transferValue, getTransferLimit(transferNode));
       }
-
       if (sourceNode === this) {
         deltaValue -= transferValue;
       } else if (targetNode === this) {
@@ -156,14 +156,10 @@ const SetAccumulatorValueFunction = function(nodeValues) {
       break;
     }
   }
-
-  // accumulators hold their values in previousValue which is confusing
-  // (this done because the accumulator values is only computed on the first of the 20 loops in RangeIntegrationFunction)
-  // TODO: possibly change RangeIntegrationFunction function to make this more clear
-  return this.currentValue = this.filterFinalValue(startValue + deltaValue);
+  this.currentValue = this.filterFinalValue(this.previousValue + deltaValue * timeStep);
 };
 
-export class Simulation {
+export class SimulationV2 {
   private opts: any;
   private nodes: any[];
   private duration: number;
@@ -194,32 +190,29 @@ export class Simulation {
   }
 
   public decorateNodes() {
-    return _.each(this.nodes, node => {
+    this.nodes.forEach(node => {
       // make this a local node property (it may eventually be different per node)
       node.capNodeValues = this.capNodeValues;
       node.filterFinalValue = filterFinalValue.bind(node);
-      node._cumulativeValue = 0;  // for averaging
       // Create a bound method on this node.
       // Put the functionality here rather than in the class "Node".
       // Keep all the logic for integration here in one file for clarity.
-      node.getCurrentValue = RangeIntegrationFunction.bind(node);
-      node.setAccumulatorValue = SetAccumulatorValueFunction.bind(node);
-      return node.setInitialAccumulatorValue = SetInitialAccumulatorValueFunction.bind(node);
+      node.evaluateStaticRelationships = EvaluateStaticRelationshipsFunction.bind(node);
+      node.evaluateAccumulatorValue = EvaluateAccumulatorValueFunction.bind(node);
+      node.setInitialAccumulatorValue = SetInitialAccumulatorValueFunction.bind(node);
     });
   }
 
   public initializeValues(node) {
     node.currentValue = null;
-    return node.previousValue = null;
+    node.previousValue = null;
+    node.loopId = null;
   }
 
   public nextStep(node) {
     node.previousValue = node.currentValue;
-    return node.currentValue = null;
-  }
-
-  public evaluateNode(node, firstTime?) {
-    return node.currentValue = node.getCurrentValue(firstTime);
+    node.currentValue = null;
+    node.loopId = null;
   }
 
   // create an object representation of the current timeStep and add
@@ -245,77 +238,43 @@ export class Simulation {
 
 
   public run() {
-    console.log("simulation v1 start");
+    console.log("simulation v2 start");
     this.stopRun = false;
     let time = 0;
     this.framesBundle = [];
-    _.each(this.nodes, node => this.initializeValues(node));
+    const timeStep = (urlParams.timestep && Number(urlParams.timestep)) || 1;
+
+    this.nodes.forEach(node => this.initializeValues(node));
 
     const nodeNames = _.pluck(this.nodes, "title");
     this.onStart(nodeNames);
 
-    // For each step, we run the simulation many times, and then average the final few results.
-    // We first run the simulation 10 times. This has the effect of "pushing" a value from
-    // a parent node all the way down to all the descendants, while still allowing a simple
-    // integration function on each node that only pulls values from immediate parents.
-    // Note that this "pushing" may not do anything of value in a closed loop, as the values
-    // will simply move around the circle.
-    // We then run the simulation an additional 20 times, and average the 20 results to
-    // obtain a final value.
-    // The number "20" used is arbitrary, but large enough not to affect loops that we expect
-    // to see in Sage. In any loop, if the number of nodes in the loop and the number of times
-    // we iterate are not divisible by each other, we'll see imbalances, but the effect of the
-    // imbalance is smaller the more times we loop around.
-
-    // Changes to accomodate data flows:
-    //
     // There are now three types of nodes: normal, collector, and transfer and four types of links:
     // range, accumulator, transfer and transfer-modifier.  Transfer nodes are created automatically
     // between two accumulator nodes when the link type is set to transfer and are automatically
     // removed if the link is changed away from transfer or either of the nodes in the link
     // is changed from not being an accumulator.  Range links are the type of the original links -
-    // they are pure functions that transmit a value from a source (domain) to a target (range) node
-    // and are the only links evaluated during the 20 step cumulative value calculation.
-    // Once each node's cumulative value is obtained and then averaged across the nodes, the accumulator
-    // values are updated by checking the accumulator and transfer links into any accumulator node.
-    // The transfer links values are then modified by the transfer-modifier links which are links
-    // from the source node of a transfer link to the transfer node of the transfer link.
+    // they are pure functions that transmit a value from a source (domain) to a target (range) node.
 
-    const nodeValues = {};
-    const collectorNodes = _.filter(this.nodes, node => node.isAccumulator);
+    const allNodes = this.nodes;
+    const collectorNodes = this.nodes.filter(node => node.isAccumulator);
+    const staticNodes = this.nodes.filter(node => !node.isAccumulator);
 
-    // before the first step, set the initial values of all aqccumulators,
-    // in case they are linked with `initial-value` relationships
-    _.each(collectorNodes, node => node.setInitialAccumulatorValue());
+    // Before the first step, set the initial values of all accumulators,
+    // in case they are linked with `initial-value` relationships.
+    collectorNodes.forEach(node => node.setInitialAccumulatorValue());
+    allNodes.forEach(node => node.currentValue = node.initialValue);
+
+    staticNodes.forEach(node => node.evaluateStaticRelationships(node.key));
 
     const step = () => {
+      allNodes.forEach(node => this.nextStep(node));  // toggles previous / current val.
 
-      // update the accumulator/collector values on all but the first step
-      let i;
-      if (time !== 0) {
-        _.each(collectorNodes, node => node.setAccumulatorValue(nodeValues));
-      }
+      collectorNodes.forEach(node => node.evaluateAccumulatorValue(timeStep));
+      staticNodes.forEach(node => node.evaluateStaticRelationships(node.key));
 
-      // push values down chain
-      for (i = 0; i < 10; i++) {
-        _.each(this.nodes, node => this.nextStep(node));  // toggles previous / current val.
-        _.each(this.nodes, node => this.evaluateNode(node, i === 0));
-      }
-
-      // accumulate values for later averaging
-      for (i = 0; i < 20; i++) {
-        _.each(this.nodes, node => this.nextStep(node));
-        _.each(this.nodes, node => node._cumulativeValue += this.evaluateNode(node));
-      }
-
-      // calculate average and capture the instantaneous node values
-      _.each(this.nodes, (node) => {
-        nodeValues[node.key] = (node.currentValue = node._cumulativeValue / 20);
-        return node._cumulativeValue = 0;
-      });
-
-      // output before collectors are updated
-      return this.generateFrame(time++);
+      this.generateFrame(time);
+      time += timeStep;
     };
 
     // simulate each step

--- a/src/code/models/simulation-v2.ts
+++ b/src/code/models/simulation-v2.ts
@@ -72,8 +72,7 @@ const EvaluateStaticRelationshipsFunction = function(loopId: string) {
     return this.currentValue;
   }
   if (loopId === this.loopId) {
-    window.alert("Cycle detected!");
-    throw new Error("cycle detected");
+    throw new Error("loop detected");
   }
   this.loopId = loopId;
 
@@ -263,9 +262,18 @@ export class SimulationV2 {
     // Before the first step, set the initial values of all accumulators,
     // in case they are linked with `initial-value` relationships.
     collectorNodes.forEach(node => node.setInitialAccumulatorValue());
-    allNodes.forEach(node => node.currentValue = node.initialValue);
 
-    staticNodes.forEach(node => node.evaluateStaticRelationships(node.key));
+    // Move initial value to previousValue and use that to calculate initial state. Note that we only need to update
+    // static nodes. Accumulators will always have their initial value at time 0.
+    allNodes.forEach(node => node.previousValue = node.initialValue);
+
+
+    try {
+      staticNodes.forEach(node => node.evaluateStaticRelationships(node.key));
+    } catch (e) {
+      window.alert("Simulation engine error: " + e.message);
+      return;
+    }
 
     const step = () => {
       allNodes.forEach(node => this.nextStep(node));  // toggles previous / current val.

--- a/src/code/models/simulation-v2.ts
+++ b/src/code/models/simulation-v2.ts
@@ -4,20 +4,12 @@
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
-// transfer values are scaled if they have no modifier and
-// their source is an independent node (has no inputs)
-
 const _ = require("lodash");
 const log = require("loglevel");
 import { urlParams } from "../utils/url-params";
+import { Node } from "./node";
 
-interface DecoratedNode {
-  key: string;
-  previousValue: null | number;
-  currentValue: null | number;
-  loopId: string;
-  evaluateStaticRelationships: (loopId: string, inLoop: boolean) => void;
-}
+const LOOP_RESOLVING_STEPS = 30;
 
 // Valid time step is either integer number or a binary fraction (0.5, 0.25, 0.125, 0.0625, ...).
 // Binary fractions are required to avoid floating point precision errors when time steps are summed multiple times.
@@ -30,6 +22,8 @@ const isTimeStepValid = (timeStep) => {
   return (1 / timeStep) % 1 === 0 && isPowerOfTwo(1 / timeStep);
 };
 
+// transfer values are scaled if they have no modifier and
+// their source is an independent node (has no inputs)
 const isScaledTransferNode = (node) => {
   if (!node.isTransfer) { return false; }
   if (node.inLinks("transfer-modifier").length) { return false; }
@@ -70,155 +64,41 @@ const combineInputs = (inValues, useScaledProduct?) => {
   return numerator / denominator;
 };
 
-const getTransferLimit = (transferNode) => {
-  const {sourceNode} = transferNode != null ? transferNode.transferLink : undefined;
-  if (sourceNode) { return sourceNode.previousValue != null ? sourceNode.previousValue : sourceNode.initialValue; } else { return 0; }
-};
-
-// keep as function so it can be bound to a node
-const filterFinalValue = function(value) {
-  // limit max value
-  value = this.capNodeValues ? Math.min(this.max, value) : value;
-  // limit min value
-  const shouldLimitMinValue = this.capNodeValues || this.limitMinValue;
-  if (shouldLimitMinValue) { return Math.max(this.min, value); } else { return value; }
-};
-
-// keep as function so it can be bound to a node
-const EvaluateStaticRelationshipsFunction = function(loopId: string, inLoop: false) {
-  // if we've already calculated a currentValue for ourselves this step, return it
-  if (this.currentValue != null) {
-    return this.currentValue;
-  }
-  if (loopId === this.loopId) {
-    if (!inLoop) {
-      EvaluateLoopFunction(this.allNodes, loopId);
-    }
-  }
-  this.loopId = loopId;
-
-  // regular nodes and flow nodes only have 'range' and 'transfer-modifier' links
-  const links = this.inLinks("range").concat(this.inLinks("transfer-modifier"));
-
-  const inValues: any = [];
-  _.each(links, link => {
-    if (!link.relation.isDefined) { return; }
-    const { sourceNode } = link;
-    let sourceValue;
-
-    if (!inLoop) {
-      if (sourceNode.currentValue == null) {
-        sourceNode.evaluateStaticRelationships(loopId);
-      }
-      sourceValue = sourceNode.currentValue;
-    } else {
-      sourceValue = sourceNode.previousValue;
-    }
-
-    const inV = scaleInput(sourceValue, sourceNode, this);
-    const outV = this.previousValue;
-    return inValues.push(link.relation.evaluate(inV, outV, link.sourceNode.max, this.max));
-  });
-
-  // if the user has explicitly set the combination method, we use that
-  // otherwise, if any link points to a collector, it should use the scaled product
-  const useScaledProduct = (this.combineMethod === "product") || this.isTransfer;
-
-  let value = inValues.length ? combineInputs(inValues, useScaledProduct) : this.previousValue;
-
-  // can't transfer more than is present in source
-  if (this.capNodeValues && isUnscaledTransferNode(this)) {
-    value = Math.min(value, getTransferLimit(this));
-  }
-  // if we need to cap, do it at end of all calculations
-  this.currentValue = this.filterFinalValue(value);
-};
-
-const LOOP_RESOLVING_STEPS = 30;
-const EvaluateLoopFunction = (nodes: DecoratedNode[], loopId: string) => {
-  const loopNodes = nodes.filter(n => n.loopId = loopId);
-  const avg = {};
-  for (let i = 0; i < LOOP_RESOLVING_STEPS; i += 1) {
-    loopNodes.forEach(n => {
-      n.evaluateStaticRelationships(loopId, true);
-      if (avg[n.key] === undefined) {
-        avg[n.key] = 0;
-      }
-      avg[n.key] += n.currentValue!;
-    });
-    loopNodes.forEach(n => {
-      n.previousValue = n.currentValue;
-      n.currentValue = null;
-    });
-  }
-  loopNodes.forEach(n => {
-    n.currentValue = avg[n.key] / LOOP_RESOLVING_STEPS;
-  });
-};
-
 // Sets the value of node.initialValue before the simulations starts. If there
 // are inbound `initial-value` links, we request the initial values of the
 // source nodes (no calculations needed) and average them.
 // keep as function so it can be bound to a node
-const SetInitialAccumulatorValueFunction = function() {
-  const initialValueLinks = this.inLinks("initial-value");
-  const inValues: any = [];
+const setInitialAccumulatorValue = (node: Node) => {
+  const initialValueLinks = node.inLinks("initial-value");
+  const inValues: number[] = [];
   initialValueLinks.forEach(link => {
-    if (!link.relation.isDefined) { return; }
+    if (!link.relation.isDefined) {
+      return;
+    }
     const { sourceNode } = link;
     return inValues.push(sourceNode.initialValue);
   });
   if (inValues.length) {
-    this.initialValue = combineInputs(inValues);
+    node.initialValue = combineInputs(inValues);
   }
-};
-
-// keep as function so it can be bound to a node
-const GetAccumulatorDeltaFunction = function() {
-  // collectors only have accumulator and transfer links
-  const links = this.inLinks("accumulator").concat(this.inLinks("transfer")).concat(this.outLinks("transfer"));
-
-  if (links.length === 0) {
-    this.currentValue = this.previousValue;
-  }
-
-  let deltaValue = 0;
-  for (const link of links) {
-    const {sourceNode, targetNode, relation, transferNode} = link;
-    const inV = sourceNode.previousValue;
-    const outV = this.previousValue;
-    switch (relation.type) {
-    case "accumulator":
-      deltaValue += relation.evaluate(inV, outV, sourceNode.max, this.max);
-      break;
-    case "transfer":
-      let transferValue = transferNode.previousValue;
-      // can't overdraw non-negative collectors
-      if (this.capNodeValues || sourceNode.limitMinValue) {
-        transferValue = Math.min(transferValue, getTransferLimit(transferNode));
-      }
-      if (sourceNode === this) {
-        deltaValue -= transferValue;
-      } else if (targetNode === this) {
-        deltaValue += transferValue;
-      }
-      break;
-    }
-  }
-  return deltaValue;
 };
 
 export class SimulationV2 {
-  private opts: any;
-  private nodes: any[];
-  private duration: number;
+  public currentValue: {[key: string]: number | null} = {};
+  public previousValue: {[key: string]: number | null} = {};
+  public loopId: {[key: string]: string | null} = {};
+
+  public timeStep = (urlParams.timestep && Number(urlParams.timestep)) || 1;
+  public duration: number;
+  public nodes: Node[];
+  public staticNodes: Node[];
+  public collectorNodes: Node[];
   private capNodeValues: boolean;
+
+  private opts: any;
   private onStart: any;
   private onFrames: any;
   private onEnd: any;
-  private recalculateDesiredSteps: boolean;
-  private stopRun: boolean;
-  private framesBundle: any[];
 
   constructor(opts) {
     if (opts == null) { opts = {}; }
@@ -226,170 +106,261 @@ export class SimulationV2 {
     this.nodes          = this.opts.nodes      || [];
     this.duration       = this.opts.duration   || 10;
     this.capNodeValues  = this.opts.capNodeValues || false;
-    this.decorateNodes(); // extend nodes with integration methods
     this.onStart     = this.opts.onStart || (nodeNames => log.info(`simulation stated: ${nodeNames}`));
     this.onFrames    = this.opts.onFrames || (frames => log.info(`simulation frames: ${frames}`));
     this.onEnd       = this.opts.onEnd || (() => log.info("simulation end"));
-    this.recalculateDesiredSteps = false;
-    this.stopRun = false;
-  }
 
-  public decorateNodes() {
-    this.nodes.forEach(node => {
-      // make this a local node property (it may eventually be different per node)
-      node.capNodeValues = this.capNodeValues;
-      node.filterFinalValue = filterFinalValue.bind(node);
-      // Create a bound method on this node.
-      // Put the functionality here rather than in the class "Node".
-      // Keep all the logic for integration here in one file for clarity.
-      node.evaluateStaticRelationships = EvaluateStaticRelationshipsFunction.bind(node);
-      node.getAccumulatorDelta = GetAccumulatorDeltaFunction.bind(node);
-      node.setInitialAccumulatorValue = SetInitialAccumulatorValueFunction.bind(node);
-      node.allNodes = this.nodes;
-    });
-  }
-
-  public initializeValues(node) {
-    node.currentValue = null;
-    node.previousValue = null;
-    node.loopId = null;
-  }
-
-  public toggleCurrentPrevValues() {
-    this.nodes.forEach(node => {
-      node.previousValue = node.currentValue;
-      node.currentValue = null;
-      node.loopId = null;
-    });
-  }
-
-  // create an object representation of the current timeStep and add
-  // it to the current bundle of frames.
-  public generateFrame(time) {
-    const nodes = _.map(this.nodes, node =>
-      ({
-        title: node.title,
-        value: node.currentValue
-      })
-    );
-    const frame = {
-      time,
-      nodes
-    };
-
-    return this.framesBundle.push(frame);
-  }
-
-  public stop() {
-    return this.stopRun = true;
-  }
-
-
-  public run() {
-    console.log("simulation v2 start");
-    console.time("sim-v2-run");
-    const timeStep = (urlParams.timestep && Number(urlParams.timestep)) || 1;
-    if (!isTimeStepValid(timeStep)) {
-      window.alert(
-        "Invalid time step. Please use a whole number (1, 2, 3, ...) or binary fraction " +
-        "(0.5, 0.25, 0.125, 0.0625, ...) to avoid floating-point errors."
-      );
-      return;
-    }
-
-    this.stopRun = false;
-    let time = 0;
-    this.framesBundle = [];
-
-    this.nodes.forEach(node => this.initializeValues(node));
-
-    const nodeNames = _.pluck(this.nodes, "title");
-    this.onStart(nodeNames);
-
-    // There are now three types of nodes: normal, collector, and transfer and four types of links:
+    // There are now three types of nodes: normal / static, collector, and transfer and four types of links:
     // range, accumulator, transfer and transfer-modifier.  Transfer nodes are created automatically
     // between two accumulator nodes when the link type is set to transfer and are automatically
     // removed if the link is changed away from transfer or either of the nodes in the link
     // is changed from not being an accumulator.  Range links are the type of the original links -
     // they are pure functions that transmit a value from a source (domain) to a target (range) node.
+    this.staticNodes = this.nodes.filter(node => !node.isAccumulator);
+    this.collectorNodes = this.nodes.filter(node => node.isAccumulator);
 
-    const collectorNodes = this.nodes.filter(node => node.isAccumulator);
-    const staticNodes = this.nodes.filter(node => !node.isAccumulator);
+    if (!isTimeStepValid(this.timeStep)) {
+      window.alert(
+        "Invalid time step. Please use a whole number (1, 2, 3, ...) or binary fraction " +
+        "(0.5, 0.25, 0.125, 0.0625, ...) to avoid floating-point errors."
+      );
+    }
+  }
 
-    const evaluateStaticNodes = () => {
-      staticNodes.forEach(node => node.evaluateStaticRelationships(node.key));
+  public initializeValues() {
+    this.currentValue = {};
+    this.previousValue = {};
+    this.loopId = {};
+  }
+
+  public toggleCurrentPrevValues() {
+    this.nodes.forEach(n => {
+      this.previousValue[n.key] = this.currentValue[n.key];
+      this.currentValue[n.key] = null;
+      this.loopId[n.key] = null;
+    });
+  }
+
+  public filterFinalValue(node, value) {
+    // limit max value
+    value = this.capNodeValues ? Math.min(node.max, value) : value;
+    // limit min value
+    const shouldLimitMinValue = this.capNodeValues || node.limitMinValue;
+    if (shouldLimitMinValue) {
+      return Math.max(node.min, value);
+    } else {
+      return value;
+    }
+  }
+
+  public getTransferLimit(transferNode) {
+    const { sourceNode } = transferNode != null ? transferNode.transferLink : undefined;
+    if (sourceNode) { return this.previousValue[sourceNode.key] != null ? this.previousValue[sourceNode.key] : sourceNode.initialValue; } else { return 0; }
+  }
+
+  public evaluateStaticRelationships(node: Node, loopId: string, inLoop = false) {
+    // if we've already calculated a currentValue for ourselves this step, return it
+    if (this.currentValue[node.key] != null) {
+      return this.currentValue[node.key];
+    }
+    if (loopId === this.loopId[node.key]) {
+      if (!inLoop) {
+        this.evaluateStaticLoop(loopId);
+      }
+    }
+    this.loopId[node.key] = loopId;
+
+    // regular nodes and flow nodes only have 'range' and 'transfer-modifier' links
+    const links = node.inLinks("range").concat(node.inLinks("transfer-modifier"));
+    const inValues: number[] = [];
+
+    links.forEach(link => {
+      if (!link.relation.isDefined) {
+        return;
+      }
+      const { sourceNode } = link;
+      let sourceValue;
+
+      if (!inLoop) {
+        if (this.currentValue[sourceNode.key] == null) {
+          this.evaluateStaticRelationships(sourceNode, loopId);
+        }
+        sourceValue = this.currentValue[sourceNode.key];
+      } else {
+        sourceValue = this.previousValue[sourceNode.key];
+      }
+
+      const inV = scaleInput(sourceValue, sourceNode, node);
+      const outV = this.previousValue[node.key];
+      return inValues.push(link.relation.evaluate(inV, outV, link.sourceNode.max, node.max));
+    });
+
+    // if the user has explicitly set the combination method, we use that
+    // otherwise, if any link points to a collector, it should use the scaled product
+    const useScaledProduct = (node.combineMethod === "product") || node.isTransfer;
+
+    let value = inValues.length ? combineInputs(inValues, useScaledProduct) : this.previousValue[node.key];
+
+    // can't transfer more than is present in source
+    if (this.capNodeValues && isUnscaledTransferNode(node)) {
+      value = Math.min(value, this.getTransferLimit(node));
+    }
+    // if we need to cap, do it at end of all calculations
+    this.currentValue[node.key] = this.filterFinalValue(node, value);
+  }
+
+  public evaluateStaticLoop(loopId: string) {
+    const loopNodes = this.nodes.filter(n => this.loopId[n.key] = loopId);
+    const avg = {};
+    for (let i = 0; i < LOOP_RESOLVING_STEPS; i += 1) {
+      loopNodes.forEach(n => {
+        this.evaluateStaticRelationships(n, loopId, true);
+        if (avg[n.key] === undefined) {
+          avg[n.key] = 0;
+        }
+        avg[n.key] += this.currentValue[n.key];
+      });
+      loopNodes.forEach(n => {
+        this.previousValue[n.key] = this.currentValue[n.key];
+        this.currentValue[n.key] = null;
+      });
+    }
+    loopNodes.forEach(n => {
+      this.currentValue[n.key] = avg[n.key] / LOOP_RESOLVING_STEPS;
+    });
+  }
+
+  public getAccumulatorDelta(node: Node) {
+    // collectors only have accumulator and transfer links
+    const links = node.inLinks("accumulator").concat(node.inLinks("transfer")).concat(node.outLinks("transfer"));
+
+    if (links.length === 0) {
+      this.currentValue[node.key] = this.previousValue[node.key];
+    }
+
+    let deltaValue = 0;
+    for (const link of links) {
+      const {sourceNode, targetNode, relation, transferNode} = link;
+      const inV = this.previousValue[sourceNode.key];
+      const outV = this.previousValue[node.key];
+      switch (relation.type) {
+        case "accumulator":
+          deltaValue += relation.evaluate(inV, outV, sourceNode.max, node.max);
+          break;
+        case "transfer":
+          let transferValue = this.previousValue[transferNode.key] as number;
+          // can't overdraw non-negative collectors
+          if (this.capNodeValues || sourceNode.limitMinValue) {
+            transferValue = Math.min(transferValue, this.getTransferLimit(transferNode));
+          }
+          if (sourceNode === node) {
+            deltaValue -= transferValue;
+          } else if (targetNode === node) {
+            deltaValue += transferValue;
+          }
+          break;
+      }
+    }
+    return deltaValue;
+  }
+
+  // create an object representation of the current timeStep and add
+  // it to the current bundle of frames.
+  public generateFrame(time) {
+    return {
+      time,
+      nodes: this.nodes.map(node =>
+        ({
+          title: node.title,
+          value: this.currentValue[node.key]
+        })
+      )
     };
+  }
+
+  public evaluateStaticNodes() {
+    this.staticNodes.forEach(node => this.evaluateStaticRelationships(node, node.key));
+  }
+
+  public eulerStep() {
+    this.collectorNodes.forEach(node =>
+      this.currentValue[node.key] = this.filterFinalValue(node, this.previousValue[node.key]! + this.getAccumulatorDelta(node) * this.timeStep)
+    );
+    this.evaluateStaticNodes();
+  }
+
+  public rk4Step() {
+    // See: https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods#The_Runge%E2%80%93Kutta_method
+    // Note that static nodes don't require any integration. It's all about collectors.
+    // If you take a look at RK4 references / descriptions, y function is a collector value,
+    // delta y is collector delta in each step.
+
+    // Store collectors previous values, they're going to be useful during all the calculations.
+    const prevValue = this.collectorNodes.map(node => this.previousValue[node.key]);
+
+    // Calculate k1, k2, k3 and k4, which are partial deltas, used in the final equation.
+    // k1 = dt * f(tn, yn)
+    const k1 = this.collectorNodes.map(node => this.timeStep * this.getAccumulatorDelta(node));
+
+    // k2 = dt * f(tn + 0.5 * dt, yn + 0.5 * k1)
+    // We need to update y values first.
+    this.collectorNodes.forEach((node, idx) =>
+      this.currentValue[node.key] = this.filterFinalValue(node, prevValue[idx]! + 0.5 * k1[idx])
+    );
+    this.evaluateStaticNodes();
+    // Calc k2. Toggle current and prev values first, as getAccumulatorDelta() uses previous value.
+    this.toggleCurrentPrevValues();
+    const k2 = this.collectorNodes.map(node => this.timeStep * this.getAccumulatorDelta(node));
+
+    // k3 = dt * f(tn + 0.5 * dt, yn + 0.5 * k2)
+    // We need to update y values first.
+    this.collectorNodes.forEach((node, idx) =>
+      this.currentValue[node.key] = this.filterFinalValue(node, prevValue[idx]! + 0.5 * k2[idx])
+    );
+    this.evaluateStaticNodes();
+    this.toggleCurrentPrevValues();
+    // Calc k3. Toggle current and prev values first, as getAccumulatorDelta() uses previous value.
+    const k3 = this.collectorNodes.map(node => this.timeStep * this.getAccumulatorDelta(node));
+
+    // k4 = dt * f(tn + dt, yn * k3)
+    // We need to update y values first.
+    this.collectorNodes.forEach((node, idx) =>
+      this.currentValue[node.key] = this.filterFinalValue(node, prevValue[idx]! + k3[idx])
+    );
+    this.evaluateStaticNodes();
+    this.toggleCurrentPrevValues();
+    // Calc k4. Toggle current and prev values first, as getAccumulatorDelta() uses previous value.
+    const k4 = this.collectorNodes.map(node => this.timeStep * this.getAccumulatorDelta(node));
+
+    // Finally calculate yn+1
+    this.collectorNodes.forEach((node, idx) =>
+      this.currentValue[node.key] = this.filterFinalValue(node, prevValue[idx]! + (k1[idx] + 2 * k2[idx] + 2 * k3[idx] + k4[idx]) / 6)
+    );
+    this.evaluateStaticNodes();
+  }
+
+  public run() {
+    console.time("sim-v2-run");
+
+    const framesBundle: any[] = [];
+
+    this.initializeValues();
+
+    const nodeNames = _.pluck(this.nodes, "title");
+    this.onStart(nodeNames);
 
     // Before the first step, set the initial values of all accumulators,
     // in case they are linked with `initial-value` relationships.
-    collectorNodes.forEach(node => node.setInitialAccumulatorValue());
+    this.collectorNodes.forEach(node => setInitialAccumulatorValue(node));
     // Calculate initial state.
     // All nodes should have set previous value correctly.
-    this.nodes.forEach(node => node.previousValue = node.initialValue);
+    this.nodes.forEach(node => this.previousValue[node.key] = node.initialValue);
     // Collectors should be just set to their initial value (t=0 value).
-    collectorNodes.forEach(node => node.currentValue = node.initialValue);
+    this.collectorNodes.forEach(node => this.currentValue[node.key] = node.initialValue);
     // Static nodes should be evaluated at t=0.
-    evaluateStaticNodes();
+    this.evaluateStaticNodes();
 
-    const eulerStep = () => {
-      collectorNodes.forEach(node =>
-        node.currentValue = node.filterFinalValue(node.previousValue + node.getAccumulatorDelta() * timeStep)
-      );
-      evaluateStaticNodes();
-    };
-
-    const rk4Step = () => {
-      // See: https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta_methods#The_Runge%E2%80%93Kutta_method
-      // Note that static nodes don't require any integration. It's all about collectors.
-      // If you take a look at RK4 references / descriptions, y function is a collector value,
-      // delta y is collector delta in each step.
-
-      // Store collectors previous values, they're going to be useful during all the calculations.
-      const prevValue = collectorNodes.map(node => node.previousValue);
-
-      // Calculate k1, k2, k3 and k4, which are partial deltas, used in the final equation.
-      // k1 = dt * f(tn, yn)
-      const k1 = collectorNodes.map(node => timeStep * node.getAccumulatorDelta());
-
-      // k2 = dt * f(tn + 0.5 * dt, yn + 0.5 * k1)
-      // We need to update y values first.
-      collectorNodes.forEach((node, idx) =>
-        node.currentValue = node.filterFinalValue(prevValue[idx] + 0.5 * k1[idx])
-      );
-      evaluateStaticNodes();
-      // Calc k2. Toggle current and prev values first, as getAccumulatorDelta() uses previous value.
-      this.toggleCurrentPrevValues();
-      const k2 = collectorNodes.map(node => timeStep * node.getAccumulatorDelta());
-
-      // k3 = dt * f(tn + 0.5 * dt, yn + 0.5 * k2)
-      // We need to update y values first.
-      collectorNodes.forEach((node, idx) =>
-        node.currentValue = node.filterFinalValue(prevValue[idx] + 0.5 * k2[idx])
-      );
-      evaluateStaticNodes();
-      this.toggleCurrentPrevValues();
-      // Calc k3. Toggle current and prev values first, as getAccumulatorDelta() uses previous value.
-      const k3 = collectorNodes.map(node => timeStep * node.getAccumulatorDelta());
-
-      // k4 = dt * f(tn + dt, yn * k3)
-      // We need to update y values first.
-      collectorNodes.forEach((node, idx) =>
-        node.currentValue = node.filterFinalValue(prevValue[idx] + k3[idx])
-      );
-      evaluateStaticNodes();
-      this.toggleCurrentPrevValues();
-      // Calc k4. Toggle current and prev values first, as getAccumulatorDelta() uses previous value.
-      const k4 = collectorNodes.map(node => timeStep * node.getAccumulatorDelta());
-
-      // Finally calculate yn+1
-      collectorNodes.forEach((node, idx) =>
-        node.currentValue = node.filterFinalValue(prevValue[idx] + (k1[idx] + 2 * k2[idx] + 2 * k3[idx] + k4[idx]) / 6)
-      );
-      evaluateStaticNodes();
-    };
-
-    const step = urlParams.integration === "rk4" ? rk4Step : eulerStep;
-
+    let time = 0;
     while (time < this.duration) {
       // Generate frames (notify rest of the app about new data) only when time is a whole number (0, 1, 2, 3, ...).
       // Note that because of the floating inaccuracy, we can't simply expect time % 1 to be equal 0.
@@ -397,17 +368,26 @@ export class SimulationV2 {
       // That's why it's recommended to use time steps that can be precisely represented using binary system, like
       // 1/2 (0.5), 1/4 (0.25), 1/8 (0.125), 1/16 (0.0625) and so on.
       const wholeNumberDiff = Math.min(time % 1, 1 - (time % 1));
-      if (wholeNumberDiff < timeStep * 0.1) {
+      if (wholeNumberDiff < this.timeStep * 0.1) {
         time = Math.round(time); // just in case non-binary fraction is allowed
-        this.generateFrame(time);
+        framesBundle.push(this.generateFrame(time));
       }
       this.toggleCurrentPrevValues();
-      step();
-      time += timeStep;
+
+      if (urlParams.integration === "rk4") {
+        this.rk4Step();
+      } else {
+        this.eulerStep();
+      }
+
+      time += this.timeStep;
     }
 
-    this.onFrames(this.framesBundle);    // send all at once
+    this.nodes.forEach(n => n.currentValue = this.currentValue[n.key] || n.initialValue);
+    this.onFrames(framesBundle); // send all at once
+
     console.timeEnd("sim-v2-run");
-    return this.onEnd();
+
+    this.onEnd();
   }
 }

--- a/src/code/stores/simulation-store.tsx
+++ b/src/code/stores/simulation-store.tsx
@@ -6,7 +6,7 @@ const Reflux = require("reflux");
 import { AppSettingsStore, AppSettingsActions } from "./app-settings-store";
 import { ImportActions } from "../actions/import-actions";
 import { GraphActions } from "../actions/graph-actions";
-import { Simulation } from "../models/simulation";
+import { SimulationV1 } from "../models/simulation-v1";
 import { SimulationV2 } from "../models/simulation-v2";
 import { urlParams } from "../utils/url-params";
 import { TimeUnits } from "../utils/time-units";
@@ -208,7 +208,7 @@ export const SimulationStore = Reflux.createStore({
       // it is run to clear pre-saved data after first load
       this.settings.modelIsRunning = true;
       this.notifyChange();
-      const SimulationClass = urlParams.simulation === "v2" ? SimulationV2 : Simulation;
+      const SimulationClass = urlParams.simulation === "v2" ? SimulationV2 : SimulationV1;
       this.currentSimulation = new SimulationClass({
         nodes: this.nodes,
         duration: this.simulationStepCount(),

--- a/src/code/stores/simulation-store.tsx
+++ b/src/code/stores/simulation-store.tsx
@@ -1,3 +1,5 @@
+
+
 const _ = require("lodash");
 const Reflux = require("reflux");
 
@@ -5,6 +7,8 @@ import { AppSettingsStore, AppSettingsActions } from "./app-settings-store";
 import { ImportActions } from "../actions/import-actions";
 import { GraphActions } from "../actions/graph-actions";
 import { Simulation } from "../models/simulation";
+import { SimulationV2 } from "../models/simulation-v2";
+import { urlParams } from "../utils/url-params";
 import { TimeUnits } from "../utils/time-units";
 import { tr } from "../utils/translate";
 import { Mixin } from "../mixins/components";
@@ -204,7 +208,8 @@ export const SimulationStore = Reflux.createStore({
       // it is run to clear pre-saved data after first load
       this.settings.modelIsRunning = true;
       this.notifyChange();
-      this.currentSimulation = new Simulation({
+      const SimulationClass = urlParams.simulation === "v2" ? SimulationV2 : Simulation;
+      this.currentSimulation = new SimulationClass({
         nodes: this.nodes,
         duration: this.simulationStepCount(),
         capNodeValues: this.settings.capNodeValues,

--- a/src/code/stores/simulation-store.tsx
+++ b/src/code/stores/simulation-store.tsx
@@ -211,6 +211,8 @@ export const SimulationStore = Reflux.createStore({
       const SimulationClass = urlParams.simulation === "v2" ? SimulationV2 : SimulationV1;
       this.currentSimulation = new SimulationClass({
         nodes: this.nodes,
+        timeStep: urlParams.timestep,
+        integrationMethod: urlParams.integration,
         duration: this.simulationStepCount(),
         capNodeValues: this.settings.capNodeValues,
 

--- a/src/code/stores/simulation-store.tsx
+++ b/src/code/stores/simulation-store.tsx
@@ -241,7 +241,7 @@ export const SimulationStore = Reflux.createStore({
         }
       });
 
-      return this.currentSimulation.run();
+      this.currentSimulation.run();
     }
   },
 

--- a/src/code/utils/url-params.ts
+++ b/src/code/utils/url-params.ts
@@ -21,6 +21,8 @@ export interface UrlParams {
   lang?: string;
   showTopology?: string;
   enableAllBelowZero?: string;
+  simulation?: string;
+  timestep?: number;
 }
 
 export const urlParams: UrlParams = params;

--- a/src/code/utils/url-params.ts
+++ b/src/code/utils/url-params.ts
@@ -23,6 +23,7 @@ export interface UrlParams {
   enableAllBelowZero?: string;
   simulation?: string;
   timestep?: number;
+  integration?: string;
 }
 
 export const urlParams: UrlParams = params;

--- a/test/simulation-test.ts
+++ b/test/simulation-test.ts
@@ -18,7 +18,7 @@ const { expect }         = chai;
 import { Link } from "../src/code/models/link";
 import { Node } from "../src/code/models/node";
 import { TransferModel } from "../src/code/models/transfer";
-import { Simulation } from "../src/code/models/simulation";
+import { SimulationV1 } from "../src/code/models/simulation-v1";
 import { Relationship } from "../src/code/models/relationship";
 import { RelationFactory } from "../src/code/models/relation-factory";
 
@@ -66,7 +66,7 @@ describe("Simulation", () => {
 
   describe("the constructor", () => {
     beforeEach(() => {
-      this.simulation = new Simulation(this.arguments);
+      this.simulation = new SimulationV1(this.arguments);
     });
 
     it("makes a configured instance", () => {
@@ -87,7 +87,7 @@ describe("Simulation", () => {
         };
 
         LinkNodes(this.nodeA, this.nodeB, { type: "range", formula: this.formula });
-        this.simulation = new Simulation(this.arguments);
+        this.simulation = new SimulationV1(this.arguments);
       });
 
       it("the link formula should work", () => {
@@ -277,7 +277,7 @@ describe("Simulation", () => {
               node = nodes[key];
               nodeArray.push(node);
             }
-            const simulation = new Simulation({
+            const simulation = new SimulationV1({
               nodes: nodeArray,
               duration: j + 1,
               capNodeValues: scenario.cap === true
@@ -308,7 +308,7 @@ describe("Simulation", () => {
         };
 
         LinkNodes(this.nodeA, this.nodeB, { type: "range", formula: this.formula });
-        this.simulation = new Simulation(this.arguments);
+        this.simulation = new SimulationV1(this.arguments);
       });
 
       describe("when the input is SQ and the output is Q", () => {
@@ -363,7 +363,7 @@ describe("Simulation", () => {
           duration: 2
         };
 
-        this.simulation = new Simulation(this.arguments);
+        this.simulation = new SimulationV1(this.arguments);
       });
 
       describe("should transfer appropriate amount from the source node to the target node", () => {

--- a/test/simulation-v1-test.ts
+++ b/test/simulation-v1-test.ts
@@ -55,7 +55,7 @@ const asyncListenTest = (done, action, func) => {
   });
 };
 
-describe("Simulation", () => {
+describe("Simulation V1", () => {
   beforeEach(() => {
     this.nodes     = [];
     this.arguments = {

--- a/test/simulation-v2-test.ts
+++ b/test/simulation-v2-test.ts
@@ -1,0 +1,494 @@
+const _ = require("lodash");
+
+const g = global as any;
+
+g.window = { location: "" };
+g.window.performance = {
+  now() {
+    return Date.now();
+  }
+};
+g.requestAnimationFrame = callback => setTimeout(callback, 1);
+
+import * as chai from "chai";
+chai.config.includeStack = true;
+
+const { expect }         = chai;
+
+import { Link } from "../src/code/models/link";
+import { Node } from "../src/code/models/node";
+import { TransferModel } from "../src/code/models/transfer";
+import { SimulationV2 } from "../src/code/models/simulation-v2";
+import { Relationship } from "../src/code/models/relationship";
+import { RelationFactory } from "../src/code/models/relation-factory";
+
+import { GraphStore } from "../src/code/stores/graph-store";
+import { SimulationStore, SimulationActions } from "../src/code/stores/simulation-store";
+
+const CodapHelper = require("./codap-helper");
+
+const LinkNodes = (sourceNode, targetNode, relationSpec) => {
+  const link = new Link({
+    title: "function",
+    sourceNode,
+    targetNode,
+    relation: new Relationship(relationSpec)
+  });
+  sourceNode.addLink(link);
+  targetNode.addLink(link);
+  if (link.relation.type === "transfer") {
+    link.transferNode = new TransferModel({});
+    link.transferNode.setTransferLink(link);
+  }
+  return link;
+};
+
+const asyncListenTest = (done, action, func) => {
+  const stopListening = action.listen(function(args) { // tslint:disable-line:only-arrow-functions
+    try {
+      func.apply(null, arguments);
+      done();
+    } catch (ex) {
+      done(ex);
+    }
+    stopListening();
+  });
+};
+
+describe("Simulation V2", () => {
+  beforeEach(() => {
+    this.nodes     = [];
+    this.arguments = {
+      nodes: this.nodes,
+      duration: 5
+    };
+  });
+
+  describe("the constructor", () => {
+    beforeEach(() => {
+      this.simulation = new SimulationV2(this.arguments);
+    });
+
+    it("makes a configured instance", () => {
+      this.simulation.duration.should.equal(this.arguments.duration);
+      this.simulation.nodes.should.equal(this.arguments.nodes);
+    });
+  });
+
+  describe("run", () => {
+    describe("for a simple graph A(10) -0.1-> B(0) for 10 iterations", () => {
+      beforeEach(() => {
+        this.nodeA    = new Node({initialValue: 10});
+        this.nodeB    = new Node({initialValue: 0 });
+        this.formula  = "0.1 * in";
+        this.arguments = {
+          nodes: [this.nodeA, this.nodeB],
+          duration: 10
+        };
+
+        LinkNodes(this.nodeA, this.nodeB, { type: "range", formula: this.formula });
+        this.simulation = new SimulationV2(this.arguments);
+      });
+
+      it("the link formula should work", () => {
+        this.nodeB.inLinks().length.should.equal(1);
+      });
+
+      describe("the result", () =>
+        it("should give B 10 at the end", () => {
+          this.simulation.run();
+          this.nodeB.currentValue.should.equal(1);
+        })
+      );
+    });
+
+    // We can describe each scenario as an object:
+    // Each single-letter key is a node.
+    // Values can be:
+    //  * `20` (number for independent variables)
+    //  * `x+` (string for initial value for collectors)
+    //  * `x*` (string for initial value when nodes uses`product` for `combineMethod`)
+    //  * null (dependent variables).
+    // Each two-letter node is a link, with the formula for the link.
+    // Results is an array of arbitrary length, describing the expected result for each
+    // node on each step.
+    describe("for other scenarios", () => {
+      const scenarios = [
+        // 0: unlinked nodes should retain their initial values
+        {A: 0, B: 50, C: 100, D: "0+", E: "50+", F: "100+",
+        results: [
+          [0, 50, 100, 0, 50, 100],
+          [0, 50, 100, 0, 50, 100]
+        ]},
+
+        // 1: cascade independent and dependent variables (A->B->C)
+        {A: 50, B: 40, C: 30, AB: "1 * in", BC: "0.1 * in",
+        results: [
+          [50, 50, 5],
+          [50, 50, 5]
+        ]},
+
+        // 2: cascade independent and dependent variables with negative relationship (A->B->C)
+        {A: 50, B: 40, C: 30, AB: "0.1 * in", BC: "-1 * in",
+        results: [
+          [50, 5, -5],
+          [50, 5, -5]
+        ]},
+
+        // 3: basic collector (A->[B])
+        {A: 5, B: "50+", AB: "1 * in",
+        results: [
+          [5, 50],
+          [5, 55],
+          [5, 60]
+        ]},
+
+        // 4: basic collector with feedback (A<->[B])
+        {A: 10, B: "50+", AB: "1 * in", BA: "1 * in",
+        results: [
+          [50, 50],
+          [100, 100],
+          [200, 200]
+        ]},
+
+        // 5: three-node graph (>-) with averaging
+        {A: 10, B: 20, C: null, AC: "1 * in", BC: "1 * in",
+        results: [
+          [10, 20, 15],
+          [10, 20, 15]
+        ]},
+
+        // 6: three-node graph (>-) with non-linear averaging
+        {A: 10, B: 20, C: null, AC: "1 * in", BC: "0.1 * in",
+        results: [
+          [10, 20, 6],
+          [10, 20, 6]
+        ]},
+
+        // 7: three-node graph with collector (>-[C])
+        {A: 10, B: 20, C: "0+", AC: "1 * in", BC: "0.1 * in",
+        results: [
+          [10, 20, 0],
+          [10, 20, 12],
+          [10, 20, 24]
+        ]},
+
+        // 8: three-node graph with collector (>-[C]) and negative relationship
+        {A: 10, B: 1, C: "0+", AC: "1 * in", BC: "-1 * in",
+        results: [
+          [10, 1, 0],
+          [10, 1, 9],
+          [10, 1, 18]
+        ]},
+
+        // 9: four-node graph with collector (>-[D]) and scaled product combination
+        {A: 50, B: 50, C: "0*", D: "0+", AC: "1 * in", BC: "1 * in", CD: "1 * in",
+        results: [
+          [50, 50, 25, 0],
+          [50, 50, 25, 25],
+          [50, 50, 25, 50]
+        ]},
+
+        // *** Tests for graphs with bounded ranges ***
+        // Note most nodes have min:0 and max:100 by default
+        // But collectors have a default max of 1000
+        // 10: basic collector (A->[B])
+        {A: 30, B: "900+", AB: "1 * in",
+        cap: true,
+        results: [
+          [30, 900],
+          [30, 930],
+          [30, 960],
+          [30, 990],
+          [30, 1000]
+        ]},
+
+        // 11: basic subtracting collector (A- -1 ->[B])
+        {A: 40, B: "90+", AB: "-1 * in",
+        cap: true,
+        results: [
+          [40, 90],
+          [40, 50],
+          [40, 10],
+          [40, 0]
+        ]},
+
+        // 12: basic independent and dependent nodes (A->B)
+        {A: 120, B: 0, AB: "1 * in",
+        cap: true,
+        results: [
+          [100, 100]
+        ]},
+
+        // *** Collector initial-value tests ***
+
+        // 13: (A-init->B+)
+        {A: 10, B: "50+", AB: "initial-value",
+        results: [
+          [10, 10],
+          [10, 10]
+        ]},
+
+        // 14: A and B averageing initial values >- (A-init->C+, B-init->C+)
+        {A: 10, B: 20, C: "50+", AC: "initial-value", BC: "initial-value",
+        results: [
+          [10, 20, 15],
+          [10, 20, 15]
+        ]},
+
+        // 15: Setting initial values, and accumulating >- (A-init->C+, B->C+)
+        {A: 10, B: 20, C: "50+", AC: "initial-value", BC: "1 * in",
+        results: [
+          [10, 20, 10],
+          [10, 20, 30]
+        ]}
+      ];
+
+      _.each(scenarios, (scenario, i) =>
+        it(`should compute scenario ${i} correctly`, () => {
+          let key, node;
+          const nodes = {};
+          for (key in scenario) {
+            let isAccumulator;
+            const value = scenario[key];
+            if (key.length === 1) {
+              isAccumulator = (typeof value === "string") && ~value.indexOf("+"); // tslint:disable-line:no-bitwise
+              const isProduct = (typeof value === "string") && ~value.indexOf("*"); // tslint:disable-line:no-bitwise
+              const combineMethod = isProduct ? "product" : "average";
+              nodes[key] = new Node({title: key, initialValue: parseInt(value, 10), combineMethod, isAccumulator});
+            } else if (key.length === 2) {
+              let type;
+              const node1 = nodes[key[0]];
+              const node2 = nodes[key[1]];
+              let func;
+              if (node2.isAccumulator) {
+                type = value === "initial-value" ? value : "accumulator";
+                if (type === "initial-value") { func = () => ({}); }
+              } else {
+                type = "range";
+              }
+              LinkNodes(node1, node2, { type, formula: value, func });
+            }
+          }
+          for (let j = 0; j < scenario.results.length; j++) {
+            const result = scenario.results[j];
+            const nodeArray: Node[] = [];
+            for (key in nodes) {
+              node = nodes[key];
+              nodeArray.push(node);
+            }
+            const simulation = new SimulationV2({
+              nodes: nodeArray,
+              duration: j,
+              capNodeValues: scenario.cap === true
+            });
+
+            if (result === false) {
+              expect(simulation.run.bind(simulation)).to.throw("Graph not valid");
+            } else {
+              simulation.run();
+              for (let k = 0; k < nodeArray.length; k++) {
+                node = nodeArray[k];
+                expect(node.currentValue, `Step: ${j}, Node: ${node.title}`).to.be.closeTo(result[k], 0.000001);
+              }
+            }
+          }
+        })
+      );
+    });
+
+    describe("for mixed semiquantitative and quantitative nodes", () => {
+      beforeEach(() => {
+        this.nodeA    = new Node({initialValue: 20});
+        this.nodeB    = new Node({initialValue: 50});
+        this.formula  = "1 * in";
+        this.arguments = {
+          nodes: [this.nodeA, this.nodeB],
+          duration: 1
+        };
+
+        LinkNodes(this.nodeA, this.nodeB, { type: "range", formula: this.formula });
+        this.simulation = new SimulationV2(this.arguments);
+      });
+
+      describe("when the input is SQ and the output is Q", () => {
+        beforeEach(() => {
+          this.nodeA.valueDefinedSemiQuantitatively = true;
+          this.nodeB.valueDefinedSemiQuantitatively = false;
+        });
+
+        // sanity check
+        it("should be no different when both have the same range", () => {
+          this.simulation.run();
+          this.nodeB.currentValue.should.equal(20);
+        });
+
+        it("should scale between output's min and max", () => {
+          this.nodeB.min = 50;
+          this.nodeB.max = 100;
+          this.simulation.run();
+          this.nodeB.currentValue.should.equal(60);
+        });
+      });
+
+      describe("when the input is Q and the output is SQ", () => {
+        beforeEach(() => {
+          this.nodeA.valueDefinedSemiQuantitatively = false;
+          this.nodeB.valueDefinedSemiQuantitatively = true;
+        });
+
+        // sanity check
+        it("should be no different when both have the same range", () => {
+          this.simulation.run();
+          this.nodeB.currentValue.should.equal(20);
+        });
+
+        it("should scale between output's min and max", () => {
+          this.nodeA.min = 0;
+          this.nodeA.max = 50;
+          this.simulation.run();
+          this.nodeB.currentValue.should.equal(40);
+        });
+      });
+    });
+
+    describe("for transfer nodes", () => {
+      beforeEach(() => {
+        this.nodeA    = new Node({title: "A", isAccumulator: true, initialValue: 100});
+        this.nodeB    = new Node({title: "B", isAccumulator: true, initialValue: 50});
+        this.transferLink = LinkNodes(this.nodeA, this.nodeB, RelationFactory.transferred);
+        this.transferNode = this.transferLink.transferNode;
+        this.arguments = {
+          nodes: [this.nodeA, this.nodeB, this.transferNode],
+          duration: 1
+        };
+
+        this.simulation = new SimulationV2(this.arguments);
+      });
+
+      describe("should transfer appropriate amount from the source node to the target node", () => {
+
+        // sanity check
+        it("should transfer (transwerNode.initialValue 50) to B with no transfer-modifier", () => {
+          this.transferNode.initialValue = 50;
+          this.simulation.run();
+          expect(this.nodeA.currentValue, `Node: ${this.nodeA.title}`).to.be.closeTo(50, 0.000001);
+          expect(this.nodeB.currentValue, `Node: ${this.nodeB.title}`).to.be.closeTo(100, 0.000001);
+        });
+
+        // sanity check
+        it("should transfer (transwerNode.initialValue 80) to B with no transfer-modifier", () => {
+          this.transferNode.initialValue = 80;
+          this.simulation.run();
+          expect(this.nodeA.currentValue, `Node: ${this.nodeA.title}`).to.be.closeTo(20, 0.000001);
+          expect(this.nodeB.currentValue, `Node: ${this.nodeB.title}`).to.be.closeTo(130, 0.000001);
+        });
+
+        // sanity check
+        it("should limit the transfer to the quantity in the source node", () => {
+          this.nodeA.initialValue = 5;
+          this.nodeA.capNodeValues = (this.nodeB.capNodeValues = true);
+          this.simulation.duration = 12;
+          this.simulation.run();
+          expect(this.nodeA.currentValue, `Node: ${this.nodeA.title}`).to.be.closeTo(0, 0.000001);
+          expect(this.nodeB.currentValue, `Node: ${this.nodeB.title}`).to.be.closeTo(55, 0.000001);
+        });
+
+        // sanity check
+        // transfer 10% of source (2) per step. 20 - 2 = 18 ,  50 + 2 = 52
+        it("should transfer the appropriate percentage of the source node with a transfer-modifer", () => {
+          this.nodeA.initialValue = 20;
+          this.transferModifier = LinkNodes(this.nodeA, this.transferNode, RelationFactory.proportionalSourceMore);
+          this.simulation.duration = 1;
+          this.simulation.run();
+          expect(this.nodeA.currentValue, `Node: ${this.nodeA.title}`).to.be.closeTo(18, 0.000001);
+          expect(this.nodeB.currentValue, `Node: ${this.nodeB.title}`).to.be.closeTo(52, 0.000001);
+        });
+      });
+    });
+  });
+});
+
+
+describe("The SimulationStore, with a network in the GraphStore", () => {
+  beforeEach(() => {
+    CodapHelper.Stub();
+
+    this.nodeA    = new Node({title: "A", initialValue: 10});
+    this.nodeB    = new Node({title: "B", initialValue: 0 });
+    this.formula  = "0.1 * in";
+
+    GraphStore.init();
+
+    GraphStore.addNode(this.nodeA);
+    GraphStore.addNode(this.nodeB);
+
+    LinkNodes(this.nodeA, this.nodeB, { type: "range", formula: this.formula });
+  });
+
+  afterEach(() => CodapHelper.UnStub());
+
+  describe("for a fast simulation for 10 iterations", () => {
+
+    beforeEach(() => {
+      SimulationStore.settings.experimentFrame = 0;
+      SimulationActions.setDuration.trigger(10);
+      SimulationActions.expandSimulationPanel.trigger();
+    });
+
+    it("should start simulation when experiment is created", (done) => {
+
+      asyncListenTest(done, SimulationActions.simulationStarted, (nodeNames) => {
+        nodeNames.length.should.equal(2);
+      });
+
+      SimulationActions.createExperiment();
+    });
+
+    it("should call recordingDidStart with the node names", (done) => {
+      asyncListenTest(done, SimulationActions.recordingDidStart, nodeNames => nodeNames.should.eql(["A", "B"]));
+
+      SimulationActions.createExperiment();
+      SimulationActions.recordPeriod();
+    });
+
+    it("should call simulationFramesCreated with all the step values", (done) => {
+
+      asyncListenTest(done, SimulationActions.recordingFramesCreated, (data) => {
+
+          data.length.should.equal(10);
+
+          const frame0 = data[0];
+          frame0.time.should.equal(1);
+          frame0.nodes.should.eql([ { title: "A", value: 10 }, { title: "B", value: 1 } ]);
+
+          const frame9 = data[9];
+          frame9.time.should.equal(10);
+          frame9.nodes.should.eql([ { title: "A", value: 10 }, { title: "B", value: 1 } ]);
+      });
+
+      SimulationActions.createExperiment();
+      SimulationActions.recordPeriod();
+    });
+  });
+
+  describe("for a slow simulation for 3 iterations", () => {
+
+    beforeEach(() => {
+      SimulationActions.setDuration.trigger(3);
+      SimulationActions.expandSimulationPanel.trigger();
+    });
+    it("should call simulationFramesCreated with 3 frames", (done) => {
+      const testFunction = (data) => {
+        const size = data.length;
+        size.should.eql(3);
+      };
+
+      asyncListenTest(done, SimulationActions.recordingFramesCreated, testFunction);
+      SimulationActions.recordPeriod();
+    });
+  });
+});
+
+
+


### PR DESCRIPTION
This PR adds a new module called Simulation V2. It's partially based on previous Simulation class (which is still there but renamed to SimulationV1), although there are many changes:

1. No hacks with 10 pre-steps and 30 steps that average values (unless it's necessary, more about that below). Cleaner integration loop.
1. Static nodes are evaluated recursively and immediately. We used to treat them as a part of the integration loop, and each step included 10 "pre-steps" to push values down the chain. This didn't seem correct and was limiting chains of static relationships to 10 nodes, or there was some delay.
1. Loops that include only static nodes are now detected and evaluated only if necessary. A similar method is used -> 30 steps + averaging. But it's more explicit and not run all the time, even if it's not necessary.
1. The Euler method is more explicitly implemented.
1. The RK4 method is also added.
1. Time step is now called timeStep and there are some bug fixes related to its handling (e.g. transfer nodes didn't use it before).
1. Changing the time step to a value smaller than 1 doesn't require the user to increase the number of steps in the simulation settings. It will happen automatically. But we'll still output data only at whole number time values. So, changing the time step will only increase accuracy and decrease performance. It won't have any other visible effects for the user.
1. I reused SimulationV1 tests. Although I had to change some details, plus I've added tests of the RK4 method and different time steps.

