### PR TITLE
fix: Switch to SageModeler Google Drive project [PT-186851280]

### DIFF
--- a/src/assets/sage.html
+++ b/src/assets/sage.html
@@ -79,8 +79,9 @@
         },
         {
           "name": "googleDrive",
-          "apiKey": "AIzaSyAUobrEXqtbZHBvr24tamdE6JxmPYTRPEA",
-          "clientId": "1095918012594-svs72eqfalasuc4t1p1ps1m8r9b8psso.apps.googleusercontent.com"
+          "apiKey": "AIzaSyArBgGAjVU_TvSXtluZPaEDnBToANkMD4Q",
+          "clientId": "617149450375-rglbpcteq9ej0j3gsfc59io5fgpp42eb.apps.googleusercontent.com",
+          "appId": "617149450375"
         },
         {
           "name": "documentStore",


### PR DESCRIPTION
This was using a Google project we no longer has access to and thus can't enable the Google picker on.