### PR TITLE
Removed default "New Model" filename [#181175814]

### DIFF
--- a/src/code/stores/graph-store.ts
+++ b/src/code/stores/graph-store.ts
@@ -1138,7 +1138,7 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
       this.removeNode(node);
     }
     GraphPrimitive.resetCounters();
-    this.setFilename("New Model");
+    this.setFilename(null);
     return this.undoRedoManager.clearHistory();
   },
 

--- a/src/code/utils/importer.ts
+++ b/src/code/utils/importer.ts
@@ -30,7 +30,14 @@ export class Importer {
     this.importLinks(data.links);
     // set the nextID counters
     GraphPrimitive.initCounters({nodes: this.graphStore.getNodes(), links: this.graphStore.getLinks()});
-    return this.graphStore.setFilename(data.filename || "New Model");
+
+    // Update with the saved filename
+    // NOTE: we used to use "New Model" as the default but this caused hash(dataOnLoad) !== hash(dataOnSave)
+    // which then caused immediate saves when a new model was loaded.  These immediate saves caused the linked
+    // interactive UI to show as it compares save times to figure out it content changed.
+    // We opted to remove the default here instead of setting the default in graphStore.init() so that old
+    // saved models, with null as their filename, would hash the same.
+    return this.graphStore.setFilename(data.filename);
   }
 
   public importNode(nodeSpec) {

--- a/test/graph-store-test.ts
+++ b/test/graph-store-test.ts
@@ -22,6 +22,53 @@ describe("The Graphstore", () => {
 
   afterEach(() => UnStub());
 
+  describe("default filename", () => {
+    it("should not have a default filename after init", () => {
+      expect(this.graphStore.filename).to.equal(null);
+    });
+
+    it("should not have a default filename after deleting all", () => {
+      this.graphStore.setFilename("test");
+      expect(this.graphStore.filename).to.equal("test");
+      this.graphStore.deleteAll();
+      expect(this.graphStore.filename).to.equal(null);
+    });
+
+    it("should not have a default filename after loading data with a null filename", () => {
+      const data: Record<string, any> = {
+        "version": "1.25.0",
+        "filename": null,
+        "palette": [],
+        "nodes": [],
+        "links": [],
+        "settings": {
+          "complexity": 1,
+          "simulationType": 2,
+          "relationshipSymbols": false,
+          "guide": false,
+          "simulation": {
+            "duration": 20,
+            "stepUnits": "STEP",
+            "capNodeValues": false
+          }
+        }
+      };
+
+      expect(data.filename).to.equal(null);
+      expect(this.graphStore.filename).to.equal(null);
+
+      this.graphStore.loadData(data);
+      expect(this.graphStore.filename).to.equal(null);
+
+      this.graphStore.deleteAll();
+      expect(this.graphStore.filename).to.equal(null);
+
+      data.filename = "New Model";
+      this.graphStore.loadData(data);
+      expect(this.graphStore.filename).to.equal("New Model");
+    });
+  });
+
   describe("with transfer nodes", () => {
     beforeEach(() => {
       this.graphStore.loadData({


### PR DESCRIPTION
We used to use "New Model" as the default but this caused
hash(dataOnLoad) !== hash(dataOnSave) which then caused
immediate saves when a new model was loaded.  These
immediate saves caused the linked interactive UI to show
as it compares save times to figure out it content changed.
We opted to remove the default here instead of setting the
default in graphStore.init() so that old saved models, with
null as their filename, would hash the same.