### PR TITLE
Quick action menu tweaks [#181336977]

### DIFF
--- a/src/code/views/node-inspector-view.tsx
+++ b/src/code/views/node-inspector-view.tsx
@@ -6,6 +6,7 @@ import { ImagePickerView } from "./image-picker-view";
 import { NodeTitleMixin, NodeTitleMixinProps, NodeTitleMixinState } from "../mixins/node-title";
 import { Mixer } from "../mixins/components";
 import { Node } from "../models/node";
+import { ImageChange } from "../stores/graph-store";
 
 export interface NodeChangedValues {
 }
@@ -80,11 +81,12 @@ export class NodeInspectorView extends Mixer<NodeInspectorViewProps, NodeInspect
 
   private handleChangeImage = (node) => {
     if (this.props.onNodeChanged) {
-      this.props.onNodeChanged(this.props.node, {
+      const imageChange: ImageChange = {
         image: node.image,
         paletteItem: node.uuid,
         usesDefaultImage: node.usesDefaultImage
-      });
+      };
+      this.props.onNodeChanged(this.props.node, imageChange);
     }
   }
 

--- a/src/code/views/relation-inspector-view.tsx
+++ b/src/code/views/relation-inspector-view.tsx
@@ -106,6 +106,11 @@ export class RelationInspectorView extends Mixer<RelationInspectorViewProps, Rel
     });
     const affectsTabDisabled = affectsLinkTabs.length === 0;
 
+    // don't render a totally disabled tabbed panel
+    if (affectedByTabDisabled && affectedByTabDisabled) {
+      return <div />;
+    }
+
     const affectedByTab = HorizontalTabbedPanelView.Tab({
       label: "Affected By",
       component: <TabbedPanelView


### PR DESCRIPTION
- Only show create graph option for transfer nodes
- Update node image correctly when switching between node types
- Removes flow links when a node is converted to a normal node