### PR TITLE
Guard against LARA passing empty string

### DIFF
--- a/src/templates/lara.html.ejs
+++ b/src/templates/lara.html.ejs
@@ -86,10 +86,15 @@
     // mutates passed-in object by json-parsing any props that ought to be objects but
     // might be strings
     // (see bug https://www.pivotaltracker.com/n/projects/736901/stories/171888125)
+    // Note LARA may pass in an empty string, so we need to check the length
     const parseJSON = (obj, propsToParse) => {
       for (const prop of propsToParse) {
-        if (typeof obj[prop] === "string") {
-          obj[prop] = JSON.parse(obj[prop]);
+        if (typeof obj[prop] === "string" && obj[prop].length > 0) {
+          try {
+            obj[prop] = JSON.parse(obj[prop]);
+          } catch (e) {
+            // do nothing
+          }
         }
       }
     };


### PR DESCRIPTION
If a model has no authoredState, and the model is being used in runtime, LARA will pass in an initial state as 

```
{
    ...
    authoredState: null
}
```

which is fine.

However, for some reason in report-mode, LARA passes the initial state as

```
{
    ...
    authoredState: ""
}
```

which causes `JSON.parse` to throw an error. This adds a simple check on length which should fix that, and also protects it further with try/catch.

(This should also be fixed on LARA's end, but that's out of scope right now.)