### PR TITLE
Switched position of transfer link symbol positions [#181337002]

### DIFF
--- a/src/code/utils/js-plumb-diagram-toolkit.ts
+++ b/src/code/utils/js-plumb-diagram-toolkit.ts
@@ -304,6 +304,7 @@ export class DiagramToolkit {
     let changeIndicator: string|null = "";
     let changeLocation = 0.9;
     const reversedChangeLocation = 1 - changeLocation;
+    const transferChangeLocation = 0.8;
     let thickness = Math.abs(opts.magnitude);
     if (!thickness) {
       thickness = 1;
@@ -347,7 +348,7 @@ export class DiagramToolkit {
         changeIndicator = minusChangeIndicator;
       } else if (opts.isTransfer) {
         changeIndicator = opts.fromSource ? minusChangeIndicator : plusChangeIndicator;
-        changeLocation = opts.fromSource ? reversedChangeLocation : changeLocation;
+        changeLocation = opts.fromSource ? transferChangeLocation : reversedChangeLocation;
       }
       thickness = 10;
       fixedColor = LinkColors.transferPipe;


### PR DESCRIPTION
The transfer links now have their relationship symbols next to the transfer variables instead of at the ends of the link.

Old:

![image](https://user-images.githubusercontent.com/112938/159742766-9871ea3d-bed7-4a1a-8779-0de78fd9e69f.png)

New:

![image](https://user-images.githubusercontent.com/112938/159742604-3ced1474-b48c-4d0b-9c3d-571d1e9a69ea.png)
