### PR TITLE
Add optional fullscreen button (?fullscreenButton=true)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8301,6 +8301,12 @@
         "ajv-keywords": "^3.1.0"
       }
     },
+    "screenfull": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.0.2.tgz",
+      "integrity": "sha512-cCF2b+L/mnEiORLN5xSAz6H3t18i2oHh9BA8+CQlAh5DRw2+NFAGQJOSYbcGw8B2k04g/lVvFcfZ83b3ysH5UQ==",
+      "dev": true
+    },
     "seed-random": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "postcss-loader": "^3.0.0",
     "rimraf": "^2.6.2",
     "sass-loader": "^7.1.0",
+    "screenfull": "^5.0.0",
     "semver": "^5.1.0",
     "sinon": "^1.12.2",
     "strip-json-comments-cli": "^1.0.1",

--- a/src/assets/img/fullscreen-exit.svg
+++ b/src/assets/img/fullscreen-exit.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="20px" height="20px" viewBox="0 0 20 20" enable-background="new 0 0 20 20" xml:space="preserve">
+  <g id="Layer_1">
+    <g>
+      <polyline fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" points="18,14 13,14
+        13,19 		"/>
+      <line fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" x1="13" y1="13" x2="17" y2="18"/>
+      <polyline fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" points="7,19 7,14
+        2,14 		"/>
+      <line fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" x1="7" y1="14" x2="3" y2="18"/>
+      <polyline fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" points="2,8 7,8
+        7,3 		"/>
+      <line fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" x1="7" y1="8" x2="3" y2="4"/>
+      <polyline fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" points="13,3 13,8
+        18,8 		"/>
+      <line fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" x1="13" y1="8" x2="17" y2="4"/>
+    </g>
+  </g>
+</svg>

--- a/src/assets/img/fullscreen.svg
+++ b/src/assets/img/fullscreen.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="20px" height="20px" viewBox="0 0 20 20" enable-background="new 0 0 20 20" xml:space="preserve">
+  <g id="Layer_1">
+    <g>
+      <polyline fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" points="8,4 3,4
+        3,9 		"/>
+      <line fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" x1="3" y1="3" x2="7" y2="8"/>
+      <polyline fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" points="17,9 17,4
+        12,4 		"/>
+      <line fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" x1="17" y1="4" x2="13" y2="8"/>
+      <polyline fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" points="12,18 17,18
+        17,13 		"/>
+      <line fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" x1="17" y1="18" x2="13" y2="14"/>
+      <polyline fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" points="3,13 3,18
+        8,18 		"/>
+      <line fill="none" stroke="#000" stroke-width="2" stroke-miterlimit="10" x1="3" y1="18" x2="7" y2="14"/>
+    </g>
+  </g>
+</svg>

--- a/src/code/app.tsx
+++ b/src/code/app.tsx
@@ -17,6 +17,7 @@ import { PaletteStore } from "./stores/palette-store";
 import { HashParams } from "./utils/hash-parameters";
 
 import * as $ from "jquery";
+import { urlParams } from "./utils/url-params";
 require("jquery-ui-dist/jquery-ui.js");
 const Touchpunch = require("./vendor/touchpunch.js");
 Touchpunch($);
@@ -78,4 +79,5 @@ const waitForAppView = (callback: () => void) => {
   },
 
   iframePhone: IframePhone,         // re-expose for external use
+  urlParams,
 };

