### PR TITLE
Fixed topology tagger breaking when transfer node is deleted [#170410042]

### DIFF
--- a/src/code/stores/graph-store.ts
+++ b/src/code/stores/graph-store.ts
@@ -426,6 +426,7 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
     this.endNodeEdit();
     const node = this.nodeKeys[nodeKey];
     const transferRelation = node.transferLink != null ? node.transferLink.relation : undefined;
+    const transferNode = node.transferLink != null ? node.transferLink.transferNode : undefined;
 
     // create a copy of the list of links
     const links = node.links.slice();
@@ -441,6 +442,7 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
       execute: () => {
         if (node.transferLink != null) {
           node.transferLink.relation = node.transferLink.defaultRelation();
+          delete node.transferLink.transferNode;
         }
         for (const link of links) { this._removeLink(link); }
         for (const link of transferLinks) { this._removeTransfer(link); }
@@ -449,6 +451,7 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
       undo: () => {
         if (node.transferLink != null) {
           node.transferLink.relation = transferRelation;
+          node.transferLink.transferNode = transferNode;
         }
         this._addNode(node);
         for (const link of transferLinks) { this._addTransfer(link); }
@@ -965,8 +968,7 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
     })();
     const settings = AppSettingsStore.serialize();
     settings.simulation = SimulationStore.serialize();
-    // TODO: fix and re-enable https://www.pivotaltracker.com/n/projects/1263626/stories/170410042
-    // const topology = getTopology({nodes: nodeExports, links: linkExports});
+    const topology = getTopology({nodes: nodeExports, links: linkExports});
     const data = {
       version: latestVersion(),
       filename: this.filename,
@@ -974,7 +976,7 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
       nodes: nodeExports,
       links: linkExports,
       settings,
-      // topology
+      topology
     };
     return data;
   },

--- a/src/code/utils/topology-tagger.ts
+++ b/src/code/utils/topology-tagger.ts
@@ -80,10 +80,15 @@ export function getAnalysisGraph(sageModelGraph: ISageGraph, swapTransferSource 
     graphlibGraph.setNode(n.key, { isAccumulator: n.data && n.data.isAccumulator });
   });
 
+  const hasValidTransferNode = (link: ISageLink) =>
+    link.transferNode
+    && (link.transferNode !== "")
+    && graphlibGraph.hasNode(link.transferNode);
+
   const setEdge = (s, t, link, label) => {
     const linkData = {
       title: link.title,
-      transferNode: link.transferNode ? link.transferNode : "",
+      transferNode: hasValidTransferNode(link) ? link.transferNode : "",
       relation: link.relation ? link.relation : null,
       source: link.sourceNode
     };
@@ -91,7 +96,7 @@ export function getAnalysisGraph(sageModelGraph: ISageGraph, swapTransferSource 
   };
 
   sageModelGraph.links.forEach((l) => {
-    if (l.transferNode && l.transferNode !== "") {
+    if (hasValidTransferNode(l)) {
       if (swapTransferSource) {
         setEdge(l.transferNode, l.sourceNode, l, "source-to-transfer-node");
       } else {

--- a/test/serialized-test-data/topology-test-cases/two-transfer-nodes.ts
+++ b/test/serialized-test-data/topology-test-cases/two-transfer-nodes.ts
@@ -1,0 +1,55 @@
+// Test case of a transfer link between two nodes. It would look, something
+// like this, when drawn in SageModeler (where double-line top/bottom
+// node borders means the node is a collector):
+//
+//                     -x-
+// +========+        ___!___        +========+
+// | Node-1 |=======>|_____|=======>| Node-2 |
+// +========+          ^  T1        +========+
+
+import { ISageGraph } from "../../../src/code/utils/topology-tagger"
+
+export const twoTransferNodes: ISageGraph =
+  {
+  "nodes":
+    [
+      {
+        "key": "Node-1",
+        "data":
+        {
+          "title": "Untitled",
+          "isAccumulator": true,
+        }
+      },
+      {
+        "key": "Node-2",
+        "data":
+        {
+          "title": "Untitled 2",
+           "isAccumulator": true,
+        }
+      },
+      {
+        "key": "T1",
+        "data":
+        {
+            "title": "flow from Untitled to Untitled 2",
+            "isAccumulator": false,
+        }
+      }
+    ],
+  "links":
+    [
+      {
+        "title": "",
+        "sourceNode": "Node-1",
+        "targetNode": "Node-2",
+        "relation":
+        {
+            "type": "transfer",
+            "formula": "in"
+        },
+        "transferNode": "T1"
+      }
+    ]
+}

--- a/test/topology-tagger-test.ts
+++ b/test/topology-tagger-test.ts
@@ -29,6 +29,7 @@ import { leadingRingFeedback } from "./serialized-test-data/topology-test-cases/
 import { embeddedRingFeedback } from "./serialized-test-data/topology-test-cases/embedded-ring-feedback";
 import { immediateFeedbackOut } from "./serialized-test-data/topology-test-cases/immedate-feedback-from";
 import { multipathAndFeedback } from "./serialized-test-data/topology-test-cases/multipath-and-feedback";
+import { twoTransferNodes } from "./serialized-test-data/topology-test-cases/two-transfer-nodes";
 
 describe("TopologyTagger", () => {
   beforeEach(() => null);
@@ -563,6 +564,22 @@ describe("TopologyTagger", () => {
     });
     it("finds no graphs with a multi-path", () => {
       chai.expect(getTopology(graph).multiPathGraphs).to.eql(0);
+    });
+  });
+
+  describe("does not break when the transfer node is deleted", () => {
+    const graph: ISageGraph = twoTransferNodes;
+
+    // fake deleting the transfer node (T1)
+    const preDeleteNumNodes = graph.nodes.length;
+    graph.nodes = graph.nodes.filter(node => node.key !== "T1");
+    graph.links[0].relation = {type: "range"};
+    const postDeleteNumNodes = graph.nodes.length;
+
+    it("finds 3 nodes before deletion and 2 nodes after", () => {
+      chai.expect(preDeleteNumNodes).to.eql(3);
+      chai.expect(postDeleteNumNodes).to.eql(2);
+      chai.expect(getTopology(graph).nodes).to.eql(2);
     });
   });
 


### PR DESCRIPTION
The topology tagger was dereferencing a transferNode attribute that was not being cleared when the transfer node was deleted in the graph store.

Along with this fix the graph store deleteNode method was updated to clear the  transferNode attribute on the link.