### PR TITLE
Added naming of flow [#171530932]

### DIFF
--- a/src/code/mixins/node-title.ts
+++ b/src/code/mixins/node-title.ts
@@ -8,20 +8,29 @@ const _ = require("lodash");
 
 import { tr } from "../utils/translate";
 import { Mixin } from "./components";
+import { Node } from "../models/node";
+import { TransferModel } from "../models/transfer";
 
 export interface NodeTitleMixinProps {
   title: string;
+  node: Node;
 }
 export interface NodeTitleMixinState {}
 
 export class NodeTitleMixin extends Mixin<NodeTitleMixinProps, NodeTitleMixinState> {
 
   public defaultTitle() {
-    return tr("~NODE.UNTITLED");
+    let title = tr("~NODE.UNTITLED");
+    const node = this.props.node;
+    if (node.isTransfer) {
+      title = (node as TransferModel).computeTitle() || title;
+    }
+    return title;
   }
 
   public titlePlaceholder() {
-    return this.defaultTitle();
+    const node = this.props.node;
+    return node.isTransfer ? "" : this.defaultTitle();
   }
 
   public isDefaultTitle() {

--- a/src/code/models/transfer.ts
+++ b/src/code/models/transfer.ts
@@ -29,14 +29,16 @@ export class TransferModel extends Node {
     }
   }
 
-  public isDefaultTransferTitle() {
-    return this.title === this.computeTitle();
+  public isDefaultTransferTitle(changedNode?: Node, prevTitle?: string) {
+    return this.title === this.computeTitle(changedNode, prevTitle);
   }
 
-  public computeTitle() {
+  public computeTitle(changedNode?: Node, prevTitle?: string) {
     if (this.transferLink) {
-      return tr("~TRANSFER_NODE.TITLE", { sourceTitle: this.transferLink.sourceNode.title,
-        targetTitle: this.transferLink.targetNode.title });
+      const {sourceNode, targetNode} = this.transferLink;
+      const sourceTitle = sourceNode === changedNode ? prevTitle : sourceNode.title;
+      const targetTitle = targetNode === changedNode ? prevTitle : targetNode.title;
+      return tr("~TRANSFER_NODE.TITLE", { sourceTitle, targetTitle });
     } else {
       return undefined;
     }

--- a/src/code/models/transfer.ts
+++ b/src/code/models/transfer.ts
@@ -24,7 +24,9 @@ export class TransferModel extends Node {
 
   public setTransferLink(link) {
     this.transferLink = link;
-    return this.title = this.title || this.computeTitle();
+    if (this.title === tr("~NODE.UNTITLED")) {
+      this.title = this.computeTitle();
+    }
   }
 
   public isDefaultTransferTitle() {

--- a/src/code/models/transfer.ts
+++ b/src/code/models/transfer.ts
@@ -24,7 +24,11 @@ export class TransferModel extends Node {
 
   public setTransferLink(link) {
     this.transferLink = link;
-    return this.title = this.computeTitle();
+    return this.title = this.title || this.computeTitle();
+  }
+
+  public isDefaultTransferTitle() {
+    return this.title === this.computeTitle();
   }
 
   public computeTitle() {

--- a/src/code/stores/graph-store.ts
+++ b/src/code/stores/graph-store.ts
@@ -729,7 +729,7 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
             const codapConnect = CodapConnect.instance(DEFAULT_CONTEXT_NAME);
             codapConnect.sendRenameAttribute(node.key, prev);
           }
-          this._maybeChangeTransferTitle(node);
+          this._maybeChangeTransferTitle(node, prev);
         }
       }
     }
@@ -847,20 +847,14 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
     }
   },
 
-  _maybeChangeTransferTitle(changedNode) {
-    return (() => {
-      const result: any = [];
-      for (const key in this.nodeKeys) {
-        const node = this.nodeKeys[key];
-        const { transferLink } = node;
-        if (transferLink && ((transferLink.sourceNode === changedNode) || (transferLink.targetNode === changedNode))) {
-          result.push(this.changeNodeWithKey(key, {title: node.computeTitle()}));
-        } else {
-          result.push(undefined);
-        }
+  _maybeChangeTransferTitle(changedNode, prevTitle) {
+    for (const key in this.nodeKeys) {
+      const node = this.nodeKeys[key];
+      const { transferLink } = node;
+      if (transferLink && node.isDefaultTransferTitle(changedNode, prevTitle) && ((transferLink.sourceNode === changedNode) || (transferLink.targetNode === changedNode))) {
+        this.changeNodeWithKey(key, {title: node.computeTitle()});
       }
-      return result;
-    })();
+    }
   },
 
   _changeLink(link, changes) {


### PR DESCRIPTION
- When a flow variable is created it still gets the same default name and this name is hidden.
- If the user hovers over or selects a flow variable, the name becomes visible _and_ editable.
- If the user edits the variable name, then this name is now shown even when the variable is not selected or hovered over. In other words, it behaves just like any other variable.
- If the user delete the customized name of the flow variable, it reverts to its default name and hidden behavior.