### PR TITLE
fix: SageModeler plugin coming "unattached" from the CODAP canvas [PT-185485076]

### DIFF
--- a/src/code/models/codap-connect.ts
+++ b/src/code/models/codap-connect.ts
@@ -105,7 +105,7 @@ export class CodapConnect {
           action: "update",
           resource: "interactiveFrame",
           values: {
-            title: tr("~CODAP.INTERACTIVE_FRAME.TITLE"),
+            title: "SageModeler", // do not translate, this isn't displayed but is used to match with the standalone parameter
             preventBringToFront: true,
             cannotClose: true,
             preventDataContextReorg: false // allows tables to be reorganized


### PR DESCRIPTION
This was caused by the Korean translation of the iframe title parameter which is not translated in any of the other languages.  The title is used when trying to match the standalone parameter and thus can't be translated.

The code has been updated to not use the translation.