### PR TITLE
Add fix to allow using React developer tools to inspect components inside an iframe

### DIFF
--- a/src/templates/index.html.ejs
+++ b/src/templates/index.html.ejs
@@ -62,6 +62,11 @@
   <div class="content-box">
     <div id='app'></div>
   </div>
+  <script>
+    if (window.parent !== window) {
+      window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    }
+  </script>
   <script type="text/javascript" charset="utf-8">
     var loading = true;
     var displaySeconds = 4;


### PR DESCRIPTION
Hello!

I was poking around the Sage Modeler plugin this morning and noticed that the React developer tools extension is not very helpful to explore/debug the component layout since iframed components don't appear in the developer tools by default (and most of the app is in an iframe). An issue on the React devtools repo [has a fix which appears to be widely adopted](https://github.com/facebook/react-devtools/issues/76) (and therefore hopefully doesn't have any unwanted side effects).

I made the corresponding change in `index.html.ejs` and everything seems to work out, so I figured I'd open a PR in case this is something you wanted to merge into the plugin. Thanks!