### PR TITLE
Fix data export upon record [#180562893]

### DIFF
--- a/src/code/stores/app-settings-store.ts
+++ b/src/code/stores/app-settings-store.ts
@@ -12,7 +12,6 @@ import { ImportActions } from "../actions/import-actions";
 import { urlParams } from "../utils/url-params";
 import { StoreClass, StoreUnsubscriber } from "./store-class";
 import { Mixin } from "../mixins/components";
-import { CodapConnect } from "../models/codap-connect";
 
 export declare class AppSettingsActionsClass {
   public setComplexity(val: any): void;  // TODO: get concrete class
@@ -153,11 +152,6 @@ export const AppSettingsStore: AppSettingsStoreClass = Reflux.createStore({
   onSetSimulationType(val) {
     const prevSimulationType = this.settings.simulationType;
     this.settings.simulationType = val;
-
-    // if changing from static simulation remove the data point column if it is empty
-    if ((prevSimulationType === SimulationType.static) && (val !== SimulationType.static)) {
-      CodapConnect.instance("building-models").removeEmptyDataPointColumn();
-    }
 
     return this.notifyChange();
   },


### PR DESCRIPTION
At some point CODAP started deleting the samples subcollection when the data point column was deleted and the collection had no more attributes.

This fix moves the deleting of the extra column to after the simulation has run so that the collection remains when the column is removed.

This also adds code to re-create the missing subcollection on saved files.