### PR TITLE
181336977 add quick action menu

### DIFF
--- a/src/code/models/node.ts
+++ b/src/code/models/node.ts
@@ -16,7 +16,7 @@ import { GraphPrimitive } from "./graph-primitive";
 import { ColorChoices } from "../utils/colors";
 import { tr } from "../utils/translate";
 import { urlParams } from "../utils/url-params";
-import { PalleteItem } from "../stores/palette-store";
+import { PaletteItem } from "../stores/palette-store";
 import { Link } from "./link";
 
 const SEMIQUANT_MIN = 0;
@@ -70,7 +70,7 @@ export class Node extends GraphPrimitive {
   public readonly usesDefaultImage: boolean;
 
   protected allowNegativeValues: any; // TODO: get concrete type
-  protected paletteItem: PalleteItem;
+  protected paletteItem: PaletteItem;
   protected _min: any; // TODO: get concrete type
   protected _max: any; // TODO: get concrete type
   protected _initialValue: any; // TODO: get concrete type

--- a/src/code/models/node.ts
+++ b/src/code/models/node.ts
@@ -54,6 +54,7 @@ export class Node extends GraphPrimitive {
   public animateRescale: boolean = false;
   public uuid: string;
   public image: string;
+  public isFlowVariable: boolean;
 
   public readonly combineMethod: any; // TODO: get concrete type
   public readonly valueDefinedSemiQuantitatively: any; // TODO: get concrete type
@@ -65,7 +66,6 @@ export class Node extends GraphPrimitive {
   public readonly x: any; // TODO: get concrete type
   public readonly y: any; // TODO: get concrete type
   public readonly frames: any; // TODO: get concrete type
-  public readonly isFlowVariable: boolean;
   public readonly links: Link[];
   public readonly usesDefaultImage: boolean;
 

--- a/src/code/stores/palette-delete-dialog-store.ts
+++ b/src/code/stores/palette-delete-dialog-store.ts
@@ -1,7 +1,7 @@
 const _ = require("lodash");
 const Reflux = require("reflux");
 
-import { PaletteStore, PaletteActions, PalleteItem } from "./palette-store";
+import { PaletteStore, PaletteActions, PaletteItem } from "./palette-store";
 import { undoRedoInstance } from "../utils/undo-redo";
 import { NodesStore } from "./nodes-store";
 import { Mixin } from "../mixins/components";
@@ -101,7 +101,7 @@ export interface PaletteDeleteDialogMixinProps {}
 
 export interface PaletteDeleteDialogMixinState {
   showing: any; // TODO: get concrete type
-  paletteItem: PalleteItem;
+  paletteItem: PaletteItem;
   options: any; // TODO: get concrete type
   replacement: any; // TODO: get concrete type
   deleted: any; // TODO: get concrete type

--- a/src/code/stores/palette-store.ts
+++ b/src/code/stores/palette-store.ts
@@ -23,7 +23,7 @@ import { Node } from "../models/node";
 import { urlParams } from "../utils/url-params";
 import { AppSettingsStore } from "./app-settings-store";
 
-export interface PalleteItem {
+export interface PaletteItem {
   id: string;
   uuid: string;
   image: string;
@@ -40,7 +40,7 @@ export const PaletteActions = Reflux.createActions(
 );
 
 export const fixedPaletteItemIds = ["1", "flow-variable"];
-export const isFixedPaletteItem = (paletteItem: PalleteItem) => {
+export const isFixedPaletteItem = (paletteItem: PaletteItem) => {
   return fixedPaletteItemIds.indexOf(paletteItem.id) >= 0;
 };
 
@@ -49,20 +49,20 @@ interface LibraryMap {
 }
 
 export declare class PaletteStoreClass extends StoreClass {
-  public readonly palette: PalleteItem[];
+  public readonly palette: PaletteItem[];
   public readonly library: LibraryMap;
   public readonly collections: LibraryMap[];
-  public readonly selectedPaletteItem: PalleteItem;
+  public readonly selectedPaletteItem: PaletteItem;
   public readonly selectedPaletteIndex: number;
   public readonly selectedPaletteImage: ImageInfo;
   public readonly imageMetadata: ImageMetadata;
   public inLibrary(node: Node): boolean;
   public inPalette(node: Node): boolean;
-  public findByUUID(uuid: string): PalleteItem | undefined;
-  public getBlankPaletteItem(): PalleteItem | undefined;
-  public getFlowVariablePaletteItem(): PalleteItem | undefined;
-  public orderedPalette(): PalleteItem[];
-  public isFixedPaletteItem(paletteItem: PalleteItem): boolean;
+  public findByUUID(uuid: string): PaletteItem | undefined;
+  public getBlankPaletteItem(): PaletteItem | undefined;
+  public getFlowVariablePaletteItem(): PaletteItem | undefined;
+  public orderedPalette(): PaletteItem[];
+  public isFixedPaletteItem(paletteItem: PaletteItem): boolean;
 }
 
 export const PaletteStore: PaletteStoreClass = Reflux.createStore({
@@ -342,8 +342,8 @@ export const PaletteStore: PaletteStoreClass = Reflux.createStore({
   },
 
   orderedPalette() {
-    const result: PalleteItem[] = [];
-    const itemsById: Record<string, PalleteItem> = {};
+    const result: PaletteItem[] = [];
+    const itemsById: Record<string, PaletteItem> = {};
     const enableFlowVariable = this.simulationType === AppSettingsStore.SimulationType.time;
     this.palette.forEach(item => itemsById[item.id] = item);
     fixedPaletteItemIds.forEach(id => {
@@ -368,7 +368,7 @@ export interface PaletteMixinState {
   palette: any; // TODO: get concrete type
   library: any; // TODO: get concrete type
   collections: any;
-  selectedPaletteItem: PalleteItem;
+  selectedPaletteItem: PaletteItem;
   selectedPaletteIndex: any; // TODO: get concrete type
   selectedPaletteImage: any; // TODO: get concrete type
   imageMetadata: any; // TODO: get concrete type

--- a/src/code/utils/lang/en-US-master.json
+++ b/src/code/utils/lang/en-US-master.json
@@ -253,5 +253,12 @@
     "~SAGEMODELER.OPEN_OR_CREATE.OPEN_DOC": "Open Document or Browse Examples",
     "~SAGEMODELER.OPEN_OR_CREATE.NEW_DOC": "Create New Document",
     "~SAGEMODELER.OPEN_OR_CREATE.EXAMPLES": "Examples",
-    "~SAGEMODELER.SHARE_DIALOG.SERVER_URL": "SageModeler Server URL:"
+    "~SAGEMODELER.SHARE_DIALOG.SERVER_URL": "SageModeler Server URL:",
+
+    // quick actions
+    "~QUICK_ACTIONS.SET_IMAGE": "Set image",
+    "~QUICK_ACTIONS.CONVERT_TO_COLLECTOR": "Convert to collector",
+    "~QUICK_ACTIONS.CONVERT_TO_FLOW": "Convert to flow",
+    "~QUICK_ACTIONS.CONVERT_TO_STANDARD_VARIABLE": "Convert to standard variable",
+    "~QUICK_ACTIONS.CREATE_GRAPH": "Create graph"
 }

--- a/src/code/utils/lang/en-US.json
+++ b/src/code/utils/lang/en-US.json
@@ -253,6 +253,12 @@
     "~SAGEMODELER.OPEN_OR_CREATE.OPEN_DOC": "Open Document or Browse Examples",
     "~SAGEMODELER.OPEN_OR_CREATE.NEW_DOC": "Create New Document",
     "~SAGEMODELER.OPEN_OR_CREATE.EXAMPLES": "Examples",
-    "~SAGEMODELER.SHARE_DIALOG.SERVER_URL": "SageModeler Server URL:"
+    "~SAGEMODELER.SHARE_DIALOG.SERVER_URL": "SageModeler Server URL:",
+
+    "~QUICK_ACTIONS.SET_IMAGE": "Set image",
+    "~QUICK_ACTIONS.CONVERT_TO_COLLECTOR": "Convert to collector",
+    "~QUICK_ACTIONS.CONVERT_TO_FLOW": "Convert to flow",
+    "~QUICK_ACTIONS.CONVERT_TO_STANDARD_VARIABLE": "Convert to standard variable",
+    "~QUICK_ACTIONS.CREATE_GRAPH": "Create graph"
 }
 

--- a/src/code/views/app-view.tsx
+++ b/src/code/views/app-view.tsx
@@ -7,7 +7,7 @@ import { tr } from "../utils/translate";
 const _ = require("lodash");
 const log = require("loglevel");
 
-import { PaletteStore, PalleteItem } from "../stores/palette-store";
+import { PaletteStore, PaletteItem } from "../stores/palette-store";
 import { CodapStore } from "../stores/codap-store";
 import { LaraStore } from "../stores/lara-store";
 import { GoogleFileActions } from "../stores/google-file-store";
@@ -45,7 +45,7 @@ interface AppViewOuterProps {
 }
 interface AppViewOuterState {
   selectedNode: Node | null;
-  palette: PalleteItem[];
+  palette: PaletteItem[];
   undoRedoShowing: boolean;
   showBuildInfo: boolean;
   iframed: boolean;

--- a/src/code/views/image-picker-view.tsx
+++ b/src/code/views/image-picker-view.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-
 import { tr } from "../utils/translate";
 
 import { PaletteAddView } from "./palette-add-view";
@@ -8,35 +7,7 @@ import { Mixer } from "../mixins/components";
 
 import { Node } from "../models/node";
 import { ImageInfo } from "./preview-image-dialog-view";
-
-interface ImgChoiceViewProps {
-  node: Node;
-  selected: string;
-  onChange: (node: Node) => void;
-}
-
-interface ImgChoiceViewState {}
-
-class ImgChoiceView extends React.Component<ImgChoiceViewProps, ImgChoiceViewState> {
-
-  public static displayName = "ImgChoiceView";
-
-  public render() {
-    let className = "image-choice";
-    if (this.props.node.image === this.props.selected) {
-      className = "image-choice selected";
-    }
-    return (
-      <div className={className} onClick={this.handleSelectNode}>
-        <img src={this.props.node.image} className="image-choice" />
-      </div>
-    );
-  }
-
-  private handleSelectNode = () => {
-    return this.props.onChange(this.props.node);
-  }
-}
+import { ImgChoiceView } from "./img-choice-view";
 
 interface ImagePickerViewOuterProps {
   selected: string;

--- a/src/code/views/img-choice-view.tsx
+++ b/src/code/views/img-choice-view.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { Node } from "../models/node";
+import { PalleteItem } from "../stores/palette-store";
+
+interface ImgChoiceViewProps {
+  node: Node | PaletteItem;
+  selected: string;
+  onChange: (node: Node) => void;
+}
+
+interface ImgChoiceViewState {}
+
+export class ImgChoiceView extends React.Component<ImgChoiceViewProps, ImgChoiceViewState> {
+
+  public static displayName = "ImgChoiceView";
+
+  public render() {
+    let className = "image-choice";
+    if (this.props.node.image === this.props.selected) {
+      className = "image-choice selected";
+    }
+    return (
+      <div className={className} onClick={this.handleSelectNode}>
+        <img src={this.props.node.image} className="image-choice" />
+      </div>
+    );
+  }
+  private handleSelectNode = () => {
+    return this.props.onChange(this.props.node);
+  }
+}

--- a/src/code/views/img-choice-view.tsx
+++ b/src/code/views/img-choice-view.tsx
@@ -1,11 +1,13 @@
 import * as React from "react";
-import { Node } from "../models/node";
-import { PalleteItem } from "../stores/palette-store";
+
+interface HasImage {
+  image: string;
+}
 
 interface ImgChoiceViewProps {
-  node: Node | PaletteItem;
+  node: HasImage;
   selected: string;
-  onChange: (node: Node) => void;
+  onChange: (node: HasImage) => void;
 }
 
 interface ImgChoiceViewState {}

--- a/src/code/views/inspector-panel-view.tsx
+++ b/src/code/views/inspector-panel-view.tsx
@@ -22,7 +22,7 @@ import { Mixer } from "../mixins/components";
 import { Node } from "../models/node";
 import { Link } from "../models/link";
 import { GraphStoreClass } from "../stores/graph-store";
-import { PalleteItem } from "../stores/palette-store";
+import { PaletteItem } from "../stores/palette-store";
 
 interface ToolButtonViewProps {
   key?: string;
@@ -141,7 +141,7 @@ interface InspectorPanelViewOuterProps {
   link: Link | null;
   onNodeChanged: (node: Node, data: NodeChangedValues) => void;
   onNodeDelete: (node: Node) => void;
-  palette: PalleteItem[];
+  palette: PaletteItem[];
   graphStore: GraphStoreClass;
 }
 interface InspectorPanelViewOuterState {

--- a/src/code/views/node-view.tsx
+++ b/src/code/views/node-view.tsx
@@ -34,6 +34,7 @@ import { stepSize } from "../utils/step-size";
 import { logEvent } from "../utils/logger";
 import { TransferModel } from "../models/transfer";
 import { FlowImageView } from "./flow-image-view";
+import { QuickActionButton } from "./quick-action-button";
 
 interface NodeTitleViewOuterProps {
   isEditing: boolean;
@@ -329,13 +330,7 @@ getDefaultProps() {
             <div>
               <div className="actions">
                 <div className="connection-source action-circle icon-codap-link" data-node-key={this.props.nodeKey} />
-                {this.props.showGraphButton ?
-                  <div
-                    className="graph-source action-circle icon-codap-graph"
-                    draggable={true}
-                    onDragStart={handleDragStart}
-                    onClick={handleGraphButtonClick}
-                  /> : undefined}
+                <QuickActionButton node={this.props.data}/>
               </div>
               <div className={this.topClasses()} data-node-key={this.props.nodeKey}>
                 <div

--- a/src/code/views/node-view.tsx
+++ b/src/code/views/node-view.tsx
@@ -330,7 +330,11 @@ getDefaultProps() {
             <div>
               <div className="actions">
                 <div className="connection-source action-circle icon-codap-link" data-node-key={this.props.nodeKey} />
-                <QuickActionButton node={this.props.data}/>
+                <QuickActionButton
+                  node={this.props.data}
+                  showGraphButton={this.props.showGraphButton}
+                  graphClickHandler={handleGraphButtonClick}
+                />
               </div>
               <div className={this.topClasses()} data-node-key={this.props.nodeKey}>
                 <div

--- a/src/code/views/palette-delete-view.tsx
+++ b/src/code/views/palette-delete-view.tsx
@@ -4,12 +4,12 @@ const log = require("loglevel");
 import { tr } from "../utils/translate";
 import { PaletteDeleteDialogActions } from "../stores/palette-delete-dialog-store";
 import { ImagePickerView } from "./image-picker-view";
-import { PalleteItem } from "../stores/palette-store";
+import { PaletteItem } from "../stores/palette-store";
 
 interface PaletteDeleteViewProps {
   showReplacement: boolean;
-  replacement: PalleteItem;
-  paletteItem?: PalleteItem;
+  replacement: PaletteItem;
+  paletteItem?: PaletteItem;
   cancel?: () => void;
   ok?: () => void;
 }

--- a/src/code/views/palette-inspector-view.tsx
+++ b/src/code/views/palette-inspector-view.tsx
@@ -5,7 +5,7 @@ import { PaletteItemView } from "./palette-item-view";
 import { PaletteAddView } from "./palette-add-view";
 import { ImageMetadataView } from "./image-metadata-view";
 
-import { PaletteActions, PalleteItem, PaletteStore } from "../stores/palette-store";
+import { PaletteActions, PaletteStore, isFixedPaletteItem } from "../stores/palette-store";
 import { PaletteDeleteDialogActions } from "../stores/palette-delete-dialog-store";
 import { NodesMixin, NodesMixinProps, NodesMixinState } from "../stores/nodes-store";
 
@@ -31,8 +31,6 @@ export class PaletteInspectorView extends Mixer<PaletteInspectorViewProps, Palet
 
   private palette: HTMLDivElement | null;
 
-  private fixedPaletteItemIds = ["1", "flow-variable"];
-
   constructor(props: PaletteInspectorViewProps) {
     super(props);
     this.mixins = [new PaletteMixin(this), new NodesMixin(this), new AppSettingsMixin(this)];
@@ -48,7 +46,7 @@ export class PaletteInspectorView extends Mixer<PaletteInspectorViewProps, Palet
         <div className="palette" ref={el => this.palette = el}>
           <div>
             <PaletteAddView label={tr("~PALETTE-INSPECTOR.ADD_IMAGE")} />
-            {_.map(this.orderedPalette(), (node, index) => {
+            {_.map(PaletteStore.orderedPalette(), (node, index) => {
               return <PaletteItemView
                 key={node.uuid}
                 node={node}
@@ -65,7 +63,7 @@ export class PaletteInspectorView extends Mixer<PaletteInspectorViewProps, Palet
               {this.state.selectedPaletteItem.metadata
                 ? <ImageMetadataView small={true} metadata={this.state.selectedPaletteItem.metadata} update={PaletteActions.update} />
                 : undefined}
-              {!this.isFixedPaletteItem(this.state.selectedPaletteItem) ?
+              {!isFixedPaletteItem(this.state.selectedPaletteItem) ?
               <div className="palette-delete" onClick={this.handleDelete}>
                 {this.state.paletteItemHasNodes ?
                   <span>
@@ -99,26 +97,4 @@ export class PaletteInspectorView extends Mixer<PaletteInspectorViewProps, Palet
     PaletteDeleteDialogActions.open();
   }
 
-  private orderedPalette() {
-    const result: PalleteItem[] = [];
-    const itemsById: Record<string, PalleteItem> = {};
-    const enableFlowVariable = this.state.simulationType === AppSettingsStore.SimulationType.time;
-    this.state.palette.forEach(item => itemsById[item.id] = item);
-    this.fixedPaletteItemIds.forEach(id => {
-      // only display flow variable in time based simulations
-      if (itemsById[id] && (enableFlowVariable || id !== "flow-variable")) {
-        result.push(itemsById[id]);
-      }
-    });
-    this.state.palette.forEach(item => {
-      if (!this.isFixedPaletteItem(item)) {
-        result.push(item);
-      }
-    });
-    return result;
-  }
-
-  private isFixedPaletteItem(paletteItem: PalleteItem) {
-    return this.fixedPaletteItemIds.indexOf(paletteItem.id) >= 0;
-  }
 }

--- a/src/code/views/palette-inspector-view.tsx
+++ b/src/code/views/palette-inspector-view.tsx
@@ -15,7 +15,10 @@ import { PaletteMixinProps, PaletteMixinState, PaletteMixin } from "../stores/pa
 import { AppSettingsStore, AppSettingsMixin, AppSettingsMixinProps, AppSettingsMixinState } from "../stores/app-settings-store";
 import { Mixer } from "../mixins/components";
 
-interface PaletteInspectorViewOuterProps {}
+interface PaletteInspectorViewOuterProps {
+  hideSelectedInspector?: boolean;
+}
+
 type PaletteInspectorViewProps = PaletteInspectorViewOuterProps & PaletteMixinProps & NodesMixinProps & AppSettingsMixinProps;
 
 interface PaletteInspectorViewOuterState {
@@ -56,7 +59,7 @@ export class PaletteInspectorView extends Mixer<PaletteInspectorViewProps, Palet
             })}
           </div>
         </div>
-        {this.state.selectedPaletteItem ?
+        {this.state.selectedPaletteItem && (!this.props.hideSelectedInspector) ?
           <div className="palette-about-image">
             <div className="palette-about-image-info">
               {this.state.selectedPaletteItem.metadata

--- a/src/code/views/quick-action-button.tsx
+++ b/src/code/views/quick-action-button.tsx
@@ -1,0 +1,73 @@
+import { Node } from "../models/node";
+import { tr } from "../utils/translate";
+import * as React from "react";
+import { runInThisContext } from "vm";
+
+export type CircleButtonState = "default" | "hover" | "active" | "disabled";
+
+export interface QuickActionButtonProps {
+    node: Node;
+}
+
+export interface QuickActionButtonState {
+  state: CircleButtonState;
+}
+
+
+const VerticalEllipse = (props: {size: number} = {size: 16} ) => {
+  const {size} = props;
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path fill-rule="evenodd" d="M6 12a2 2 0 11-4 0 2 2 0 014 0zm8 0a2 2 0 11-4 0 2 2 0 014 0zm6 2a2 2 0 100-4 2 2 0 000 4z" fill="white" transform="translate(24, 0) rotate(90)" />
+    </svg>
+  );
+};
+
+export class QuickActionButton extends React.Component<QuickActionButtonProps, QuickActionButtonState> {
+  constructor(props: QuickActionButtonProps) {
+    super(props);
+    this.state = { state: "default" };
+  }
+
+  public render() {
+    const node = this.props.node;
+    return(
+      <>
+        <div
+          className="graph-source action-circle"
+          data-node-key={node.key}
+          onClick={this.handleClick}
+        >
+          <VerticalEllipse size={16}/>
+        </div>
+        {this.renderOtherDiv()}
+      </>
+    );
+  }
+
+  private renderOtherDiv() {
+    if (this.state.state === "active") {
+      return (
+        <div className="quick-actions-panel">
+          This is a panel thing
+        </div>
+      );
+    }
+    return "";
+  }
+
+  private toggleState = (): void => {
+    const state = this.state.state;
+    console.log("click state", this.state);
+    if (state === "default") {
+      this.setState({ state: "active" });
+    } else if (state === "active") {
+      this.setState({ state: "default" });
+    }
+  }
+
+  private handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    this.toggleState();
+  }
+
+}

--- a/src/code/views/quick-action-button.tsx
+++ b/src/code/views/quick-action-button.tsx
@@ -1,7 +1,6 @@
 import { Node } from "../models/node";
-import { tr } from "../utils/translate";
 import * as React from "react";
-import { runInThisContext } from "vm";
+import { QuickActionMenu } from "./quick-action-menu";
 
 export type CircleButtonState = "default" | "hover" | "active" | "disabled";
 
@@ -48,9 +47,7 @@ export class QuickActionButton extends React.Component<QuickActionButtonProps, Q
   private renderOtherDiv() {
     if (this.state.state === "active") {
       return (
-        <div className="quick-actions-panel">
-          This is a panel thing
-        </div>
+        <QuickActionMenu node={this.props.node} />
       );
     }
     return "";

--- a/src/code/views/quick-action-button.tsx
+++ b/src/code/views/quick-action-button.tsx
@@ -6,6 +6,8 @@ export type CircleButtonState = "default" | "hover" | "active" | "disabled";
 
 export interface QuickActionButtonProps {
     node: Node;
+    graphClickHandler?: () => void;
+    showGraphButton?: boolean;
 }
 
 export interface QuickActionButtonState {
@@ -47,13 +49,14 @@ export class QuickActionButton extends React.Component<QuickActionButtonProps, Q
   private renderOtherDiv() {
     if (this.state.state === "active") {
       const closeActionMenu = () => {
-        console.log("Closing things");
         this.setState({state: "default"});
       };
       return (
         <QuickActionMenu
           node={this.props.node}
           closeFn={closeActionMenu}
+          showGraphButton={this.props.showGraphButton}
+          graphClickHandler={this.props.graphClickHandler}
         />
       );
     }

--- a/src/code/views/quick-action-button.tsx
+++ b/src/code/views/quick-action-button.tsx
@@ -65,7 +65,6 @@ export class QuickActionButton extends React.Component<QuickActionButtonProps, Q
 
   private toggleState = (): void => {
     const state = this.state.state;
-    console.log("click state", this.state);
     if (state === "default") {
       this.setState({ state: "active" });
     } else if (state === "active") {

--- a/src/code/views/quick-action-button.tsx
+++ b/src/code/views/quick-action-button.tsx
@@ -46,8 +46,15 @@ export class QuickActionButton extends React.Component<QuickActionButtonProps, Q
 
   private renderOtherDiv() {
     if (this.state.state === "active") {
+      const closeActionMenu = () => {
+        console.log("Closing things");
+        this.setState({state: "default"});
+      };
       return (
-        <QuickActionMenu node={this.props.node} />
+        <QuickActionMenu
+          node={this.props.node}
+          closeFn={closeActionMenu}
+        />
       );
     }
     return "";

--- a/src/code/views/quick-action-menu.tsx
+++ b/src/code/views/quick-action-menu.tsx
@@ -143,9 +143,8 @@ export class QuickActionMenu extends React.Component<QuickActionMenuProps, Quick
             callback={imageAddCallback}
           />
           { palette.map((pi, i) =>
-            <div className="image-choice-wrapper" key={i}>
+            <div className="image-choice-wrapper" key={pi.uuid}>
               <ImgChoiceView
-                key={i}
                 node={pi}
                 selected={selected}
                 onChange={onImageChage}

--- a/src/code/views/quick-action-menu.tsx
+++ b/src/code/views/quick-action-menu.tsx
@@ -6,6 +6,8 @@ import { PaletteStore } from "../stores/palette-store";
 import { SimulationStore } from "../stores/simulation-store";
 import { AppSettingsStore, SimulationType } from "../stores/app-settings-store";
 import { nodeName } from "jquery";
+import { PaletteAddView } from "./palette-add-view";
+import { GraphStore } from "../stores/graph-store";
 
 export interface QuickActionMenuProps {
     node: Node;
@@ -92,17 +94,16 @@ export class QuickActionMenu extends React.Component<QuickActionMenuProps, Quick
                   >
                     {flowLabel}
                   </li>
+
+                  <li
+                    className={standardClasses}
+                    onClick={this.convertToStandard}
+                    onMouseEnter={hideImagesF}
+                  >
+                  {standardVariableLabel}
+                  </li>
                 </>
               }
-
-
-              <li
-                className={standardClasses}
-                onClick={this.convertToStandard}
-                onMouseEnter={hideImagesF}
-              >
-                {standardVariableLabel}
-              </li>
 
               {showGraphButton &&
                 <li
@@ -116,7 +117,7 @@ export class QuickActionMenu extends React.Component<QuickActionMenuProps, Quick
 
             </ul>
           </div>
-          {showImages && this.renderRightMenu()}
+          {true && this.renderRightMenu()}
         </div>
       </>
     );
@@ -125,14 +126,32 @@ export class QuickActionMenu extends React.Component<QuickActionMenuProps, Quick
   private renderRightMenu() {
     const thisNode = this.props.node;
     const selected = thisNode.image;
-    const onChange = (i: {image: string}) => thisNode.image = i.image;
-    const palette = PaletteStore.palette;
+    const onImageChage = (i: {image: string}) =>  {
+      GraphStore.changeNode({ image: i.image }, thisNode);
+    };
+
+    const palette = PaletteStore.orderedPalette();
+    const imageAddCallback = (i: {image: string}) => {
+      this.setState({ showImages: true, closeTimer: null });
+      GraphStore.changeNode({ image: i.image }, thisNode);
+    };
     return (
       <div className="right-panel">
         <div className="image-choices">
+          <PaletteAddView
+            label={tr("~PALETTE-INSPECTOR.ADD_IMAGE")}
+            callback={imageAddCallback}
+          />
           { palette.map((pi, i) =>
-              <ImgChoiceView key={i} node={pi} selected={selected} onChange={onChange} />)
-          }
+            <div className="image-choice-wrapper" key={i}>
+              <ImgChoiceView
+                key={i}
+                node={pi}
+                selected={selected}
+                onChange={onImageChage}
+              />
+            </div>
+          )}
         </div>
       </div>
     );
@@ -161,20 +180,17 @@ export class QuickActionMenu extends React.Component<QuickActionMenuProps, Quick
 
   private convertToCollector = (): void => {
     const {node} = this.props;
-    node.isAccumulator = true;
-    node.isFlowVariable = false;
+    GraphStore.changeNode({ isFlowVariable: false, isAccumulator: true}, node);
   }
 
   private convertToFlow = (): void => {
     const {node} = this.props;
-    node.isFlowVariable = true;
-    node.isAccumulator = false;
+    GraphStore.changeNode({ isFlowVariable: true, isAccumulator: false }, node);
   }
 
   private convertToStandard = (): void => {
     const {node} = this.props;
-    node.isFlowVariable = false;
-    node.isAccumulator = false;
+    GraphStore.changeNode({ isFlowVariable: false, isAccumulator: false }, node);
   }
 
   private createGraph = (): void => {

--- a/src/code/views/quick-action-menu.tsx
+++ b/src/code/views/quick-action-menu.tsx
@@ -10,6 +10,8 @@ import { nodeName } from "jquery";
 export interface QuickActionMenuProps {
     node: Node;
     closeFn?: () => void;
+    showGraphButton?: boolean;
+    graphClickHandler?: () => void;
 }
 
 export interface QuickActionMenuState {
@@ -53,6 +55,8 @@ export class QuickActionMenu extends React.Component<QuickActionMenuProps, Quick
 
     const showImagesF = () => this.setState({ showImages: true });
     const hideImagesF = () =>  this.setState({ showImages: false });
+
+    const { showGraphButton  } = this.props;
     return(
       <>
         <div
@@ -100,13 +104,16 @@ export class QuickActionMenu extends React.Component<QuickActionMenuProps, Quick
                 {standardVariableLabel}
               </li>
 
-              <li
-                className={createGraphClasses}
-                onClick={this.createGraph}
-                onMouseEnter={hideImagesF}
-              >
-                {createGraphLabel}
-              </li>
+              {showGraphButton &&
+                <li
+                  className={createGraphClasses}
+                  onClick={this.createGraph}
+                  onMouseEnter={hideImagesF}
+                >
+                  {createGraphLabel}
+                </li>
+              }
+
             </ul>
           </div>
           {showImages && this.renderRightMenu()}
@@ -171,6 +178,9 @@ export class QuickActionMenu extends React.Component<QuickActionMenuProps, Quick
   }
 
   private createGraph = (): void => {
-    console.log("create graph");
+    const {graphClickHandler} = this.props;
+    if (graphClickHandler) {
+      graphClickHandler();
+    }
   }
 }

--- a/src/code/views/quick-action-menu.tsx
+++ b/src/code/views/quick-action-menu.tsx
@@ -1,0 +1,104 @@
+import * as React from "react";
+import { Node } from "../models/node";
+import { tr } from "../utils/translate";
+import { ImgChoiceView } from "./img-choice-view";
+import { PaletteStore } from "../stores/palette-store";
+
+export interface QuickActionMenuProps {
+    node: Node;
+}
+
+export interface QuickActionMenuState {
+  showImages: boolean;
+}
+
+
+export class QuickActionMenu extends React.Component<QuickActionMenuProps, QuickActionMenuState> {
+  constructor(props: QuickActionMenuProps) {
+    super(props);
+    this.state = { showImages: false };
+  }
+
+  public render() {
+    const node = this.props.node;
+    const { showImages } = this.state;
+    const rightMenuClasses = showImages ? "right-menu" : "right-menu hidden";
+    const isAccumulator = node.isAccumulator;
+    const isFlow = node.isFlowVariable;
+    const isStandardVariable = !(isAccumulator || isFlow);
+
+    const collectorLabel = tr("~QUICK_ACTIONS.CONVERT_TO_COLLECTOR");
+    const collectorClasses = isAccumulator ? "quick-action-menu-label disabled" : "quick-action-menu-label";
+
+    const flowLabel = tr("~QUICK_ACTIONS.CONVERT_TO_FLOW");
+    const flowClasses = isFlow ? "quick-action-menu-label disabled" : "quick-action-menu-label";
+
+    const standardVariableLabel = tr("~QUICK_ACTIONS.CONVERT_TO_STANDARD_VARIABLE");
+    const standardClasses = isStandardVariable ? "quick-action-menu-label disabled" : "quick-action-menu-label";
+
+    const setImageLabel = tr("~QUICK_ACTIONS.SET_IMAGE");
+    const setImageClasses = showImages ? "quick-action-menu-label disabled" : "quick-action-menu-label";
+
+    const createGraphLabel = tr("~QUICK_ACTIONS.CREATE_GRAPH");
+    const createGraphClasses = "quick-action-menu-label";
+
+    return(
+      <>
+        <div className="quick-action-menu">
+          <div className="left-panel">
+            <ul>
+              <li className={setImageClasses} onClick={this.toggleShowImages}>{setImageLabel}</li>
+              <li className={collectorClasses} onClick={this.convertToCollector}>{collectorLabel}</li>
+              <li className={flowClasses} onClick={this.convertToFlow}>{flowLabel}</li>
+              <li className={standardClasses} onClick={this.convertToStandard}>{standardVariableLabel}</li>
+              <li className={createGraphClasses} onClick={this.createGraph}>{createGraphLabel}</li>
+            </ul>
+          </div>
+          {showImages && this.renderRightMenu()}
+        </div>
+      </>
+    );
+  }
+
+  private renderRightMenu() {
+    const thisNode = this.props.node;
+    const selected = thisNode.image;
+    const onChange = () => console.log("change");
+    const palette = PaletteStore.palette;
+    return (
+      <div className="right-panel">
+        <div className="image-choices">
+          { palette.map((pi, i) =>
+              <ImgChoiceView key={i} node={pi} selected={selected} onChange={onChange} />)
+          }
+        </div>
+      </div>
+    );
+  }
+
+  private toggleShowImages = (): void => {
+    const {showImages} = this.state;
+    console.log("click state", this.state);
+    this.setState({ showImages: !showImages });
+  }
+
+  private convertToCollector = (): void => {
+    console.log("convert to collector");
+  }
+
+  private convertToFlow = (): void => {
+    console.log("convert to flow");
+  }
+
+  private convertToStandard = (): void => {
+    console.log("convert to standard");
+  }
+
+  private createGraph = (): void => {
+    console.log("create graph");
+  }
+
+  private handleChangeImage = (n: Node): void => {
+    console.log("handleChangeImage graph");
+  }
+}

--- a/src/code/views/quick-action-menu.tsx
+++ b/src/code/views/quick-action-menu.tsx
@@ -6,17 +6,19 @@ import { PaletteStore } from "../stores/palette-store";
 
 export interface QuickActionMenuProps {
     node: Node;
+    closeFn?: () => void;
 }
 
 export interface QuickActionMenuState {
   showImages: boolean;
+  closeTimer: NodeJS.Timeout|null;
 }
 
 
 export class QuickActionMenu extends React.Component<QuickActionMenuProps, QuickActionMenuState> {
   constructor(props: QuickActionMenuProps) {
     super(props);
-    this.state = { showImages: false };
+    this.state = { showImages: false,  closeTimer: null };
   }
 
   public render() {
@@ -37,21 +39,61 @@ export class QuickActionMenu extends React.Component<QuickActionMenuProps, Quick
     const standardClasses = isStandardVariable ? "quick-action-menu-label disabled" : "quick-action-menu-label";
 
     const setImageLabel = tr("~QUICK_ACTIONS.SET_IMAGE");
-    const setImageClasses = showImages ? "quick-action-menu-label disabled" : "quick-action-menu-label";
+    const setImageClasses = showImages ? "quick-action-menu-label with-icon disabled" : "quick-action-menu-label with-icon";
 
     const createGraphLabel = tr("~QUICK_ACTIONS.CREATE_GRAPH");
     const createGraphClasses = "quick-action-menu-label";
-
+    const showImagesF = () => this.setState({ showImages: true });
+    const hideImagesF = () =>  this.setState({ showImages: false });
     return(
       <>
-        <div className="quick-action-menu">
+        <div
+          className="quick-action-menu"
+          onMouseEnter={this.handleMouseEnter}
+          onMouseLeave={this.handleMouseLeave}
+        >
           <div className="left-panel">
             <ul>
-              <li className={setImageClasses} onClick={this.toggleShowImages}>{setImageLabel}</li>
-              <li className={collectorClasses} onClick={this.convertToCollector}>{collectorLabel}</li>
-              <li className={flowClasses} onClick={this.convertToFlow}>{flowLabel}</li>
-              <li className={standardClasses} onClick={this.convertToStandard}>{standardVariableLabel}</li>
-              <li className={createGraphClasses} onClick={this.createGraph}>{createGraphLabel}</li>
+              <li
+                className={setImageClasses}
+                onClick={this.toggleShowImages}
+                onMouseEnter={showImagesF}
+              >
+                <div>{setImageLabel}</div>
+                <div className="icon-codap-inspectorArrow-collapse"/>
+              </li>
+
+              <li
+                className={collectorClasses}
+                onClick={this.convertToCollector}
+                onMouseEnter={hideImagesF}
+              >
+                {collectorLabel}
+              </li>
+
+              <li
+                className={flowClasses}
+                onClick={this.convertToFlow}
+                onMouseEnter={hideImagesF}
+              >
+                {flowLabel}
+              </li>
+
+              <li
+                className={standardClasses}
+                onClick={this.convertToStandard}
+                onMouseEnter={hideImagesF}
+              >
+                {standardVariableLabel}
+              </li>
+
+              <li
+                className={createGraphClasses}
+                onClick={this.createGraph}
+                onMouseEnter={hideImagesF}
+              >
+                {createGraphLabel}
+              </li>
             </ul>
           </div>
           {showImages && this.renderRightMenu()}
@@ -76,6 +118,24 @@ export class QuickActionMenu extends React.Component<QuickActionMenuProps, Quick
     );
   }
 
+  private handleMouseEnter = () => {
+    if (this.state.closeTimer) {
+      clearTimeout(this.state.closeTimer);
+    }
+    this.setState({ closeTimer: null });
+    console.log("mouse enter");
+  }
+
+  private handleMouseLeave = () => {
+    const {closeFn} = this.props;
+    console.log("mouse leave");
+    if (closeFn) {
+      const nextTimeout = setTimeout(() => {
+        closeFn();
+      }, 500);
+      this.setState({ closeTimer: nextTimeout });
+    }
+  }
   private toggleShowImages = (): void => {
     const {showImages} = this.state;
     console.log("click state", this.state);

--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -282,12 +282,3 @@ $node-design-height = 94px
 .jsplumb-connector
   z-index 0
 
-.quick-actions-panel {
-  position absolute;
-  border-radius 5px;
-  background-color white;
-  border: 1px solid light-gray;
-  padding: 5px;
-  left: 95px;
-  z-index: 1002;
-}

--- a/src/stylus/components/node.styl
+++ b/src/stylus/components/node.styl
@@ -281,3 +281,13 @@ $node-design-height = 94px
 
 .jsplumb-connector
   z-index 0
+
+.quick-actions-panel {
+  position absolute;
+  border-radius 5px;
+  background-color white;
+  border: 1px solid light-gray;
+  padding: 5px;
+  left: 95px;
+  z-index: 1002;
+}

--- a/src/stylus/components/quick-action-menu.styl
+++ b/src/stylus/components/quick-action-menu.styl
@@ -1,0 +1,52 @@
+.quick-action-menu {
+  position absolute;
+  border-radius 5px;
+  background-color white;
+  border: 1px solid light-gray;
+  padding: 0px;
+  left: 95px;
+  top: -16px;
+  z-index: 1;
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  justify-content: flex-start;
+  color: black;
+  font-size: 14px;
+  line-height: 1.6;
+  text-align: left;
+  height: 126px;
+  > div {
+    padding: 5px;
+    margin: 0px;
+    min-width:200px;
+    background: light-gray;
+    border: 1px solid blue-gray;
+  }
+  .left-panel {
+    ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    .disabled {
+      opacity: 0.5;
+    }
+  }
+  .right-panel {
+    overflow: scroll
+    flex-grow: 2;
+    .image-choices {
+      display: flex;
+      flex-direction: row;
+      align-items: flex-start;
+      justify-content: flex-start;
+      flex-wrap: wrap;
+    }
+    .image-choice {
+      padding: 0px;
+      margin: 5px;
+      height: 40px;
+    }
+  }
+}

--- a/src/stylus/components/quick-action-menu.styl
+++ b/src/stylus/components/quick-action-menu.styl
@@ -6,7 +6,7 @@
   padding: 0px;
   left: 95px;
   top: -16px;
-  z-index: 1;
+  z-index: 12; //Node titles z-index is 10
   display: flex;
   flex-direction: row;
   align-items: stretch;
@@ -28,6 +28,17 @@
       list-style: none;
       margin: 0;
       padding: 0;
+    }
+
+    li:hover {
+      cursor: pointer;
+      color: dark-blue;
+    }
+    .with-icon {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
     }
     .disabled {
       opacity: 0.5;

--- a/src/stylus/components/quick-action-menu.styl
+++ b/src/stylus/components/quick-action-menu.styl
@@ -1,7 +1,7 @@
 .quick-action-menu {
-  position absolute;
-  border-radius 5px;
-  background-color white;
+  position: absolute;
+  border-radius: 5px;
+  background-color: none;
   border: 1px solid light-gray;
   padding: 0px;
   left: 95px;
@@ -9,7 +9,7 @@
   z-index: 12; //Node titles z-index is 10
   display: flex;
   flex-direction: row;
-  align-items: stretch;
+  align-items: flex-start;
   justify-content: flex-start;
   color: black;
   font-size: 14px;

--- a/src/stylus/components/quick-action-menu.styl
+++ b/src/stylus/components/quick-action-menu.styl
@@ -50,13 +50,21 @@
     .image-choices {
       display: flex;
       flex-direction: row;
-      align-items: flex-start;
-      justify-content: flex-start;
+      align-items: center;
+      justify-content: space-between;
       flex-wrap: wrap;
+    }
+    .image-choice-wrapper {
+      padding: 2px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 44px;
     }
     .image-choice {
       padding: 0px;
-      margin: 5px;
+      margin: 0px;
       height: 40px;
     }
   }


### PR DESCRIPTION
This PR adds a "quick actions menu" in the top left of the node view.

It lets the user change the kind of variable (to test thoroughly the model settings must be for a dynamic model), and change the icon.


![image](https://user-images.githubusercontent.com/22908/158260020-38886d5d-863d-4e1f-9c05-1fafe3b45061.png)


