### PR TITLE
Image collections improvements

### DIFF
--- a/src/code/stores/image-dialog-store.ts
+++ b/src/code/stores/image-dialog-store.ts
@@ -78,7 +78,7 @@ export const ImageDialogStore = Reflux.createStore({
 
   onCancel() {
     this.resetPaletteItem();
-    return this.finish();
+    this._updateChanges();
   },
 
   invoke_callback() {

--- a/src/code/views/image-metadata-view.tsx
+++ b/src/code/views/image-metadata-view.tsx
@@ -6,6 +6,7 @@ import { ImageMetadata } from "./preview-image-dialog-view";
 
 interface ImageMetadataViewProps {
   metadata: ImageMetadata;
+  small?: boolean;
   update: ({metadata: ImageMetadata}) => void;
 }
 
@@ -25,8 +26,12 @@ export class ImageMetadataView extends React.Component<ImageMetadataViewProps, I
 
   public render() {
     return (
-      <div className="image-metadata">
-        {this.props.metadata ? this.renderMetadata() : undefined}
+      <div className={`image-metadata${this.props.small ? " small" : ""}`}>
+        {this.props.metadata ?
+          this.props.small ?
+            this.renderSmallMetadata() :
+            this.renderMetadata() :
+          undefined}
       </div>
     );
   }
@@ -85,6 +90,18 @@ export class ImageMetadataView extends React.Component<ImageMetadataViewProps, I
         </div>
       );
     }
+  }
+
+  private renderSmallMetadata() {
+    const licenseName = this.props.metadata.license || "public domain";
+    const licenseData = licenses.getLicense(licenseName);
+    const { title }   = this.props.metadata;
+    return (
+      <div>
+        <div>{title}</div>
+        <div className="license">{tr("~METADATA.LICENSE")}: <a href={licenseData.link} target="_blank">{licenseData.label}</a></div>
+      </div>
+    );
   }
 
   private hostname() {

--- a/src/code/views/palette-inspector-view.tsx
+++ b/src/code/views/palette-inspector-view.tsx
@@ -56,12 +56,11 @@ export class PaletteInspectorView extends Mixer<PaletteInspectorViewProps, Palet
         </div>
         {this.state.selectedPaletteItem ?
           <div className="palette-about-image">
-            <div className="palette-about-image-title">
-              <i className="icon-codap-info" />
-              <span>{tr("~PALETTE-INSPECTOR.ABOUT_IMAGE")}</span>
-              <img src={this.state.selectedPaletteImage} />
-            </div>
-            {(this.state.palette.length !== 1) || !this.state.paletteItemHasNodes ?
+            <div className="palette-about-image-info">
+              {this.state.selectedPaletteItem.metadata
+                ? <ImageMetadataView small={true} metadata={this.state.selectedPaletteItem.metadata} update={PaletteActions.update} />
+                : undefined}
+              {(this.state.palette.length !== 1) || !this.state.paletteItemHasNodes ?
               <div className="palette-delete" onClick={this.handleDelete}>
                 {this.state.paletteItemHasNodes ?
                   <span>
@@ -74,10 +73,9 @@ export class PaletteInspectorView extends Mixer<PaletteInspectorViewProps, Palet
                     <label>{tr("~PALETTE-INSPECTOR.DELETE")}</label>
                   </span>}
               </div> : undefined}
-            <div className="palette-about-image-info">
-              {this.state.selectedPaletteItem.metadata
-                ? <ImageMetadataView metadata={this.state.selectedPaletteItem.metadata} update={PaletteActions.update} />
-                : undefined}
+            </div>
+            <div className="palette-about-image-title">
+              <img src={this.state.selectedPaletteImage} />
             </div>
           </div> : undefined}
       </div>

--- a/src/stylus/components/image-metadata.styl
+++ b/src/stylus/components/image-metadata.styl
@@ -11,3 +11,8 @@
       td:first-child
         label-font(weight: bold)
         //margin-right 16px
+
+  &.small
+    width: 150px
+    .license
+      font-size: 10px

--- a/src/stylus/components/palette-inspector.styl
+++ b/src/stylus/components/palette-inspector.styl
@@ -50,8 +50,10 @@ pal-image-size()
       transition 0.1s
 
   .palette-about-image
-    margin-top 10px
-    padding 15px 20px
+    display flex
+    justify-content space-between
+    margin-top 6px
+    padding 12px 18px
     background-color #ebebeb
     .palette-about-image-title
       i
@@ -67,7 +69,6 @@ pal-image-size()
         float right
         pointer-events none
     .palette-about-image-info
-      margin-top 20px
       line-height 1.75em
       color #444444
       a

--- a/src/stylus/components/tabbed-panel.styl
+++ b/src/stylus/components/tabbed-panel.styl
@@ -13,7 +13,6 @@
       margin-right -1px
       list-style none
       padding-left 10px
-      max-height 300px
       overflow-x hidden
       overflow-y auto
       li

--- a/src/stylus/components/top-node-palette.styl
+++ b/src/stylus/components/top-node-palette.styl
@@ -19,6 +19,10 @@ node-well-tab-height = 30px
   z-index $node-z-index-offset + 1
   box-shadow 0px 1px 1px hsla(0,0,50,0.4)
   transition 0.2s
+  pointer-events all
+
+  .ui-draggable
+    cursor pointer
 
   .node-well
     padding 1em
@@ -59,9 +63,11 @@ node-well-tab-height = 30px
   max-width node-well-width
   z-index $node-z-index-offset + 3
   transition 0.2s
+  pointer-events none
   .tab-wrapper
     width 100%
     background-color hsla(1,1,1,0.0)
+    pointer-events all
     .top-node-palette-tab
       float right
       box-sizing border-box
@@ -77,6 +83,7 @@ node-well-tab-height = 30px
       padding 1em 2em
       z-index $node-z-index-offset + 3
       transition 0.2s
+      cursor pointer
       &.collapsed
         background-image url("../assets/img/bb-chrome/chevron-down.png")
         // top: palette-and-actions-height + global-nav-height + 30px

--- a/test/image-dialog-store-test.ts
+++ b/test/image-dialog-store-test.ts
@@ -8,6 +8,7 @@ chai.config.includeStack = true;
 const Sinon = require("sinon");
 
 import { ImageDialogStore, ImageDialogActions } from "../src/code/stores/image-dialog-store";
+import { PaletteActions } from "../src/code/stores/palette-store";
 
 describe("ImageDialogStore", () => {
 
@@ -53,15 +54,17 @@ describe("ImageDialogStore", () => {
 
         it("shouldn't keep the dialog open", () => ImageDialogStore.keepShowing.should.equal(false));
 
+        // The close and callback feature is used when the user confirms a new palette selection
+        // after having dragged in the New Image node.
         it("should call 'close' when finishing", () => {
           this.mock.expects("close");
-          this.actions.cancel();
+          PaletteActions.update();
           this.clock.tick(1);
           this.mock.verify();
         });
 
         it("should call the callback when finishing", () => {
-          this.actions.cancel();
+          PaletteActions.update();
           this.clock.tick(1);
           this.callbackF.called.should.equal(true);
         });


### PR DESCRIPTION
This

1. Fixes a bug where dragging the New Image node into the canvas and then changing tabs made the New Image Dialog close
2. Enlarges the panel containing the tabs, so more can be seen at once
3. Fixes the unclickable space right below the palette (https://www.pivotaltracker.com/story/show/172150136)
4. Made the image info box under the palette shorter (https://www.pivotaltracker.com/story/show/172150275)