### PR TITLE
Fixed z-index of modal background [#159109098]

### DIFF
--- a/src/stylus/app.styl
+++ b/src/stylus/app.styl
@@ -1,7 +1,6 @@
 @require 'menu-glyphs.styl'
 @require 'spin.styl'
 @require 'mixins/ordered-mixins.styl'
-@require 'components/modal.styl'
 @require 'components/**/**'
 @require 'test.styl'
 

--- a/src/stylus/mixins/ordered-mixins.styl
+++ b/src/stylus/mixins/ordered-mixins.styl
@@ -5,3 +5,7 @@
 @require 'components.styl'
 
 @require 'metrics.styl'
+
+// node-z-index before modal as it is used within it
+@require 'components/node-z-index.styl'
+@require 'components/modal.styl'


### PR DESCRIPTION
This adds the node-z-index constants to the stylus build before the modal styles so that the z-index variable is defined for the background.  With the invalid z-index the background click handler was not being called.