### PR TITLE
Add select of app when embedded in CODAP [#173785724]

### DIFF
--- a/src/code/models/codap-connect.ts
+++ b/src/code/models/codap-connect.ts
@@ -70,6 +70,7 @@ export class CodapConnect {
   private _attrsAreLoaded: boolean;
   private guidePollerInterval: number | null = null;
   private guideComponentId: number | null = null;
+  private id: any;
 
   constructor(context) {
     this.codapRequestHandler = this.codapRequestHandler.bind(this);
@@ -129,6 +130,8 @@ export class CodapConnect {
             this.standaloneMode = true;
             this.graphStore.setCodapStandaloneMode(true);
           }
+
+          this.id = frame ? frame.values.id : undefined;
 
           // get the current list of guide items
           this.getGuideItems();
@@ -908,6 +911,16 @@ export class CodapConnect {
         }
       }
     });
+  }
+
+  public selectSelf() {
+    if (this.id) {
+      this.codapPhone.call({
+        action: "notify",
+        resource: `component[${this.id}]`,
+        values: {request: "select"}
+      });
+    }
   }
 
   private getTimeUnit() {

--- a/src/code/utils/select-self.ts
+++ b/src/code/utils/select-self.ts
@@ -1,0 +1,9 @@
+import { CodapConnect } from "../models/codap-connect";
+
+let codapConnect: CodapConnect;
+
+// sends a message to CODAP to select the component wrapping this app
+export const selectSelf = () => {
+  codapConnect = codapConnect || CodapConnect.instance("building-models");
+  codapConnect.selectSelf();
+};

--- a/src/code/views/app-view.tsx
+++ b/src/code/views/app-view.tsx
@@ -35,6 +35,7 @@ import { NodeChangedValues } from "./node-inspector-view";
 import { InternalLibraryItem } from "../data/internal-library";
 import { FullScreenButton } from "./fullscreen-button";
 import { scaleApp } from "../utils/scale-app";
+import { selectSelf } from "../utils/select-self";
 
 interface AppViewOuterProps {
   graphStore: GraphStoreClass;
@@ -93,6 +94,8 @@ export class AppView extends Mixer<AppViewProps, AppViewState> {
       standaloneMode: urlParams.standalone === "true"
     };
     this.setInitialState(outerState, ImageDialogMixin.InitialState(), AppSettingsMixin.InitialState());
+
+    this.handleWindowClick = this.handleWindowClick.bind(this);
   }
 
   public componentDidMount() {
@@ -116,6 +119,8 @@ export class AppView extends Mixer<AppViewProps, AppViewState> {
     if (AppSettingsStore.settings.uiElements.scaling && this.appContainer) {
       scaleApp(this.appContainer);
     }
+
+    window.addEventListener("click", this.handleWindowClick, true);
   }
 
   public componentWillUnmount() {
@@ -123,6 +128,7 @@ export class AppView extends Mixer<AppViewProps, AppViewState> {
     super.componentWillUnmount();
 
     this.addDeleteKeyHandler(false);
+    window.removeEventListener("click", this.handleWindowClick, true);
   }
 
   public componentDidUpdate(prevProps, prevState, prevContext) {
@@ -328,5 +334,13 @@ export class AppView extends Mixer<AppViewProps, AppViewState> {
         }
       }
     });
+  }
+
+  private handleWindowClick() {
+    // When embedded in CODAP any click on the window sends a message to CODAP to select
+    // the app which will unselect any existing other CODAP component.
+    // This is also called in the graphView as jsPlumb adds a click handler that
+    // stops this handler from being called.
+    selectSelf();
   }
 }

--- a/src/code/views/graph-view.tsx
+++ b/src/code/views/graph-view.tsx
@@ -35,6 +35,7 @@ import { LinkColors } from "../utils/link-colors";
 import { Mixer } from "../mixins/components";
 import { Link } from "../models/link";
 import { SelectionManager } from "../models/selection-manager";
+import { selectSelf } from "../utils/select-self";
 
 interface GraphViewOuterProps {
   selectionManager: SelectionManager;
@@ -618,6 +619,12 @@ export class GraphView extends Mixer<GraphViewProps, GraphViewState> {
       // see https://www.pivotaltracker.com/story/show/164438776
       setTimeout(deselectAction, 1);
     }
+
+    // When embedded in CODAP any click on this component sends a message to CODAP to select
+    // the app which will unselect any existing other CODAP component.
+    // This is also called in the main appView but also must be called here as jsPlumb
+    // adds a click handler that stops the top level handler from being called.
+    selectSelf();
   }
 
   private handleMouseUp = (e) => {


### PR DESCRIPTION
Sends CODAP a select message to select the app when any click is performed in the app.  This will unselect all other CODAP components which will also remove their window menus.  This is needed after the new text component added a large menu.

The click handler was added both to the main app view, attached to the window, and the graph view as the graph view uses jsPlumb which attaches its own click handler which prevents the outer window handler from being called.