### PR TITLE
Added preventDataContextReorg to CODAP plugin params [#170897787]

### DIFF
--- a/src/code/models/codap-connect.ts
+++ b/src/code/models/codap-connect.ts
@@ -106,7 +106,8 @@ export class CodapConnect {
           values: {
             title: tr("~CODAP.INTERACTIVE_FRAME.TITLE"),
             preventBringToFront: true,
-            cannotClose: true
+            cannotClose: true,
+            preventDataContextReorg: false // allows tables to be reorganized
           }
         },
         {


### PR DESCRIPTION
Changes preventDataContextReorg property of SageModeler plugin to be "false" so that tables can be reorganized, including those new tables that get created through the "new table" button.