--- a/src/code/stores/app-settings-store.ts
+++ b/src/code/stores/app-settings-store.ts
@@ -87,6 +87,7 @@ export interface UIElements {
   inspectorPanel: boolean;
   nodePalette: boolean;
   fullscreenButton: boolean;
+  scaling: boolean;
 }
 
 export const AppSettingsStore: AppSettingsStoreClass = Reflux.createStore({
@@ -104,6 +105,7 @@ export const AppSettingsStore: AppSettingsStoreClass = Reflux.createStore({
       inspectorPanel: true,
       nodePalette: true,
       fullscreenButton: false,
+      scaling: false,
     };
     const uiParams = HashParams.getParam("hide") || urlParams.hide;
     // For situations where some ui elements need to be hidden, this parameter can be specified.
@@ -118,6 +120,9 @@ export const AppSettingsStore: AppSettingsStoreClass = Reflux.createStore({
 
     if (HashParams.getParam("fullscreenButton") === "true" || urlParams.fullscreenButton === "true") {
       uiElements.fullscreenButton = true;
+    }
+    if (HashParams.getParam("scaling") === "true" || urlParams.scaling === "true") {
+      uiElements.scaling = true;
     }
 
     const lockdown = (HashParams.getParam("lockdown") === "true") || (urlParams.lockdown === "true");

--- a/src/code/stores/app-settings-store.ts
+++ b/src/code/stores/app-settings-store.ts
@@ -86,6 +86,7 @@ export interface UIElements {
   actionBar: boolean;
   inspectorPanel: boolean;
   nodePalette: boolean;
+  fullscreenButton: boolean;
 }
 
 export const AppSettingsStore: AppSettingsStoreClass = Reflux.createStore({
@@ -101,7 +102,8 @@ export const AppSettingsStore: AppSettingsStoreClass = Reflux.createStore({
       globalNav: true,
       actionBar: true,
       inspectorPanel: true,
-      nodePalette: true
+      nodePalette: true,
+      fullscreenButton: false,
     };
     const uiParams = HashParams.getParam("hide") || urlParams.hide;
     // For situations where some ui elements need to be hidden, this parameter can be specified.
@@ -112,6 +114,10 @@ export const AppSettingsStore: AppSettingsStoreClass = Reflux.createStore({
       uiElements.actionBar = uiParams.indexOf("actionBar") === -1;
       uiElements.inspectorPanel = uiParams.indexOf("inspectorPanel") === -1;
       uiElements.nodePalette = uiParams.indexOf("nodePalette") === -1;
+    }
+
+    if (HashParams.getParam("fullscreenButton") === "true" || urlParams.fullscreenButton === "true") {
+      uiElements.fullscreenButton = true;
     }
 
     const lockdown = (HashParams.getParam("lockdown") === "true") || (urlParams.lockdown === "true");

--- a/src/code/utils/scale-app.ts
+++ b/src/code/utils/scale-app.ts
@@ -1,0 +1,35 @@
+import * as screenfull from "screenfull";
+import { DOMElement } from "react";
+
+const getWindowTransforms = () => {
+  const MAX_WIDTH = 2000;
+  const width  = Math.max(window.innerWidth, Math.min(MAX_WIDTH, screen.width));
+  const scale  = window.innerWidth  / width;
+  const height = window.innerHeight / scale;
+  return {
+    scale,
+    unscaledWidth: width,
+    unscaledHeight: height
+  };
+};
+
+const setScaling = (el: ElementCSSInlineStyle) => () => {
+  if (!screenfull.isEnabled || !screenfull.isFullscreen) {
+    const trans = getWindowTransforms();
+    el.style.width = trans.unscaledWidth + "px";
+    el.style.height = trans.unscaledHeight + "px";
+    el.style.transformOrigin = "top left";
+    el.style.transform = "scale3d(" + trans.scale + "," + trans.scale + ",1)";
+  } else {
+    // Disable scaling in fullscreen mode.
+    el.style.width = "100%";
+    el.style.height = "100%";
+    el.style.transform = "scale3d(1,1,1)";
+  }
+};
+
+export default function scaleApp(el: ElementCSSInlineStyle) {
+  const scaleElement = setScaling(el);
+  scaleElement();
+  window.addEventListener("resize", scaleElement);
+}

--- a/src/code/utils/scale-app.ts
+++ b/src/code/utils/scale-app.ts
@@ -20,6 +20,12 @@ const setScaling = (el: ElementCSSInlineStyle) => () => {
     el.style.height = trans.unscaledHeight + "px";
     el.style.transformOrigin = "top left";
     el.style.transform = "scale3d(" + trans.scale + "," + trans.scale + ",1)";
+
+    // if we have fullscreen help text, make it big
+    const helpText = document.getElementsByClassName("fullscreen-help")[0]  as unknown as ElementCSSInlineStyle;
+    if (helpText) {
+      helpText.style.fontSize = Math.round(Math.pow(Math.min(window.innerWidth, 500), 0.65)) + "px";
+    }
   } else {
     // Disable scaling in fullscreen mode.
     el.style.width = "100%";

--- a/src/code/utils/url-params.ts
+++ b/src/code/utils/url-params.ts
@@ -24,6 +24,7 @@ export interface UrlParams {
   timestep?: number;
   integration?: string;
   fullscreenButton?: string;    // whether to show fullscreen button (note: Document Store auomatically provides one)
+  scaling?: string;             // whether to scale the app when not fullscreen, and also inform LARA our aspect ratio should be screen's AR
   /**
    * Image Collections are groups of images that we will display in the New Image dialog
    * in separate tabs. If one or more collections are defined, they will appear at the top

--- a/src/code/utils/url-params.ts
+++ b/src/code/utils/url-params.ts
@@ -23,6 +23,7 @@ export interface UrlParams {
   simulation?: string;
   timestep?: number;
   integration?: string;
+  fullscreenButton?: string;    // whether to show fullscreen button (note: Document Store auomatically provides one)
   /**
    * Image Collections are groups of images that we will display in the New Image dialog
    * in separate tabs. If one or more collections are defined, they will appear at the top

--- a/src/code/views/app-view.tsx
+++ b/src/code/views/app-view.tsx
@@ -33,6 +33,7 @@ import { Link } from "../models/link";
 import { GraphStoreClass } from "../stores/graph-store";
 import { NodeChangedValues } from "./node-inspector-view";
 import { InternalLibraryItem } from "../data/internal-library";
+import { FullScreenButton } from "./fullscreen-button";
 
 interface AppViewOuterProps {
   graphStore: GraphStoreClass;
@@ -183,6 +184,9 @@ export class AppView extends Mixer<AppViewProps, AppViewState> {
           {this.state.showingDialog ? <ImageBrowserView /* graphStore={this.props.graphStore} */ /> : null}
           <ModalPaletteDeleteView />
         </div>
+        {AppSettingsStore.settings.uiElements.fullscreenButton &&
+          <FullScreenButton />
+        }
         {this.state.iframed ? <BuildInfoView /> : null}
       </div>
     );

--- a/src/code/views/app-view.tsx
+++ b/src/code/views/app-view.tsx
@@ -34,6 +34,7 @@ import { GraphStoreClass } from "../stores/graph-store";
 import { NodeChangedValues } from "./node-inspector-view";
 import { InternalLibraryItem } from "../data/internal-library";
 import { FullScreenButton } from "./fullscreen-button";
+import scaleApp from "../utils/scale-app";
 
 interface AppViewOuterProps {
   graphStore: GraphStoreClass;
@@ -63,6 +64,7 @@ export class AppView extends Mixer<AppViewProps, AppViewState> {
 
   public static displayName = "AppView";
 
+  private appContainer: HTMLDivElement | null;
   private inspectorPanel: InspectorPanelView | null;
 
   constructor(props: AppViewProps) {
@@ -110,6 +112,10 @@ export class AppView extends Mixer<AppViewProps, AppViewState> {
     PaletteStore.listen(this.handlePaletteChange);
     CodapStore.listen(this.handleCodapStateChange);
     // LaraStore.listen(this.onLaraStateChange);  TODO: was in coffee but doesn't exist
+
+    if (AppSettingsStore.settings.uiElements.scaling && this.appContainer) {
+      scaleApp(this.appContainer);
+    }
   }
 
   public componentWillUnmount() {
@@ -134,7 +140,7 @@ export class AppView extends Mixer<AppViewProps, AppViewState> {
     const renderGlobalNav = !this.state.iframed && (AppSettingsStore.settings.uiElements.globalNav !== false);
 
     return (
-      <div className="app">
+      <div className="app" ref={el => this.appContainer = el}>
         <div className={this.state.iframed ? "iframed-workspace" : "workspace"}>
           {renderGlobalNav ?
             <GlobalNavView

--- a/src/code/views/fullscreen-button.tsx
+++ b/src/code/views/fullscreen-button.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import * as screenfull from "screenfull";
+
+// import "./fullscreen-button.sass";
+
+interface IProps {
+  onFullscreenChange?: (isFullscreen: boolean) => void;
+}
+
+interface IState {
+  isFullscreen: boolean;
+}
+
+export class FullScreenButton extends React.Component<IProps, IState> {
+
+  public state = {
+    isFullscreen: false
+  };
+
+  public componentDidMount() {
+    if (screenfull.isEnabled) {
+      screenfull.on("change", () => {
+        const isFullscreen = (screenfull as any).isFullscreen;
+        this.setState({ isFullscreen });
+        if (this.props.onFullscreenChange) {
+          this.props.onFullscreenChange(isFullscreen);
+        }
+      });
+    }
+  }
+
+  public render() {
+    let className = "fullscreen-button-container";
+    let imgName = "img/fullscreen.svg";
+    if (this.state.isFullscreen) {
+      className += " fullscreen";
+      imgName = "img/fullscreen-exit.svg";
+    }
+
+    return (
+      <div className={className}>
+        <div className="fullscreen-help">
+          Click here to enter/exit fullscreen →
+        </div>
+        <div className="fullscreen-button" onClick={this.toggleFullscreen}>
+          <img src={imgName} />
+        </div>
+      </div>
+    );
+  }
+
+  private toggleFullscreen() {
+    if (screenfull.isEnabled) {
+      screenfull.toggle();
+    }
+  }
+}

--- a/src/code/views/fullscreen-button.tsx
+++ b/src/code/views/fullscreen-button.tsx
@@ -19,13 +19,13 @@ export class FullScreenButton extends React.Component<IProps, IState> {
 
   public componentDidMount() {
     if (screenfull.isEnabled) {
-      screenfull.on("change", () => {
-        const isFullscreen = (screenfull as any).isFullscreen;
-        this.setState({ isFullscreen });
-        if (this.props.onFullscreenChange) {
-          this.props.onFullscreenChange(isFullscreen);
-        }
-      });
+      screenfull.on("change", this.handleFullscreenChange);
+    }
+  }
+
+  public componentWillUnmount() {
+    if (screenfull.isEnabled) {
+      screenfull.off("change", this.handleFullscreenChange);
     }
   }
 
@@ -52,6 +52,14 @@ export class FullScreenButton extends React.Component<IProps, IState> {
   private toggleFullscreen() {
     if (screenfull.isEnabled) {
       screenfull.toggle();
+    }
+  }
+
+  private handleFullscreenChange = () => {
+    const isFullscreen = (screenfull as any).isFullscreen;
+    this.setState({ isFullscreen });
+    if (this.props.onFullscreenChange) {
+      this.props.onFullscreenChange(isFullscreen);
     }
   }
 }

--- a/src/stylus/components/fullscreen-button.styl
+++ b/src/stylus/components/fullscreen-button.styl
@@ -1,0 +1,29 @@
+.fullscreen-button-container
+  position absolute
+  bottom 20px
+  right 10px
+  display flex
+  align-items center
+  color #8e8e8e
+  font-size 22px
+  font-family "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
+
+  .fullscreen-button
+    img
+      width 45px
+      filter invert(0.7)
+    img:hover
+      filter invert(0.4)
+
+  .fullscreen-help
+    padding-right 5px
+    pointer-events none
+    -webkit-animation hide 1s ease-in 10s forwards
+    animation hide 1s ease-in 10s forwards
+
+@keyframes hide
+  from
+    opacity 1
+
+  to
+    opacity 0

--- a/src/templates/lara.html.ejs
+++ b/src/templates/lara.html.ejs
@@ -129,13 +129,20 @@
 
     phone.initialize();
 
-    phone.post("supportedFeatures", {
+    const supportedFeatures = {
       apiVersion: 1,
       features: {
         authoredState: true,
         interactiveState: true
       }
-    });
+    };
+
+    if (Sage.urlParams.scaling === "true") {
+      // notify LARA that we want to use screen aspect ratio as our aspect ratio
+      supportedFeatures.features.aspectRatio = screen.width / screen.height;
+    }
+
+    phone.post("supportedFeatures", supportedFeatures);
   </script>
 </body>
 </html>


### PR DESCRIPTION
When Sage is embedded using the Document Store, a fullscreen button is provided for it, but otherwise it doesn't have one.

This adds a url parameter "fullscreenButton" that can provide a similar-looking fullscreen button.

https://www.pivotaltracker.com/story/show/172377261