### PR TITLE
Fix broken mini-graphs/broken initialValue setting [#180624189]

### DIFF
--- a/src/code/models/node.ts
+++ b/src/code/models/node.ts
@@ -112,12 +112,17 @@ export class Node extends GraphPrimitive {
     const accumulatorScaleUrlParam = (urlParams.collectorScale && Number(urlParams.collectorScale)) || 1;
     this.accumulatorInputScale = accumulatorScaleUrlParam > 0 ? accumulatorScaleUrlParam : 1;
 
-    // Save internal values of min, max and initialValues. Actual values retreived
-    // using @min or node.min will depend on whether we are in quantitative or
+    // Save internal values of min, max and initialValues. Actual values retrieved
+    // using this.min or node.min will depend on whether we are in quantitative or
     // semi-quantitative mode. (See getters and setters below).
     this._min = nodeSpec.min != null ? nodeSpec.min : SEMIQUANT_MIN;
     this._max = nodeSpec.max != null ? nodeSpec.max : this.isAccumulator ? SEMIQUANT_ACCUMULATOR_MAX : SEMIQUANT_MAX;
     this._initialValue = nodeSpec.initialValue != null ? nodeSpec.initialValue : Math.round(SEMIQUANT_MAX / 2);
+
+    // ensure that initial value is within range
+    // NOTE: we are using the _min/_max values already set instead of the min/max getters as those scale up for accumulators
+    // which then cause the initialValue getter to return values out of range
+    this._initialValue = Math.max(Math.min(this._initialValue, this._max), this._min);
 
     if (this.color == null) { this.color = ColorChoices[0].value; }
 

--- a/test/simulation-v2-test.ts
+++ b/test/simulation-v2-test.ts
@@ -109,14 +109,15 @@ describe("Simulation V2", () => {
       });
 
       describe("the result", () => {
-        it("should return initial values", () => {
+        // NOTE: this is a change - we now always cap initial values on load
+        it("should return initial values within min/max", () => {
           const simulation = new SimulationV2({
             nodes: [this.nodeA, this.nodeB],
             duration: 10
           });
           simulation.run();
-          this.nodeA.currentValue.should.equal(1e7);
-          this.nodeB.currentValue.should.equal(1e6);
+          this.nodeA.currentValue.should.equal(1000);
+          this.nodeB.currentValue.should.equal(100);
         });
         it("when nodes values are capped, it should return filtered initial values", () => {
           const simulation = new SimulationV2({


### PR DESCRIPTION
This fix ensures that the initial value of the node lies within the min/max values of the node.

This bug manifested itself with a saved model that had initial values of two accumulators set at 100000000.  This caused the graphs to not draw correctly as the value was outside of the allowed range.