### PR TITLE
Only show selected link in relationship panel and enable link panel when link selected [#164294939] [#181336183]

### DIFF
--- a/src/code/stores/graph-store.ts
+++ b/src/code/stores/graph-store.ts
@@ -922,7 +922,7 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
     clearTimeout(this.lastClickLinkTimeout);
 
     if (isDoubleClick) {
-      this.selectionManager.selectNodeForInspection(link.targetNode);
+      this.selectionManager.selectLinkForInspection(link);
       return InspectorPanelActions.openInspectorPanel("relations", {link});
     } else {
       // set single click handler to run 250ms from now so we can wait to see if this is a double click

--- a/src/code/views/inspector-panel-view.tsx
+++ b/src/code/views/inspector-panel-view.tsx
@@ -78,7 +78,7 @@ class ToolPanelView extends React.Component<ToolPanelViewProps, ToolPanelViewSta
   private buttonData: ToolPanelButton[] = [
     {name: "styles", simple: true, shows: "design", "enabled": ["node", "link"] },
     {name: "values", simple: false, shows: "value", "enabled": ["node"] },
-    {name: "qualRel", simple: true, shows: "relations", "enabled": ["dependent-node"]},
+    {name: "qualRel", simple: true, shows: "relations", "enabled": ["dependent-node", "link"]},
     {name: "options",  simple: true, shows: "simulation", "enabled": ["nothing"] }
   ];
 

--- a/src/code/views/relation-inspector-view.tsx
+++ b/src/code/views/relation-inspector-view.tsx
@@ -51,7 +51,7 @@ export class RelationInspectorView extends Mixer<RelationInspectorViewProps, Rel
     if (node) {
       return this.renderNodeRelationInspector(node);
     } else if (link) {
-      return this.renderLinkRelationInspector();
+      return this.renderLinkRelationInspector(link);
     } else {
       return <div />;
     }
@@ -104,8 +104,16 @@ export class RelationInspectorView extends Mixer<RelationInspectorViewProps, Rel
     );
   }
 
-  private renderLinkRelationInspector() {
-    return <div className="relation-inspector" />;
+  private renderLinkRelationInspector(link: Link) {
+    return (
+      <div className="relation-inspector" >
+        <TabbedPanelView
+          tabs={[this.renderTabforLink(link)]}
+          selectedTabIndex={0}
+          onTabSelected={this.ignoreTabSelected}
+        />
+      </div>
+    );
   }
 
   private handleTabSelected = (index) => {
@@ -114,6 +122,8 @@ export class RelationInspectorView extends Mixer<RelationInspectorViewProps, Rel
       InspectorPanelActions.openInspectorPanel("relations", {link: __guard__(node.inLinks(), x => x[index])});
     }
   }
+
+  private ignoreTabSelected = () => undefined;
 
   private handleMethodSelected = (evt) => {
     const {node} = this.props;


### PR DESCRIPTION
With this change only the selected link is shown in the relationship panel when there are multiple links into a node and a link is double clicked in the graph.  This also enables the link panel when a link is simply selected.

**NOTE**: this is one of the rare cases where YAGNI didn't apply.  The code was setup to handle showing only the link selected but it was stubbed out for later (now) use.