### PR TITLE
Add relationship symbols to transfer modifier links [#181337002]

### DIFF
--- a/src/code/utils/js-plumb-diagram-toolkit.ts
+++ b/src/code/utils/js-plumb-diagram-toolkit.ts
@@ -13,6 +13,7 @@ import { LinkColors } from "../utils/link-colors";
 import * as $ from "jquery";
 
 import { getViewScale, registerScaleListener } from "../utils/scale-app";
+import { RelationFactory } from "../models/relation-factory";
 
 // const jsPlumb = require("../../vendor/jsPlumb");
 declare var jsPlumb;
@@ -330,6 +331,11 @@ export class DiagramToolkit {
       fixedColor = LinkColors.increase;
       fadedColor = LinkColors.increaseFaded;
       changeIndicator = plusChangeIndicator;
+    }
+    if (opts.linkModel?.relation.isTransferModifier) {
+      changeIndicator = opts.linkModel.relation.formula === RelationFactory.proportionalSourceLess.formula
+        ? minusChangeIndicator
+        : plusChangeIndicator;
     }
     if (opts.color !== LinkColors.default) {
       fixedColor = opts.color;


### PR DESCRIPTION
Before this change the relationship symbols were not shown for transfer modifier links as their magnitude was 0.