### PR TITLE
Fix setting of relationships when simulation type changes [#177724448]

### DIFF
--- a/src/code/stores/app-settings-store.ts
+++ b/src/code/stores/app-settings-store.ts
@@ -12,6 +12,7 @@ import { ImportActions } from "../actions/import-actions";
 import { urlParams } from "../utils/url-params";
 import { StoreClass, StoreUnsubscriber } from "./store-class";
 import { Mixin } from "../mixins/components";
+import { GraphStore } from "./graph-store";
 
 export declare class AppSettingsActionsClass {
   public setComplexity(val: any): void;  // TODO: get concrete class
@@ -20,6 +21,7 @@ export declare class AppSettingsActionsClass {
   public guide(show: boolean): void;
   public setTouchDevice(val: any): void;  // TODO: get concrete class
   public setGuideItems(items: GuideItem[]): void;
+  public checkRelationships(): void;
 }
 
 export declare class AppSettingsStoreClass extends StoreClass {
@@ -35,7 +37,8 @@ export const AppSettingsActions: AppSettingsActionsClass = Reflux.createActions(
     "relationshipSymbols",
     "guide",
     "setTouchDevice",
-    "setGuideItems"
+    "setGuideItems",
+    "checkRelationships"
   ]
 );
 
@@ -152,6 +155,7 @@ export const AppSettingsStore: AppSettingsStoreClass = Reflux.createStore({
   onSetSimulationType(val) {
     const prevSimulationType = this.settings.simulationType;
     this.settings.simulationType = val;
+    this.onCheckRelationships();
 
     return this.notifyChange();
   },
@@ -178,6 +182,12 @@ export const AppSettingsStore: AppSettingsStoreClass = Reflux.createStore({
   onImport(data) {
     _.merge(this.settings, data.settings);
     return this.notifyChange();
+  },
+
+  onCheckRelationships() {
+    if ((this.settings.simulationType === SimulationType.diagramOnly) && (GraphStore.allLinksAreUndefined() || (GraphStore.getMinimumComplexity() === Complexity.basic))) {
+      this.onSetComplexity(Complexity.basic);
+    }
   },
 
   serialize() {

--- a/src/code/stores/graph-store.ts
+++ b/src/code/stores/graph-store.ts
@@ -25,7 +25,7 @@ import { PaletteStore } from "../stores/palette-store";
 import { tr } from "../utils/translate";
 import { latestVersion } from "../data/migrations/migrations";
 import { PaletteDeleteDialogStore } from "../stores/palette-delete-dialog-store";
-import { AppSettingsStore } from "../stores/app-settings-store";
+import { AppSettingsStore, AppSettingsActions } from "../stores/app-settings-store";
 import { SimulationStore, SimulationActions } from "../stores/simulation-store";
 import { GraphActions } from "../actions/graph-actions";
 import { CodapActions } from "../actions/codap-actions";
@@ -688,14 +688,11 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
   },
 
   _graphUpdated() {
-    return (() => {
-      const result: any = [];
-      for (const key in this.nodeKeys) {
-        const node = this.nodeKeys[key];
-        result.push(node.checkIsInIndependentCycle());
-      }
-      return result;
-    })();
+    for (const key in this.nodeKeys) {
+      const node = this.nodeKeys[key];
+      node.checkIsInIndependentCycle();
+    }
+    AppSettingsActions.checkRelationships();
   },
 
   moveNodeCompleted(nodeKey, leftDiff, topDiff) {

--- a/src/code/views/simulation-inspector-view.tsx
+++ b/src/code/views/simulation-inspector-view.tsx
@@ -183,9 +183,6 @@ export class SimulationInspectorView extends Mixer<SimulationInspectorProps, Sim
 
   private handleSimulationType = (val) => {
     AppSettingsActions.setSimulationType(val);
-    if ((val === SimulationType.diagramOnly) && (GraphStore.allLinksAreUndefined() || (GraphStore.getMinimumComplexity() === Complexity.basic))) {
-      AppSettingsActions.setComplexity(Complexity.basic);
-    }
   }
 
   private handleComplexity = (val) => {


### PR DESCRIPTION
This moves the to automatically update the relationship type based on the model type from the view to the store.