### PR TITLE
Collapsed slider dragging actions into one undoable step [#171509259]

### DIFF
--- a/src/code/stores/graph-store.ts
+++ b/src/code/stores/graph-store.ts
@@ -778,6 +778,10 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
       node.startSliderDrag({simulationDuration});
       _.map(this.linkedOutNodes(node), (outNode: Node) => outNode.startSliderDrag({simulationDuration}));
       this.updateListeners();
+      // start a command batch and disable further command batching due to changeNode()
+      // using a command batch with each slider movement value change
+      this.undoRedoManager.startCommandBatch("changeNodeViaSlider");
+      this.undoRedoManager.enableCommandBatching(false);
     }
   },
 
@@ -789,6 +793,9 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
       _.map(this.linkedOutNodes(node), (outNode: Node) => outNode.endSliderDrag({simulationDuration}));
       this.updateListeners();
     }
+    // do this outside of if in case node disappears
+    this.undoRedoManager.enableCommandBatching(true);
+    this.undoRedoManager.endCommandBatch();
   },
 
   clickLink(link, multipleSelectionsAllowed) {


### PR DESCRIPTION
This adds both the wrapping of a command batch around the slider start/end drag and a new setter method in the undoRedo manager to enable/disable further command batches.  This needed as each slider value change caused a seperate command batch to be created.

This also fixes a typo in the internal end command batch method.