### PR TITLE
Remove recently added code to remove flow variable links when the node changes [#181336977]

### DIFF
--- a/src/code/stores/graph-store.ts
+++ b/src/code/stores/graph-store.ts
@@ -783,10 +783,8 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
             let deletedNodes: Node[];
             let deletedNode: Node;
             const accumulatorChanged = (data.isAccumulator != null) && (!!data.isAccumulator !== !!originalData.isAccumulator);
-            const flowVariableChanged = (data.isFlowVariable != null) && (!!data.isFlowVariable !== !!originalData.isFlowVariable);
-            const variableTypeChanged = accumulatorChanged || flowVariableChanged;
 
-            if (variableTypeChanged) {
+            if (accumulatorChanged) {
               // all inbound and outbound links are deleted along with any transfer nodes along those links and
               // any links pointing to deleted transfer nodes
               deletedLinks = [].concat(node.links);
@@ -830,7 +828,7 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
             this.undoRedoManager.startCommandBatch();
             this.undoRedoManager.createAndExecuteCommand("changeNode", {
               execute: () => {
-                if (variableTypeChanged) {
+                if (accumulatorChanged) {
                   for (deletedLink of deletedLinks) {
                     this._removeLink(deletedLink);
                   }
@@ -844,7 +842,7 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
               undo: () => {
                 logNodeChange(originalData);
                 this.changeNodeOutsideUndoRedo(node, originalData);
-                if (variableTypeChanged) {
+                if (accumulatorChanged) {
                   for (deletedNode of deletedNodes) {
                     this._addNode(deletedNode);
                   }

--- a/src/code/views/node-view.tsx
+++ b/src/code/views/node-view.tsx
@@ -402,28 +402,24 @@ getDefaultProps() {
 
   private renderNodeInternal() {
     const getNodeImage = (node) => {
+      let image = node.image;
 
       if (node.isAccumulator) {
         return (
           <StackedImageView
-            image={node.image}
+            image={image}
             imageProps={node.collectorImageProps()}
           />
         );
-      }
-
-      let image = node.image;
-      if (node.isTransfer) {
+      } else if (node.isTransfer) {
         image = "img/nodes/transfer.png";
-      } else {
-        const outLinks = node.outLinks();
-        if (node.isFlowVariable && (outLinks.length === 0)) {
-          image = "img/nodes/flow-variable.png";
-        } else {
-          const firstFlowLink = _.find(outLinks, link => link.relation.formula === "+in" || link.relation.formula === "-in");
-          if (firstFlowLink) {
-            return <FlowImageView link={firstFlowLink} />;
-          }
+      } else if (node.isFlowVariable) {
+        image = "img/nodes/flow-variable.png";
+
+        // if the flow variable is connected to a node use its image, else use the default flow variable image
+        const firstFlowLink = _.find(node.outLinks(), link => link.relation.formula === "+in" || link.relation.formula === "-in");
+        if (firstFlowLink) {
+          return <FlowImageView link={firstFlowLink} />;
         }
       }
 


### PR DESCRIPTION
This reverts a recent change in the user menu.  This also fixes an issue where unconnected nodes converted to flow variables didn't update their image.