### PR TITLE
Fix scaling of app

### DIFF
--- a/src/code/utils/js-plumb-diagram-toolkit.ts
+++ b/src/code/utils/js-plumb-diagram-toolkit.ts
@@ -12,7 +12,7 @@ const log = require("loglevel");
 import { LinkColors } from "../utils/link-colors";
 import * as $ from "jquery";
 
-import { getViewScale } from "../utils/scale-app";
+import { getViewScale, registerScaleListener } from "../utils/scale-app";
 
 // const jsPlumb = require("../../vendor/jsPlumb");
 declare var jsPlumb;
@@ -48,7 +48,12 @@ export class DiagramToolkit {
       ConnectionsDetachable: true,
       DoNotThrowErrors: false
     });
+
     this.kit.setZoom(getViewScale(), true);
+    registerScaleListener((scale: number) => {
+      this.kit.setZoom(scale, true);
+    });
+
     this.kit.repaintEverything();
     this.registerListeners();
 
@@ -164,7 +169,6 @@ export class DiagramToolkit {
     if (this.kit) {
       this.kit.deleteEveryEndpoint();
       this.kit.reset();
-      this.kit.setZoom(getViewScale(), true);
       this.kit.repaintEverything();
       return this.registerListeners();
     } else {

--- a/src/code/utils/js-plumb-diagram-toolkit.ts
+++ b/src/code/utils/js-plumb-diagram-toolkit.ts
@@ -12,6 +12,8 @@ const log = require("loglevel");
 import { LinkColors } from "../utils/link-colors";
 import * as $ from "jquery";
 
+import { getViewScale } from "../utils/scale-app";
+
 // const jsPlumb = require("../../vendor/jsPlumb");
 declare var jsPlumb;
 
@@ -46,6 +48,8 @@ export class DiagramToolkit {
       ConnectionsDetachable: true,
       DoNotThrowErrors: false
     });
+    this.kit.setZoom(getViewScale(), true);
+    this.kit.repaintEverything();
     this.registerListeners();
 
     // transfer-modifier links attach to fixed locations on the left or right of the flow node
@@ -160,6 +164,8 @@ export class DiagramToolkit {
     if (this.kit) {
       this.kit.deleteEveryEndpoint();
       this.kit.reset();
+      this.kit.setZoom(getViewScale(), true);
+      this.kit.repaintEverything();
       return this.registerListeners();
     } else {
       return log.info("No kit defined");

--- a/src/code/utils/scale-app.ts
+++ b/src/code/utils/scale-app.ts
@@ -1,6 +1,8 @@
 import * as screenfull from "screenfull";
 import { DOMElement } from "react";
 
+let currentScale = 1;
+
 const getWindowTransforms = () => {
   const MAX_WIDTH = 2000;
   const width  = Math.max(window.innerWidth, Math.min(MAX_WIDTH, screen.width));
@@ -16,6 +18,7 @@ const getWindowTransforms = () => {
 const setScaling = (el: ElementCSSInlineStyle) => () => {
   if (!screenfull.isEnabled || !screenfull.isFullscreen) {
     const trans = getWindowTransforms();
+    currentScale = trans.scale;
     el.style.width = trans.unscaledWidth + "px";
     el.style.height = trans.unscaledHeight + "px";
     el.style.transformOrigin = "top left";
@@ -28,13 +31,18 @@ const setScaling = (el: ElementCSSInlineStyle) => () => {
     }
   } else {
     // Disable scaling in fullscreen mode.
+    currentScale = 1;
     el.style.width = "100%";
     el.style.height = "100%";
     el.style.transform = "scale3d(1,1,1)";
   }
 };
 
-export default function scaleApp(el: ElementCSSInlineStyle) {
+export function getViewScale() {
+  return currentScale;
+}
+
+export function scaleApp(el: ElementCSSInlineStyle) {
   const scaleElement = setScaling(el);
   scaleElement();
   window.addEventListener("resize", scaleElement);

--- a/src/code/utils/scale-app.ts
+++ b/src/code/utils/scale-app.ts
@@ -3,6 +3,9 @@ import { DOMElement } from "react";
 
 let currentScale = 1;
 
+type ScaleListener = (scale: number) => void;
+const listeners: ScaleListener[] = [];
+
 const getWindowTransforms = () => {
   const MAX_WIDTH = 2000;
   const width  = Math.max(window.innerWidth, Math.min(MAX_WIDTH, screen.width));
@@ -36,7 +39,19 @@ const setScaling = (el: ElementCSSInlineStyle) => () => {
     el.style.height = "100%";
     el.style.transform = "scale3d(1,1,1)";
   }
+  listeners.forEach(l => l(currentScale));
 };
+
+export function registerScaleListener(listener: ScaleListener) {
+  listeners.push(listener);
+}
+
+export function removeScaleListener(listener: ScaleListener) {
+  const index = listeners.indexOf(listener);
+  if (index > -1) {
+    listeners.splice(index, 1);
+  }
+}
 
 export function getViewScale() {
   return currentScale;

--- a/src/code/views/app-view.tsx
+++ b/src/code/views/app-view.tsx
@@ -34,7 +34,7 @@ import { GraphStoreClass } from "../stores/graph-store";
 import { NodeChangedValues } from "./node-inspector-view";
 import { InternalLibraryItem } from "../data/internal-library";
 import { FullScreenButton } from "./fullscreen-button";
-import scaleApp from "../utils/scale-app";
+import { scaleApp } from "../utils/scale-app";
 
 interface AppViewOuterProps {
   graphStore: GraphStoreClass;

--- a/src/code/views/graph-view.tsx
+++ b/src/code/views/graph-view.tsx
@@ -600,8 +600,9 @@ export class GraphView extends Mixer<GraphViewProps, GraphViewState> {
       // calculate selection box before calling setTimeout
       const selectBox = $.extend({}, this.state.selectBox);
       const offset = $(this.linkView!).offset() || {left: 0, top: 0};
-      selectBox.startX = e.pageX - offset.left;
-      selectBox.startY = e.pageY - offset.top;
+      const viewScale = getViewScale();
+      selectBox.startX = (e.pageX - offset.left) / viewScale;
+      selectBox.startY = (e.pageY - offset.top) / viewScale;
       selectBox.x = selectBox.startX;
       selectBox.y = selectBox.startY;
 
@@ -641,8 +642,9 @@ export class GraphView extends Mixer<GraphViewProps, GraphViewState> {
     if (this.state.drawingMarquee) {
       const offset = $(this.linkView!).offset() || {left: 0, top: 0};
       const selectBox = $.extend({}, this.state.selectBox);
-      selectBox.x = e.pageX - offset.left;
-      selectBox.y = e.pageY - offset.top;
+      const viewScale = getViewScale();
+      selectBox.x = (e.pageX - offset.left) / viewScale;
+      selectBox.y = (e.pageY  - offset.top) / viewScale;
       return this.setState({selectBox});
     }
   }

--- a/src/code/views/graph-view.tsx
+++ b/src/code/views/graph-view.tsx
@@ -3,6 +3,8 @@ import * as ReactDOM from "react-dom";
 import * as _ from "lodash";
 import * as $ from "jquery";
 
+import { getViewScale } from "../utils/scale-app";
+
 /*
  * decaffeinate suggestions:
  * DS102: Remove unnecessary code created because of implicit returns
@@ -168,6 +170,12 @@ export class GraphView extends Mixer<GraphViewProps, GraphViewState> {
           height: $panel.height() || 0,
           offset: $panel.offset() || {left: 0, top: 0}
         };
+        const viewScale = getViewScale();
+
+        ui.position.top /= viewScale;
+        ui.position.left /= viewScale;
+        ui.offset.top /= viewScale;
+        ui.offset.left /= viewScale;
 
         const inPanel = (ui.offset.left >= panel.offset.left) &&
                   (ui.offset.top >= panel.offset.top) &&

--- a/src/code/views/node-view.tsx
+++ b/src/code/views/node-view.tsx
@@ -4,6 +4,8 @@ const log = require("loglevel");
 import * as React from "react";
 import * as $ from "jquery";
 
+import { getViewScale } from "../utils/scale-app";
+
 /*
  * decaffeinate suggestions:
  * DS102: Remove unnecessary code created because of implicit returns
@@ -444,6 +446,12 @@ export class NodeView extends React.Component<NodeViewProps, NodeViewState> {
   }
 
   private handleMove = (evt, extra) => {
+    const viewScale = getViewScale();
+    extra.position.top /= viewScale;
+    extra.position.left /= viewScale;
+    extra.offset.top /= viewScale;
+    extra.offset.left /= viewScale;
+
     this.props.onMove({
       nodeKey: this.props.nodeKey,
       reactComponent: this,
@@ -457,6 +465,12 @@ export class NodeView extends React.Component<NodeViewProps, NodeViewState> {
   }
 
   private handleStop = (evt, extra) => {
+    const viewScale = getViewScale();
+    extra.position.top /= viewScale;
+    extra.position.left /= viewScale;
+    extra.offset.top /= viewScale;
+    extra.offset.left /= viewScale;
+
     return this.props.onMoveComplete({
       nodeKey: this.props.nodeKey,
       reactComponent: this,

--- a/src/vendor/jsPlumb.js
+++ b/src/vendor/jsPlumb.js
@@ -63,6 +63,13 @@
  *
  */
 
+// Hack: Add a top-level zoom.
+// Issue: when instance.setZoom() is called, this fires a "zoom" event on all the listeners,
+// which includes the Katavorio drag-drop handler.
+// However, when we call instance.reset -- which we do on every update in Sage -- all the
+// listeners are removed. Thus the drag-drop handlers do not get informed of the zoom.
+var JSPLUMB_ZOOM = 1;
+
 (function() {
 
     var root = this;
@@ -1947,7 +1954,7 @@
 
         this._dragsByScope = {};
         this._dropsByScope = {};
-        var _zoom = 1,
+        var _zoom = JSPLUMB_ZOOM,
             _reg = function(obj, map) {
                 _each(obj, function(_obj) {
                     for(var i = 0; i < _obj.scopes.length; i++) {
@@ -3454,6 +3461,7 @@
 
         this.setZoom = function (z, repaintEverything) {
             _zoom = z;
+            JSPLUMB_ZOOM = z;
             _currentInstance.fire("zoom", _zoom);
             if (repaintEverything) _currentInstance.repaintEverything();
             return true;
@@ -5784,7 +5792,7 @@
                 _currentInstance.removeAllGroups();
                 _currentInstance.removeGroupManager();
                 _currentInstance.deleteEveryEndpoint();
-                _currentInstance.unbind();
+                // _currentInstance.unbind();
                 this.targetEndpointDefinitions = {};
                 this.sourceEndpointDefinitions = {};
                 connections.length = 0;


### PR DESCRIPTION
When using stand-alone Sage scaling, we have to handle all the mouse transformations ourselves. This wasn't an issue in the DocumentStore, because that scaled the entire iframe, which allows the mouse coordinates of the internal app to ignore scaling.

This is mostly straight-forward, dividing coordinates as needed by the current scale. The only annoying thing (which caused hours of face-desking) is how jsPlumb handles zooming. jsPlumb does have a `setZoom` function, which would in theory work, but each node has a drag-drop handler which doesn't hear the `zoom` event, because we call `reset` after the handler's listener is created. This hacks jsPlumb to use a single top-level zoom scale in this case.

No behavior should be different if scaling is 1 (which is always the case is `?scaling=true` is not set).

As far as I can tell, this covers all the cases, but I will not merge this in until it passes QA.