### PR TITLE
Omnibug bug fix after release [#181740905]

### DIFF
--- a/src/code/stores/graph-store.ts
+++ b/src/code/stores/graph-store.ts
@@ -790,7 +790,8 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
             let deletedNodes: Node[] = [];
             let deletedNode: Node;
             const accumulatorChanged = (data.isAccumulator != null) && (!!data.isAccumulator !== !!originalData.isAccumulator);
-            const flowVariableChangedToNormal = originalData.isFlowVariable && !data.isFlowVariable && !data.isAccumulator;
+            const flowVariableChanged = (data.isFlowVariable != null) && (!!data.isFlowVariable !== !!originalData.isFlowVariable);
+            const flowVariableChangedToNormal = flowVariableChanged && !data.isFlowVariable && !data.isAccumulator;
             const variableTypeChanged = accumulatorChanged || flowVariableChangedToNormal;
 
             if (variableTypeChanged) {
@@ -881,19 +882,28 @@ export const GraphStore: GraphStoreClass = Reflux.createStore({
     })();
   },
 
-  getChangedNodeImageInfo(changes, node): ImageChange {
+  getChangedNodeImageInfo(changes, node): ImageChange | {} {
     const accumulatorChanged = (changes.isAccumulator != null) && (!!changes.isAccumulator !== !!node.isAccumulator);
     const flowVariableChanged = (changes.isFlowVariable != null) && (!!changes.isFlowVariable !== !!node.isFlowVariable);
 
-    const imageInfo = (i: any): ImageChange => {
-      return {
+    const imageInfo = (i: any): ImageChange | {} => {
+      const result = {
         image: i.image,
-        paletteItem: i.uuid,
+        paletteItem: i.paletteItem || i.uuid,
         usesDefaultImage: i.usesDefaultImage,
       };
+      const current = {
+        image: node.image,
+        paletteItem: node.paletteItem,
+        usesDefaultImage: node.usesDefaultImage,
+      };
+      if (JSON.stringify(result) !== JSON.stringify(current)) {
+        return result;
+      }
+      return {};
     };
 
-    const nodeTypeChangeImage = (toPaletteItem: PaletteItem | undefined, fromPaletteItem: PaletteItem | undefined): ImageChange => {
+    const nodeTypeChangeImage = (toPaletteItem: PaletteItem | undefined, fromPaletteItem: PaletteItem | undefined): ImageChange | {} => {
       // always use direct image changes
       if (changes.image) {
         return imageInfo(changes);

--- a/src/code/stores/palette-store.ts
+++ b/src/code/stores/palette-store.ts
@@ -60,6 +60,7 @@ export declare class PaletteStoreClass extends StoreClass {
   public inPalette(node: Node): boolean;
   public findByUUID(uuid: string): PaletteItem | undefined;
   public getBlankPaletteItem(): PaletteItem | undefined;
+  public getAccumulatorPaletteItem(): PaletteItem | undefined;
   public getFlowVariablePaletteItem(): PaletteItem | undefined;
   public orderedPalette(simulationType: number): PaletteItem[];
   public isFixedPaletteItem(paletteItem: PaletteItem): boolean;
@@ -316,6 +317,10 @@ export const PaletteStore: PaletteStoreClass = Reflux.createStore({
 
   getBlankPaletteItem() {
     return _.find(this.palette, {id: "1"});
+  },
+
+  getAccumulatorPaletteItem() {
+    return _.find(this.palette, {id: "collector"});
   },
 
   getFlowVariablePaletteItem() {

--- a/src/code/views/graph-view.tsx
+++ b/src/code/views/graph-view.tsx
@@ -320,14 +320,16 @@ export class GraphView extends Mixer<GraphViewProps, GraphViewState> {
     // the collector image in the palette is a static png of jumbled blank nodes
     // we need to convert this into the default single blank node as the graph view
     // will then stack those images as the node is set as a collector
-    const image = isAccumulator ? PaletteStore.getBlankPaletteItem()?.image : paletteItem.image;
+    if (paletteItem.id === "collector") {
+      paletteItem = PaletteStore.getBlankPaletteItem() || paletteItem;
+    }
 
     const newNode = new Node({
       x: ui.offset.left - linkOffset.left - imageOffset.left,
       y: ui.offset.top - linkOffset.top - imageOffset.top,
       title,
       paletteItem: paletteItem.uuid,
-      image,
+      image: paletteItem.image,
       addedThisSession: true,
       isFlowVariable,
       isAccumulator,

--- a/src/code/views/node-view.tsx
+++ b/src/code/views/node-view.tsx
@@ -35,6 +35,7 @@ import { logEvent } from "../utils/logger";
 import { TransferModel } from "../models/transfer";
 import { FlowImageView } from "./flow-image-view";
 import { QuickActionButtonView } from "./quick-action-button-view";
+import { PaletteStore } from "../stores/palette-store";
 
 interface NodeTitleViewOuterProps {
   isEditing: boolean;
@@ -404,7 +405,8 @@ getDefaultProps() {
     const getNodeImage = (node) => {
       let image = node.image;
 
-      if (node.isAccumulator) {
+      // never show a stacked image for an accumulator node whose image is already stacked
+      if (node.isAccumulator && image !== PaletteStore.getAccumulatorPaletteItem()?.image) {
         return (
           <StackedImageView
             image={image}


### PR DESCRIPTION
- Fixed accidental removal of flow links on node change that isn't about node type
- Fixed image update to not update image info if it hasn't changed in the node
- Fixed node setting palette info for node when collector is dragged in.  This was just updating the image but leaving the uuid and useDefaultImage in the incorrect state.
- Updated node view not to "stack" node images if they are already the collector image